### PR TITLE
feat: eigen cli docs

### DIFF
--- a/pages/developers/cli/_meta.json
+++ b/pages/developers/cli/_meta.json
@@ -1,5 +1,6 @@
 {
   "installation": "Installation",
   "quickstart": "Quickstart",
-  "reference": "Reference"
+  "reference": "Reference",
+  "eigenlayer": "Eigenlayer Commands"
 }

--- a/pages/developers/cli/_meta.json
+++ b/pages/developers/cli/_meta.json
@@ -2,5 +2,5 @@
   "installation": "Installation",
   "quickstart": "Quickstart",
   "reference": "Reference",
-  "eigenlayer": "Eigenlayer Commands"
+  "eigenlayer": "Eigenlayer AVSs"
 }

--- a/pages/developers/cli/eigenlayer.mdx
+++ b/pages/developers/cli/eigenlayer.mdx
@@ -1,6 +1,8 @@
 # Eigenlayer CLI Commands
 
-The Tangle CLI provides commands for deploying and running Eigenlayer AVS (Active Validator Set) services. This guide covers the deployment and operation of Eigenlayer components.
+Our CLI provides commands for deploying and running Eigenlayer AVSs. We have two templates for quickly creating an AVS: the [BLS template](/developers/eigenlayer-avs/bls-template) and the [ECDSA template](/developers/eigenlayer-avs/ecdsa-template).
+
+For a step-by-step example of using the BLS template, see [Deploying an Eigenlayer AVS](/developers/eigenlayer-avs/bls-example).
 
 ## Blueprint Commands
 
@@ -13,6 +15,7 @@ cargo tangle blueprint create -n <NAME> --eigenlayer [BLS|ECDSA]
 ```
 
 #### Create Options
+
 - `-n, --name <NAME>`: Name of your AVS project
 - `--eigenlayer`: Specify either BLS or ECDSA variant
 
@@ -23,13 +26,13 @@ cargo tangle blueprint deploy eigenlayer [OPTIONS]
 ```
 
 #### Deploy Options
-- `--rpc-url <URL>`: HTTP RPC endpoint to connect to
+
+- `--rpc-url <URL>`: HTTP RPC endpoint to connect to (required unless --devnet is used)
 - `--contracts-path <PATH>`: Path to your contracts directory (defaults to "./contracts")
-- `--chain <CHAIN>`: Target chain type (e.g., "testnet", "local-testnet")
-- `--keystore-path <PATH>`: Path to your keystore
-- `--settings-file <PATH>`: Path to your settings file
-- `--devnet`: Automatically uses local settings, running a local Anvil testnet in the background that continues until it is stopped
-- `--ordered-deployment`: Deploy contracts in an interactive ordered manner
+- `--ordered-deployment`: Deploy contracts in an interactive ordered manner (if omitted, deploys as they are found)
+- `-w, --network <NETWORK>`: Network to deploy to (local, testnet, mainnet) [default: local]
+- `--devnet`: Start a local devnet using Anvil (only valid with --network local)
+- `-k, --keystore-path <PATH>`: Path to your keystore (defaults to ./keystore)
 
 ### Run AVS Service
 
@@ -38,47 +41,63 @@ cargo tangle blueprint run [OPTIONS]
 ```
 
 #### Run Options
+
 - `-p, --protocol eigenlayer`: Specify Eigenlayer protocol
-- `-u, --rpc-url <URL>`: HTTP RPC endpoint URL
+- `-u, --rpc-url <URL>`: HTTP RPC endpoint URL (required)
 - `-k, --keystore-path <PATH>`: Path to the keystore (defaults to ./keystore)
-- `-b, --binary-path <PATH>`: Path to the AVS binary (optional)
+- `-b, --binary-path <PATH>`: Path to the AVS binary (optional, will build if not provided)
 - `-w, --network <NETWORK>`: Network to connect to (local, testnet, mainnet)
 - `-d, --data-dir <PATH>`: Data directory path (defaults to ./data)
 - `-n, --bootnodes <NODES>`: Optional bootnodes to connect to
-- `-f, --settings-file <PATH>`: Path to the protocol settings env file
+- `-f, --settings-file <PATH>`: Path to the protocol settings env file (defaults to ./settings.env)
 
-### Environment Variables
+### Required Environment Variables for Eigenlayer
 
-- `EIGENLAYER_PRIVATE_KEY`: Your private key for deployment (alternative to keystore)
+The following environment variables must be set in your settings.env file:
+
+- `REGISTRY_COORDINATOR_ADDRESS`: Address of the Registry Coordinator contract
+- `OPERATOR_STATE_RETRIEVER_ADDRESS`: Address of the Operator State Retriever contract
+- `DELEGATION_MANAGER_ADDRESS`: Address of the Delegation Manager contract
+- `SERVICE_MANAGER_ADDRESS`: Address of the Service Manager contract
+- `STAKE_REGISTRY_ADDRESS`: Address of the Stake Registry contract
+- `STRATEGY_MANAGER_ADDRESS`: Address of the Strategy Manager contract
+- `AVS_DIRECTORY_ADDRESS`: Address of the AVS Directory contract
+- `REWARDS_COORDINATOR_ADDRESS`: Address of the Rewards Coordinator contract
 
 ## Example Workflow
 
 1. **Create a New AVS Project**
+
    ```bash
