### PR TITLE
fix: Update docker-node.mdx

### DIFF
--- a/pages/operators/node-basics/docker-node.mdx
+++ b/pages/operators/node-basics/docker-node.mdx
@@ -119,7 +119,7 @@ ghcr.io/tangle-network/tangle/tangle:main \
 ```sh filename="Role" copy
 docker run --rm -it --platform linux/amd64 --network="host"  \
 ghcr.io/tangle-network/tangle/tangle:main \
-    tangle key insert --base-path /data \
+    key insert --base-path /data \
     --chain tangle-mainnet \
     --scheme Ecdsa \
     --key-type role
@@ -130,7 +130,7 @@ ghcr.io/tangle-network/tangle/tangle:main \
 ```sh filename="Grandpa" copy
 docker run --rm -it --platform linux/amd64 --network="host"  \
 ghcr.io/tangle-network/tangle/tangle:main \
-    tangle key insert --base-path /data \
+    key insert --base-path /data \
     --chain tangle-mainnet \
     --scheme Ed25519 \
     --key-type gran


### PR DESCRIPTION
## Summary of changes

The role and gran docker key generation commands fail. This is because tangle command is already defined as the entrypoint, and repeating it causes an error.

This PR removes the duplicate definition of `tangle` command and just issue the `key` subcommand.

-

### Reference issue to close (if applicable)

_Specify any issues that can be closed from these changes (e.g. `Closes #233`)._

- Closes