-   cargo tangle blueprint create -n my-avs --eigenlayer BLS
+   cargo tangle blueprint create -n my-avs --eigenlayer bls
    ```
 
 2. **Build Your AVS**
+
    ```bash
    cargo build --release
    ```
 
 3. **Deploy Contracts**
+
    ```bash
+   # Deploy to local devnet
    cargo tangle blueprint deploy eigenlayer \
      --devnet \
+     --ordered-deployment
+
+   # Or deploy to testnet
+   cargo tangle blueprint deploy eigenlayer \
+     --network testnet \
+     --rpc-url <YOUR_RPC_URL> \
      --ordered-deployment
    ```
 
 4. **Run Your Service**
-   Your RPC URL will depend on the previous command's output
    ```bash
    cargo tangle blueprint run \
      -p eigenlayer \
-     -u http://localhost:<PORT> \
-     -w testnet \
-     -s ./settings.env \
-     -k ./test-keystore
+     -u <YOUR_RPC_URL>
    ```
 
 ## Troubleshooting
@@ -86,13 +105,14 @@ cargo tangle blueprint run [OPTIONS]
 Common issues and solutions:
 
 1. **Deployment Failures**
+
    - Verify RPC endpoint is accessible
-   - Ensure correct chain is specified
+   - Ensure correct network is specified (local, testnet, mainnet)
    - Check contract constructor arguments
    - Verify sufficient funds for deployment
 
 2. **Service Issues**
-   - Check configuration file format
-   - Verify contract addresses are correct
-   - Ensure binary is compiled with correct features
-   - Check network connectivity
+   - Check settings.env file contains all required contract addresses
+   - Verify contract addresses are correct for the chosen network
+   - Ensure binary is built with correct features
+   - Check network connectivity and RPC endpoint accessibility

--- a/pages/developers/cli/eigenlayer.mdx
+++ b/pages/developers/cli/eigenlayer.mdx
@@ -1,0 +1,98 @@
+# Eigenlayer CLI Commands
+
+The Tangle CLI provides commands for deploying and running Eigenlayer AVS (Active Validator Set) services. This guide covers the deployment and operation of Eigenlayer components.
+
+## Blueprint Commands
+
+The blueprint commands allow you to create, deploy, and run Eigenlayer AVS services.
+
+### Create a New AVS Project
+
+```bash
+cargo tangle blueprint create -n <NAME> --eigenlayer [BLS|ECDSA]
+```
+
+#### Create Options
+- `-n, --name <NAME>`: Name of your AVS project
+- `--eigenlayer`: Specify either BLS or ECDSA variant
+
+### Deploy AVS Contracts
+
+```bash
+cargo tangle blueprint deploy eigenlayer [OPTIONS]
+```
+
+#### Deploy Options
+- `--rpc-url <URL>`: HTTP RPC endpoint to connect to
+- `--contracts-path <PATH>`: Path to your contracts directory (defaults to "./contracts")
+- `--chain <CHAIN>`: Target chain type (e.g., "testnet", "local-testnet")
+- `--keystore-path <PATH>`: Path to your keystore
+- `--settings-file <PATH>`: Path to your settings file
+- `--devnet`: Automatically uses local settings, running a local Anvil testnet in the background that continues until it is stopped
+- `--ordered-deployment`: Deploy contracts in an interactive ordered manner
+
+### Run AVS Service
+
+```bash
+cargo tangle blueprint run [OPTIONS]
+```
+
+#### Run Options
+- `-p, --protocol eigenlayer`: Specify Eigenlayer protocol
+- `-u, --rpc-url <URL>`: HTTP RPC endpoint URL
+- `-k, --keystore-path <PATH>`: Path to the keystore (defaults to ./keystore)
+- `-b, --binary-path <PATH>`: Path to the AVS binary (optional)
+- `-w, --network <NETWORK>`: Network to connect to (local, testnet, mainnet)
+- `-d, --data-dir <PATH>`: Data directory path (defaults to ./data)
+- `-n, --bootnodes <NODES>`: Optional bootnodes to connect to
+- `-f, --settings-file <PATH>`: Path to the protocol settings env file
+
+### Environment Variables
+
+- `EIGENLAYER_PRIVATE_KEY`: Your private key for deployment (alternative to keystore)
+
+## Example Workflow
+
+1. **Create a New AVS Project**
+   ```bash
+   cargo tangle blueprint create -n my-avs --eigenlayer BLS
+   ```
+
+2. **Build Your AVS**
+   ```bash
+   cargo build --release
+   ```
+
+3. **Deploy Contracts**
+   ```bash
+   cargo tangle blueprint deploy eigenlayer \
+     --devnet \
+     --ordered-deployment
+   ```
+
+4. **Run Your Service**
+   Your RPC URL will depend on the previous command's output
+   ```bash
+   cargo tangle blueprint run \
+     -p eigenlayer \
+     -u http://localhost:<PORT> \
+     -w testnet \
+     -s ./settings.env \
+     -k ./test-keystore
+   ```
+
+## Troubleshooting
+
+Common issues and solutions:
+
+1. **Deployment Failures**
+   - Verify RPC endpoint is accessible
+   - Ensure correct chain is specified
+   - Check contract constructor arguments
+   - Verify sufficient funds for deployment
+
+2. **Service Issues**
+   - Check configuration file format
+   - Verify contract addresses are correct
+   - Ensure binary is compiled with correct features
+   - Check network connectivity

--- a/pages/developers/eigenlayer-avs/_meta.json
+++ b/pages/developers/eigenlayer-avs/_meta.json
@@ -2,5 +2,6 @@
   "overview": "Overview",
   "incredible-squaring-avs": "Incredible Squaring AVS",
   "bls-template": "Eigenlayer BLS Template",
-  "ecdsa-template": "Eigenlayer ECDSA Template"
+  "ecdsa-template": "Eigenlayer ECDSA Template",
+  "bls-example": "Deploying an Eigenlayer AVS"
 }

--- a/pages/developers/eigenlayer-avs/bls-example.mdx
+++ b/pages/developers/eigenlayer-avs/bls-example.mdx
@@ -1,0 +1,63 @@
+# Deploying and running an Eigenlayer AVS from the BLS Template
+
+The following is a step-by-step guide for deploying and running an AVS using the cargo-tangle CLI.
+
+## Generating the AVS from the Template
+
+Run the following command, answering each prompt for project information. For anything you aren't certain about, the default selection is a safe choice. This command creates a BLS AVS called `my-avs`.
+
+```bash
+cargo tangle blueprint create --name my-avs --eigenlayer bls
+```
+
+Now that you have generated your AVS project, move to the newly created directory.
+
+```bash
+cd my-avs
+```
+
+## Deploying the AVS to a local testnet
+
+The AVS is fully ready to be deployed, perfect for testing locally. The following command will start a local testnet in the background and deploy the AVS's necessary contracts.
+
+```bash
+cargo tangle blueprint deploy eigenlayer \
+    --devnet \
+    --ordered-deployment
+```
+
+In this case, you want to deploy the contracts in an ordered manner. Specifically, you need to deploy the TangleTaskManager before the TangleServiceManager, since the Service Manager takes the Task Manager's address as a constructor argument.
+
+When you deploy the TangleTaskManager, you are also given the option to initialize it. You want to make sure you do this, supplying the initialization arguments when prompted.
+
+You will be prompted for each contract's constructor arguments (if it has any). You can find the addresses of the contracts you need in your project's settings.env file. Below is a complete list of addresses you will need. Some are zero addresses because they aren't actually used.
+
+### Addresses for deployment
+
+| Address              | Value                                        |
+| -------------------- | -------------------------------------------- |
+| Registry Coordinator | c3e53f4d16ae77db1c982e75a937b9f60fe63690     |
+| Pauser Registry      | Obtained from beginning of Deployment output |
+| Initial Owner        | 70997970C51812dc3A010C7d01b50e0d17dc79C8     |
+| Aggregator           | a0Ee7A142d267C1f36714E4a8F75612F20a79720     |
+| Generator            | 15d34AAf54267DB7D7c367839AAf71A00a2C6A65     |
+| AVS Directory        | 0000000000000000000000000000000000000000     |
+| Rewards Coordinator  | 0000000000000000000000000000000000000000     |
+| Stake Registry       | 5fc8d32690cc91d4c39d9d3abcbd16989f875707     |
+| Tangle Task Manager  | Obtained in Deployment output                |
+
+Once all contracts have been deployed, you will notice that it continues running to keep the testnet alive.
+
+## Running the AVS
+
+In a new terminal, run the following command in the project's directory (make sure to replace the task manager address and the RPC URL with the values obtained from your deployment output):
+
+```bash
+TASK_MANAGER_ADDRESS=<ADDRESS_FROM_OUTPUT> cargo tangle blueprint run \
+    -p eigenlayer \
+    -u <URL_FROM_DEPLOYMENT_OUTPUT> \
+    --keystore-path ./test-keystore
+```
+
+Running this once, will register the example operator (it uses Anvil's account 0 by default) and then exit the process. Once the registration is complete, you simply need to run the same command again.
+Upon running the command for a second time, you should see "Successfully ran job function!" printed to the terminal, signifying that the job function was successfully executed!


### PR DESCRIPTION
# Overview

Adds docs and steps to using cargo-tangle for creating, deploying, and running an EigenLayer AVS