### PR TITLE
fix: CI link fixes and formatting for v2

### DIFF
--- a/.lycheeignore
+++ b/.lycheeignore
@@ -1,2 +1,4 @@
 http://localhost*
 https://localhost*
+# Testnet explorer returns 401 but links are valid
+https://testnet-explorer.tangle.tools/*

--- a/components/LandingPage.tsx
+++ b/components/LandingPage.tsx
@@ -15,22 +15,19 @@ const getStartedCards = [
   {
     icon: <GrNodes />,
     title: "Run work in secure sandboxes",
-    description:
-      "Work executes in isolated runtimes with policies and limits.",
+    description: "Work executes in isolated runtimes with policies and limits.",
     link: "/infrastructure/introduction",
   },
   {
     icon: <GiToken />,
     title: "Operate the runtime",
-    description:
-      "Host secure sandboxes and get paid through the protocol.",
+    description: "Host secure sandboxes and get paid through the protocol.",
     link: "/operators/introduction",
   },
   {
     icon: <SiBlueprint />,
     title: "Build and publish Blueprints",
-    description:
-      "Package services and workflows to run on the protocol.",
+    description: "Package services and workflows to run on the protocol.",
     link: "/developers/blueprints/introduction",
   },
 ];
@@ -81,9 +78,9 @@ const LandingPage = () => {
             System Overview
           </h2>
           <p className="mb-6 text-base text-gray-700 dark:text-gray-400">
-            Teams and agents collaborate in shared workbenches or separate
-            ones, work runs in secure sandboxes, and the protocol pays the
-            operators who host the runtime.
+            Teams and agents collaborate in shared workbenches or separate ones,
+            work runs in secure sandboxes, and the protocol pays the operators
+            who host the runtime.
           </p>
           <figure className="w-full">
             <div className="relative w-full min-h-[280px]">

--- a/components/NetworkResources.tsx
+++ b/components/NetworkResources.tsx
@@ -1,11 +1,7 @@
 import React, { useState, useEffect } from "react";
 import Link from "next/link";
 import { BlockCopyButton } from "./ui/block-copy-button";
-import {
-  FlaskConical,
-  WalletMinimal,
-  Waypoints,
-} from "lucide-react";
+import { FlaskConical, WalletMinimal, Waypoints } from "lucide-react";
 import WalletTable from "./WalletTable";
 
 type NetworkDetail = {
@@ -279,11 +275,11 @@ const NetworkTabs = () => {
       </ul>
 
       <div className="w-full table-auto">
-        {activeTab === "wallets"
-          ? <WalletTable />
-          : activeTab === "mainnet" || activeTab === "testnet"
-            ? renderTable(NETWORK_DATA[activeTab])
-            : null}
+        {activeTab === "wallets" ? (
+          <WalletTable />
+        ) : activeTab === "mainnet" || activeTab === "testnet" ? (
+          renderTable(NETWORK_DATA[activeTab])
+        ) : null}
       </div>
     </div>
   );

--- a/components/RepoArea.tsx
+++ b/components/RepoArea.tsx
@@ -7,7 +7,8 @@ export const RepoArea = () => {
       <DetailedFeatureLink
         feature={{
           Icon: GitHubIcon,
-          description: "Protocol contracts and deployment tooling for Tangle v2.",
+          description:
+            "Protocol contracts and deployment tooling for Tangle v2.",
           name: "tnt-core",
         }}
         href="https://github.com/tangle-network/tnt-core"

--- a/components/WalletTable.tsx
+++ b/components/WalletTable.tsx
@@ -55,8 +55,8 @@ const WalletTable = () => {
       </table>
       <h3 className="text-2xl mb-4">Network Details for Adding to Wallets</h3>
       <span>
-        Add the Tangle Network using the Chain ID and RPC server address on
-        this page. Follow the standard flow in your wallet to add a new network.
+        Add the Tangle Network using the Chain ID and RPC server address on this
+        page. Follow the standard flow in your wallet to add a new network.
       </span>
     </div>
   );

--- a/pages/ai/index.mdx
+++ b/pages/ai/index.mdx
@@ -23,6 +23,7 @@ Tangle is the shared operating layer for autonomous work. Teams and agents colla
 The agentic workbench is multiplayer by design. It is where teammates across engineering, product, and business collaborate with agents in a shared workspace.
 
 Key traits:
+
 - **Shared workspaces** for humans and agents across teams.
 - **Agent profiles** that control models, tools, and budgets.
 - **Background execution** so long tasks keep running.
@@ -34,6 +35,7 @@ Key traits:
 Work executes inside isolated sandboxes so tasks are contained and repeatable. The runtime is built to host autonomous work safely at scale.
 
 Core capabilities:
+
 - **Sandboxed execution** with explicit policies and resource limits.
 - **Task isolation** so background work can be reviewed and accepted before merge.
 - **Orchestrator + sidecar** separation for lifecycle control and execution.

--- a/pages/developers/api/reference/BlueprintHookBase.mdx
+++ b/pages/developers/api/reference/BlueprintHookBase.mdx
@@ -5,7 +5,7 @@ description: Auto-generated Solidity API reference.
 
 # BlueprintHookBase
 
-Source: https://github.com/tangle-network/tnt-core/blob/v2/src/v2/interfaces/IBlueprintHook.sol
+Source: https://github.com/tangle-network/tnt-core/blob/main/src/interfaces/IBlueprintHook.sol
 
 ### BlueprintHookBase
 
@@ -140,4 +140,3 @@ function getAggregationThreshold(uint64, uint8) external view virtual returns (u
 ```solidity
 function onAggregatedResult(uint64, uint64, uint256, bytes) external virtual
 ```
-

--- a/pages/developers/api/reference/IBlueprintHook.mdx
+++ b/pages/developers/api/reference/IBlueprintHook.mdx
@@ -5,18 +5,19 @@ description: Auto-generated Solidity API reference.
 
 # IBlueprintHook
 
-Source: https://github.com/tangle-network/tnt-core/blob/v2/src/v2/interfaces/IBlueprintHook.sol
+Source: https://github.com/tangle-network/tnt-core/blob/main/src/interfaces/IBlueprintHook.sol
 
 ### IBlueprintHook
 
 Simplified hook interface for basic blueprint customization
 
-_For full control, implement IBlueprintServiceManager directly.
-     This interface provides a simpler subset for common use cases.
+\_For full control, implement IBlueprintServiceManager directly.
+This interface provides a simpler subset for common use cases.
 
 Migration path:
+
 - Simple blueprints: Use IBlueprintHook / BlueprintHookBase
-- Full-featured blueprints: Use IBlueprintServiceManager / BlueprintServiceManagerBase_
+- Full-featured blueprints: Use IBlueprintServiceManager / BlueprintServiceManagerBase\_
 
 #### Functions
 
@@ -38,8 +39,8 @@ Called when an operator registers
 
 ##### Return Values
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name   | Type | Description                 |
+| ------ | ---- | --------------------------- |
 | accept | bool | True to accept registration |
 
 #### onOperatorUnregister
@@ -60,8 +61,8 @@ Called when a service is requested
 
 ##### Return Values
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name   | Type | Description            |
+| ------ | ---- | ---------------------- |
 | accept | bool | True to accept request |
 
 #### onServiceApprove
@@ -122,8 +123,8 @@ Called when a job is submitted
 
 ##### Return Values
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name   | Type | Description        |
+| ------ | ---- | ------------------ |
 | accept | bool | True to accept job |
 
 #### onJobResult
@@ -136,8 +137,8 @@ Called when an operator submits a result
 
 ##### Return Values
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name   | Type | Description           |
+| ------ | ---- | --------------------- |
 | accept | bool | True to accept result |
 
 #### onJobCompleted
@@ -158,8 +159,8 @@ Called before a slash is applied
 
 ##### Return Values
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name    | Type | Description           |
+| ------- | ---- | --------------------- |
 | approve | bool | True to approve slash |
 
 #### onSlashApplied
@@ -212,10 +213,10 @@ Get the aggregation threshold configuration for a job
 
 ##### Return Values
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| thresholdBps | uint16 | Threshold in basis points (6700 = 67%) |
-| thresholdType | uint8 | 0 = CountBased (% of operators), 1 = StakeWeighted (% of total stake) |
+| Name          | Type   | Description                                                           |
+| ------------- | ------ | --------------------------------------------------------------------- |
+| thresholdBps  | uint16 | Threshold in basis points (6700 = 67%)                                |
+| thresholdType | uint8  | 0 = CountBased (% of operators), 1 = StakeWeighted (% of total stake) |
 
 #### onAggregatedResult
 
@@ -224,4 +225,3 @@ function onAggregatedResult(uint64 serviceId, uint64 callId, uint256 signerBitma
 ```
 
 Called when an aggregated result is submitted
-

--- a/pages/developers/api/reference/IBlueprintServiceManager.mdx
+++ b/pages/developers/api/reference/IBlueprintServiceManager.mdx
@@ -5,17 +5,18 @@ description: Auto-generated Solidity API reference.
 
 # IBlueprintServiceManager
 
-Source: https://github.com/tangle-network/tnt-core/blob/v2/src/v2/interfaces/IBlueprintServiceManager.sol
+Source: https://github.com/tangle-network/tnt-core/blob/main/src/interfaces/IBlueprintServiceManager.sol
 
 ### IBlueprintServiceManager
 
 Full interface for blueprint-specific service managers
 
-_Blueprint developers implement this to customize all aspects of their blueprint.
-     This is the primary integration point for blueprint developers - implement the hooks
-     you need and leave others as default (via BlueprintServiceManagerBase).
+\_Blueprint developers implement this to customize all aspects of their blueprint.
+This is the primary integration point for blueprint developers - implement the hooks
+you need and leave others as default (via BlueprintServiceManagerBase).
 
 The lifecycle flow:
+
 1. Blueprint created → onBlueprintCreated
 2. Operators register → onRegister
 3. Service requested → onRequest
@@ -23,7 +24,7 @@ The lifecycle flow:
 5. Service activated → onServiceInitialized
 6. Jobs submitted → onJobCall
 7. Results submitted → onJobResult
-8. Service terminated → onServiceTermination_
+8. Service terminated → onServiceTermination\_
 
 #### Functions
 
@@ -39,11 +40,11 @@ _Store the blueprintId and tangleCore address for future reference_
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| blueprintId | uint64 | The new blueprint ID |
-| owner | address | The blueprint owner |
-| tangleCore | address | The address of the Tangle core contract |
+| Name        | Type    | Description                             |
+| ----------- | ------- | --------------------------------------- |
+| blueprintId | uint64  | The new blueprint ID                    |
+| owner       | address | The blueprint owner                     |
+| tangleCore  | address | The address of the Tangle core contract |
 
 #### onRegister
 
@@ -57,10 +58,10 @@ _Validate operator requirements here (stake, reputation, etc.)_
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| operator | address | The operator's address |
-| registrationInputs | bytes | Custom registration data (blueprint-specific encoding) |
+| Name               | Type    | Description                                            |
+| ------------------ | ------- | ------------------------------------------------------ |
+| operator           | address | The operator's address                                 |
+| registrationInputs | bytes   | Custom registration data (blueprint-specific encoding) |
 
 #### onUnregister
 
@@ -72,8 +73,8 @@ Called when an operator unregisters from this blueprint
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name     | Type    | Description            |
+| -------- | ------- | ---------------------- |
 | operator | address | The operator's address |
 
 #### onUpdatePreferences
@@ -86,10 +87,10 @@ Called when an operator updates their preferences (RPC address, etc.)
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| operator | address | The operator's address |
-| newPreferences | bytes | Updated preferences data |
+| Name           | Type    | Description              |
+| -------------- | ------- | ------------------------ |
+| operator       | address | The operator's address   |
+| newPreferences | bytes   | Updated preferences data |
 
 #### getHeartbeatInterval
 
@@ -103,16 +104,16 @@ _Operators must submit heartbeats within this interval_
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name      | Type   | Description    |
+| --------- | ------ | -------------- |
 | serviceId | uint64 | The service ID |
 
 ##### Return Values
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| useDefault | bool | True to use protocol default, false to use custom value |
-| interval | uint64 | Heartbeat interval in blocks (0 = disabled) |
+| Name       | Type   | Description                                             |
+| ---------- | ------ | ------------------------------------------------------- |
+| useDefault | bool   | True to use protocol default, false to use custom value |
+| interval   | uint64 | Heartbeat interval in blocks (0 = disabled)             |
 
 #### getHeartbeatThreshold
 
@@ -126,16 +127,16 @@ _Percentage of operators that must respond within interval_
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name      | Type   | Description    |
+| --------- | ------ | -------------- |
 | serviceId | uint64 | The service ID |
 
 ##### Return Values
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| useDefault | bool | True to use protocol default |
-| threshold | uint8 | Threshold percentage (0-100) |
+| Name       | Type  | Description                  |
+| ---------- | ----- | ---------------------------- |
+| useDefault | bool  | True to use protocol default |
+| threshold  | uint8 | Threshold percentage (0-100) |
 
 #### getSlashingWindow
 
@@ -149,16 +150,16 @@ _Time window for disputes before slash is finalized_
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name      | Type   | Description    |
+| --------- | ------ | -------------- |
 | serviceId | uint64 | The service ID |
 
 ##### Return Values
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| useDefault | bool | True to use protocol default |
-| window | uint64 | Slashing window in blocks |
+| Name       | Type   | Description                  |
+| ---------- | ------ | ---------------------------- |
+| useDefault | bool   | True to use protocol default |
+| window     | uint64 | Slashing window in blocks    |
 
 #### getExitConfig
 
@@ -172,18 +173,18 @@ _Defines minimum commitment and exit queue timing_
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name      | Type   | Description    |
+| --------- | ------ | -------------- |
 | serviceId | uint64 | The service ID |
 
 ##### Return Values
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| useDefault | bool | True to use protocol default |
-| minCommitmentDuration | uint64 | Minimum time operator must stay after joining (seconds) |
-| exitQueueDuration | uint64 | Time between scheduling exit and completing it (seconds) |
-| forceExitAllowed | bool | Whether service owner can force-exit operators |
+| Name                  | Type   | Description                                              |
+| --------------------- | ------ | -------------------------------------------------------- |
+| useDefault            | bool   | True to use protocol default                             |
+| minCommitmentDuration | uint64 | Minimum time operator must stay after joining (seconds)  |
+| exitQueueDuration     | uint64 | Time between scheduling exit and completing it (seconds) |
+| forceExitAllowed      | bool   | Whether service owner can force-exit operators           |
 
 #### onRequest
 
@@ -197,15 +198,15 @@ _Validate service configuration, operator selection, payment amount_
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| requestId | uint64 | The request ID |
-| requester | address | Who is requesting the service |
-| operators | address[] | Requested operators |
-| requestInputs | bytes | Service configuration (blueprint-specific encoding) |
-| ttl | uint64 | Time-to-live for the service |
-| paymentAsset | address | Payment token address (address(0) for native) |
-| paymentAmount | uint256 | Payment amount |
+| Name          | Type      | Description                                         |
+| ------------- | --------- | --------------------------------------------------- |
+| requestId     | uint64    | The request ID                                      |
+| requester     | address   | Who is requesting the service                       |
+| operators     | address[] | Requested operators                                 |
+| requestInputs | bytes     | Service configuration (blueprint-specific encoding) |
+| ttl           | uint64    | Time-to-live for the service                        |
+| paymentAsset  | address   | Payment token address (address(0) for native)       |
+| paymentAmount | uint256   | Payment amount                                      |
 
 #### onApprove
 
@@ -217,11 +218,11 @@ Called when an operator approves a service request
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| operator | address | The approving operator |
-| requestId | uint64 | The request ID |
-| stakingPercent | uint8 | Percentage of stake committed to this service (0-100) |
+| Name           | Type    | Description                                           |
+| -------------- | ------- | ----------------------------------------------------- |
+| operator       | address | The approving operator                                |
+| requestId      | uint64  | The request ID                                        |
+| stakingPercent | uint8   | Percentage of stake committed to this service (0-100) |
 
 #### onReject
 
@@ -233,10 +234,10 @@ Called when an operator rejects a service request
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| operator | address | The rejecting operator |
-| requestId | uint64 | The request ID |
+| Name      | Type    | Description            |
+| --------- | ------- | ---------------------- |
+| operator  | address | The rejecting operator |
+| requestId | uint64  | The request ID         |
 
 #### onServiceInitialized
 
@@ -248,14 +249,14 @@ Called when service becomes active (all operators approved)
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| blueprintId | uint64 | The blueprint ID |
-| requestId | uint64 | The original request ID |
-| serviceId | uint64 | The new service ID |
-| owner | address | The service owner |
+| Name             | Type      | Description                      |
+| ---------------- | --------- | -------------------------------- |
+| blueprintId      | uint64    | The blueprint ID                 |
+| requestId        | uint64    | The original request ID          |
+| serviceId        | uint64    | The new service ID               |
+| owner            | address   | The service owner                |
 | permittedCallers | address[] | Addresses allowed to submit jobs |
-| ttl | uint64 | Service time-to-live |
+| ttl              | uint64    | Service time-to-live             |
 
 #### onServiceTermination
 
@@ -267,10 +268,10 @@ Called when service is terminated
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| serviceId | uint64 | The service ID |
-| owner | address | The service owner |
+| Name      | Type    | Description       |
+| --------- | ------- | ----------------- |
+| serviceId | uint64  | The service ID    |
+| owner     | address | The service owner |
 
 #### canJoin
 
@@ -284,15 +285,15 @@ _Called before operator joins - return false to reject_
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| serviceId | uint64 | The service ID |
-| operator | address | The operator wanting to join |
+| Name      | Type    | Description                  |
+| --------- | ------- | ---------------------------- |
+| serviceId | uint64  | The service ID               |
+| operator  | address | The operator wanting to join |
 
 ##### Return Values
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name    | Type | Description               |
+| ------- | ---- | ------------------------- |
 | allowed | bool | True if operator can join |
 
 #### onOperatorJoined
@@ -305,11 +306,11 @@ Called after an operator successfully joins a service
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| serviceId | uint64 | The service ID |
-| operator | address | The operator that joined |
-| exposureBps | uint16 | The operator's stake exposure in basis points |
+| Name        | Type    | Description                                   |
+| ----------- | ------- | --------------------------------------------- |
+| serviceId   | uint64  | The service ID                                |
+| operator    | address | The operator that joined                      |
+| exposureBps | uint16  | The operator's stake exposure in basis points |
 
 #### canLeave
 
@@ -320,19 +321,19 @@ function canLeave(uint64 serviceId, address operator) external view returns (boo
 Check if an operator can leave a dynamic service
 
 _Called before operator leaves - return false to reject
-     Note: This is called AFTER the exit queue check. Use getExitConfig to customize timing._
+Note: This is called AFTER the exit queue check. Use getExitConfig to customize timing._
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| serviceId | uint64 | The service ID |
-| operator | address | The operator wanting to leave |
+| Name      | Type    | Description                   |
+| --------- | ------- | ----------------------------- |
+| serviceId | uint64  | The service ID                |
+| operator  | address | The operator wanting to leave |
 
 ##### Return Values
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name    | Type | Description                |
+| ------- | ---- | -------------------------- |
 | allowed | bool | True if operator can leave |
 
 #### onOperatorLeft
@@ -345,10 +346,10 @@ Called after an operator successfully leaves a service
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| serviceId | uint64 | The service ID |
-| operator | address | The operator that left |
+| Name      | Type    | Description            |
+| --------- | ------- | ---------------------- |
+| serviceId | uint64  | The service ID         |
+| operator  | address | The operator that left |
 
 #### onExitScheduled
 
@@ -362,11 +363,11 @@ _Allows manager to track pending exits, notify other parties, etc._
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| serviceId | uint64 | The service ID |
-| operator | address | The operator scheduling exit |
-| executeAfter | uint64 | Timestamp when exit can be executed |
+| Name         | Type    | Description                         |
+| ------------ | ------- | ----------------------------------- |
+| serviceId    | uint64  | The service ID                      |
+| operator     | address | The operator scheduling exit        |
+| executeAfter | uint64  | Timestamp when exit can be executed |
 
 #### onExitCanceled
 
@@ -378,10 +379,10 @@ Called when an operator cancels their scheduled exit
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| serviceId | uint64 | The service ID |
-| operator | address | The operator canceling exit |
+| Name      | Type    | Description                 |
+| --------- | ------- | --------------------------- |
+| serviceId | uint64  | The service ID              |
+| operator  | address | The operator canceling exit |
 
 #### onJobCall
 
@@ -395,12 +396,12 @@ _Validate job inputs, check caller permissions, etc._
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| serviceId | uint64 | The service ID |
-| job | uint8 | The job index in the blueprint |
-| jobCallId | uint64 | Unique ID for this job call |
-| inputs | bytes | Job inputs (blueprint-specific encoding) |
+| Name      | Type   | Description                              |
+| --------- | ------ | ---------------------------------------- |
+| serviceId | uint64 | The service ID                           |
+| job       | uint8  | The job index in the blueprint           |
+| jobCallId | uint64 | Unique ID for this job call              |
+| inputs    | bytes  | Job inputs (blueprint-specific encoding) |
 
 #### onJobResult
 
@@ -414,14 +415,14 @@ _Validate result format, check operator eligibility, aggregate results_
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| serviceId | uint64 | The service ID |
-| job | uint8 | The job index |
-| jobCallId | uint64 | The job call ID |
-| operator | address | The operator submitting |
-| inputs | bytes | Original job inputs |
-| outputs | bytes | Result outputs (blueprint-specific encoding) |
+| Name      | Type    | Description                                  |
+| --------- | ------- | -------------------------------------------- |
+| serviceId | uint64  | The service ID                               |
+| job       | uint8   | The job index                                |
+| jobCallId | uint64  | The job call ID                              |
+| operator  | address | The operator submitting                      |
+| inputs    | bytes   | Original job inputs                          |
+| outputs   | bytes   | Result outputs (blueprint-specific encoding) |
 
 #### onUnappliedSlash
 
@@ -435,11 +436,11 @@ _This is the dispute window - gather evidence, notify parties_
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| serviceId | uint64 | The service ID |
-| offender | bytes | The operator being slashed (encoded as bytes for flexibility) |
-| slashPercent | uint8 | Percentage of stake to slash |
+| Name         | Type   | Description                                                   |
+| ------------ | ------ | ------------------------------------------------------------- |
+| serviceId    | uint64 | The service ID                                                |
+| offender     | bytes  | The operator being slashed (encoded as bytes for flexibility) |
+| slashPercent | uint8  | Percentage of stake to slash                                  |
 
 #### onSlash
 
@@ -451,11 +452,11 @@ Called when a slash is finalized and applied
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| serviceId | uint64 | The service ID |
-| offender | bytes | The slashed operator |
-| slashPercent | uint8 | Percentage slashed |
+| Name         | Type   | Description          |
+| ------------ | ------ | -------------------- |
+| serviceId    | uint64 | The service ID       |
+| offender     | bytes  | The slashed operator |
+| slashPercent | uint8  | Percentage slashed   |
 
 #### querySlashingOrigin
 
@@ -469,14 +470,14 @@ _Override to allow custom slashing authorities (dispute contracts, etc.)_
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name      | Type   | Description    |
+| --------- | ------ | -------------- |
 | serviceId | uint64 | The service ID |
 
 ##### Return Values
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name           | Type    | Description                                     |
+| -------------- | ------- | ----------------------------------------------- |
 | slashingOrigin | address | Address that can slash (default: this contract) |
 
 #### queryDisputeOrigin
@@ -491,14 +492,14 @@ _Override to allow custom dispute resolution_
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name      | Type   | Description    |
+| --------- | ------ | -------------- |
 | serviceId | uint64 | The service ID |
 
 ##### Return Values
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name          | Type    | Description                                       |
+| ------------- | ------- | ------------------------------------------------- |
 | disputeOrigin | address | Address that can dispute (default: this contract) |
 
 #### queryDeveloperPaymentAddress
@@ -513,14 +514,14 @@ _Override to route payments to different addresses per service_
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name      | Type   | Description    |
+| --------- | ------ | -------------- |
 | serviceId | uint64 | The service ID |
 
 ##### Return Values
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name                    | Type            | Description                        |
+| ----------------------- | --------------- | ---------------------------------- |
 | developerPaymentAddress | address payable | Address to receive developer share |
 
 #### queryIsPaymentAssetAllowed
@@ -533,15 +534,15 @@ Check if a payment asset is allowed for this blueprint
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| serviceId | uint64 | The service ID |
-| asset | address | The payment asset address (address(0) for native) |
+| Name      | Type    | Description                                       |
+| --------- | ------- | ------------------------------------------------- |
+| serviceId | uint64  | The service ID                                    |
+| asset     | address | The payment asset address (address(0) for native) |
 
 ##### Return Values
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name      | Type | Description                               |
+| --------- | ---- | ----------------------------------------- |
 | isAllowed | bool | True if the asset can be used for payment |
 
 #### getRequiredResultCount
@@ -556,15 +557,15 @@ _Override for consensus requirements (e.g., 2/3 majority)_
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name      | Type   | Description    |
+| --------- | ------ | -------------- |
 | serviceId | uint64 | The service ID |
-| jobIndex | uint8 | The job index |
+| jobIndex  | uint8  | The job index  |
 
 ##### Return Values
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name     | Type   | Description                                           |
+| -------- | ------ | ----------------------------------------------------- |
 | required | uint32 | Number of results needed (0 = service operator count) |
 
 #### requiresAggregation
@@ -576,19 +577,19 @@ function requiresAggregation(uint64 serviceId, uint8 jobIndex) external view ret
 Check if a job requires BLS aggregated results
 
 _When true, operators must submit individual signatures that are aggregated
-     off-chain, then submitted via submitAggregatedResult instead of submitResult_
+off-chain, then submitted via submitAggregatedResult instead of submitResult_
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name      | Type   | Description    |
+| --------- | ------ | -------------- |
 | serviceId | uint64 | The service ID |
-| jobIndex | uint8 | The job index |
+| jobIndex  | uint8  | The job index  |
 
 ##### Return Values
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name     | Type | Description                                      |
+| -------- | ---- | ------------------------------------------------ |
 | required | bool | True if BLS aggregation is required for this job |
 
 #### getAggregationThreshold
@@ -603,17 +604,17 @@ _Only relevant if requiresAggregation returns true_
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name      | Type   | Description    |
+| --------- | ------ | -------------- |
 | serviceId | uint64 | The service ID |
-| jobIndex | uint8 | The job index |
+| jobIndex  | uint8  | The job index  |
 
 ##### Return Values
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| thresholdBps | uint16 | Threshold in basis points (6700 = 67%) |
-| thresholdType | uint8 | 0 = CountBased (% of operators), 1 = StakeWeighted (% of total stake) |
+| Name          | Type   | Description                                                           |
+| ------------- | ------ | --------------------------------------------------------------------- |
+| thresholdBps  | uint16 | Threshold in basis points (6700 = 67%)                                |
+| thresholdType | uint8  | 0 = CountBased (% of operators), 1 = StakeWeighted (% of total stake) |
 
 #### onAggregatedResult
 
@@ -627,15 +628,15 @@ _Validate the aggregated result, verify BLS signature, check threshold_
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| serviceId | uint64 | The service ID |
-| job | uint8 | The job index |
-| jobCallId | uint64 | The job call ID |
-| output | bytes | The aggregated output |
-| signerBitmap | uint256 | Bitmap of which operators signed |
-| aggregatedSignature | uint256[2] | The aggregated BLS signature (G1 point x, y) |
-| aggregatedPubkey | uint256[4] | The aggregated public key of signers (G2 point) |
+| Name                | Type       | Description                                     |
+| ------------------- | ---------- | ----------------------------------------------- |
+| serviceId           | uint64     | The service ID                                  |
+| job                 | uint8      | The job index                                   |
+| jobCallId           | uint64     | The job call ID                                 |
+| output              | bytes      | The aggregated output                           |
+| signerBitmap        | uint256    | Bitmap of which operators signed                |
+| aggregatedSignature | uint256[2] | The aggregated BLS signature (G1 point x, y)    |
+| aggregatedPubkey    | uint256[4] | The aggregated public key of signers (G2 point) |
 
 #### getMinOperatorStake
 
@@ -649,7 +650,7 @@ _Called during operator registration to validate stake requirements_
 
 ##### Return Values
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| useDefault | bool | True to use protocol default from staking module |
-| minStake | uint256 | Custom minimum stake amount (only used if useDefault=false) |
+| Name       | Type    | Description                                                 |
+| ---------- | ------- | ----------------------------------------------------------- |
+| useDefault | bool    | True to use protocol default from staking module            |
+| minStake   | uint256 | Custom minimum stake amount (only used if useDefault=false) |

--- a/pages/developers/api/reference/IERC7540.mdx
+++ b/pages/developers/api/reference/IERC7540.mdx
@@ -5,11 +5,10 @@ description: Auto-generated Solidity API reference.
 
 # IERC7540
 
-Source: https://github.com/tangle-network/tnt-core/blob/v2/src/v2/interfaces/IERC7540.sol
+Source: https://github.com/tangle-network/tnt-core/blob/main/src/interfaces/IERC7540.sol
 
 ### IERC7540
 
 Full ERC7540 interface combining deposit, redeem, and operator management
 
 _Extends ERC4626 with asynchronous request patterns_
-

--- a/pages/developers/api/reference/IERC7540Deposit.mdx
+++ b/pages/developers/api/reference/IERC7540Deposit.mdx
@@ -5,7 +5,7 @@ description: Auto-generated Solidity API reference.
 
 # IERC7540Deposit
 
-Source: https://github.com/tangle-network/tnt-core/blob/v2/src/v2/interfaces/IERC7540.sol
+Source: https://github.com/tangle-network/tnt-core/blob/main/src/interfaces/IERC7540.sol
 
 ### IERC7540Deposit
 
@@ -25,16 +25,16 @@ Request an asynchronous deposit
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| assets | uint256 | Amount of assets to deposit |
+| Name       | Type    | Description                       |
+| ---------- | ------- | --------------------------------- |
+| assets     | uint256 | Amount of assets to deposit       |
 | controller | address | Address that controls the request |
-| owner | address | Address that owns the assets |
+| owner      | address | Address that owns the assets      |
 
 ##### Return Values
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name      | Type    | Description                        |
+| --------- | ------- | ---------------------------------- |
 | requestId | uint256 | Unique identifier for this request |
 
 #### pendingDepositRequest
@@ -47,15 +47,15 @@ Get pending deposit request amount
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| requestId | uint256 | The request identifier |
+| Name       | Type    | Description            |
+| ---------- | ------- | ---------------------- |
+| requestId  | uint256 | The request identifier |
 | controller | address | The controller address |
 
 ##### Return Values
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name   | Type    | Description              |
+| ------ | ------- | ------------------------ |
 | assets | uint256 | Amount of assets pending |
 
 #### claimableDepositRequest
@@ -68,15 +68,15 @@ Get claimable deposit request amount
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| requestId | uint256 | The request identifier |
+| Name       | Type    | Description            |
+| ---------- | ------- | ---------------------- |
+| requestId  | uint256 | The request identifier |
 | controller | address | The controller address |
 
 ##### Return Values
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name   | Type    | Description                |
+| ------ | ------- | -------------------------- |
 | assets | uint256 | Amount of assets claimable |
 
 #### Events
@@ -88,4 +88,3 @@ event DepositRequest(address controller, address owner, uint256 requestId, addre
 ```
 
 Emitted when a deposit request is created
-

--- a/pages/developers/api/reference/IERC7540Operator.mdx
+++ b/pages/developers/api/reference/IERC7540Operator.mdx
@@ -5,7 +5,7 @@ description: Auto-generated Solidity API reference.
 
 # IERC7540Operator
 
-Source: https://github.com/tangle-network/tnt-core/blob/v2/src/v2/interfaces/IERC7540.sol
+Source: https://github.com/tangle-network/tnt-core/blob/main/src/interfaces/IERC7540.sol
 
 ### IERC7540Operator
 
@@ -23,15 +23,15 @@ Check if operator is approved for controller
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name       | Type    | Description            |
+| ---------- | ------- | ---------------------- |
 | controller | address | The controller address |
-| operator | address | The operator address |
+| operator   | address | The operator address   |
 
 ##### Return Values
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name   | Type | Description      |
+| ------ | ---- | ---------------- |
 | status | bool | True if approved |
 
 #### setOperator
@@ -44,15 +44,15 @@ Grant or revoke operator permissions
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| operator | address | The operator address |
-| approved | bool | True to approve, false to revoke |
+| Name     | Type    | Description                      |
+| -------- | ------- | -------------------------------- |
+| operator | address | The operator address             |
+| approved | bool    | True to approve, false to revoke |
 
 ##### Return Values
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name    | Type | Description        |
+| ------- | ---- | ------------------ |
 | success | bool | True if successful |
 
 #### Events
@@ -64,4 +64,3 @@ event OperatorSet(address controller, address operator, bool approved)
 ```
 
 Emitted when operator approval changes
-

--- a/pages/developers/api/reference/IERC7540Redeem.mdx
+++ b/pages/developers/api/reference/IERC7540Redeem.mdx
@@ -5,7 +5,7 @@ description: Auto-generated Solidity API reference.
 
 # IERC7540Redeem
 
-Source: https://github.com/tangle-network/tnt-core/blob/v2/src/v2/interfaces/IERC7540.sol
+Source: https://github.com/tangle-network/tnt-core/blob/main/src/interfaces/IERC7540.sol
 
 ### IERC7540Redeem
 
@@ -25,16 +25,16 @@ Request an asynchronous redemption
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| shares | uint256 | Amount of shares to redeem |
+| Name       | Type    | Description                       |
+| ---------- | ------- | --------------------------------- |
+| shares     | uint256 | Amount of shares to redeem        |
 | controller | address | Address that controls the request |
-| owner | address | Address that owns the shares |
+| owner      | address | Address that owns the shares      |
 
 ##### Return Values
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name      | Type    | Description                        |
+| --------- | ------- | ---------------------------------- |
 | requestId | uint256 | Unique identifier for this request |
 
 #### pendingRedeemRequest
@@ -47,15 +47,15 @@ Get pending redeem request amount
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| requestId | uint256 | The request identifier |
+| Name       | Type    | Description            |
+| ---------- | ------- | ---------------------- |
+| requestId  | uint256 | The request identifier |
 | controller | address | The controller address |
 
 ##### Return Values
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name   | Type    | Description              |
+| ------ | ------- | ------------------------ |
 | shares | uint256 | Amount of shares pending |
 
 #### claimableRedeemRequest
@@ -68,15 +68,15 @@ Get claimable redeem request amount
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| requestId | uint256 | The request identifier |
+| Name       | Type    | Description            |
+| ---------- | ------- | ---------------------- |
+| requestId  | uint256 | The request identifier |
 | controller | address | The controller address |
 
 ##### Return Values
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name   | Type    | Description                |
+| ------ | ------- | -------------------------- |
 | shares | uint256 | Amount of shares claimable |
 
 #### Events
@@ -88,4 +88,3 @@ event RedeemRequest(address controller, address owner, uint256 requestId, addres
 ```
 
 Emitted when a redeem request is created
-

--- a/pages/developers/api/reference/IFacetSelectors.mdx
+++ b/pages/developers/api/reference/IFacetSelectors.mdx
@@ -5,7 +5,7 @@ description: Auto-generated Solidity API reference.
 
 # IFacetSelectors
 
-Source: https://github.com/tangle-network/tnt-core/blob/v2/src/v2/interfaces/IFacetSelectors.sol
+Source: https://github.com/tangle-network/tnt-core/blob/main/src/interfaces/IFacetSelectors.sol
 
 ### IFacetSelectors
 
@@ -20,4 +20,3 @@ function selectors() external pure returns (bytes4[])
 ```
 
 Return the selectors this facet wants registered
-

--- a/pages/developers/api/reference/IMBSMRegistry.mdx
+++ b/pages/developers/api/reference/IMBSMRegistry.mdx
@@ -5,7 +5,7 @@ description: Auto-generated Solidity API reference.
 
 # IMBSMRegistry
 
-Source: https://github.com/tangle-network/tnt-core/blob/v2/src/v2/interfaces/IMBSMRegistry.sol
+Source: https://github.com/tangle-network/tnt-core/blob/main/src/interfaces/IMBSMRegistry.sol
 
 ### IMBSMRegistry
 
@@ -23,14 +23,14 @@ Get the MBSM address currently pinned for a blueprint
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name        | Type   | Description              |
+| ----------- | ------ | ------------------------ |
 | blueprintId | uint64 | The blueprint identifier |
 
 ##### Return Values
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name        | Type    | Description                               |
+| ----------- | ------- | ----------------------------------------- |
 | mbsmAddress | address | The pinned MBSM (or latest if not pinned) |
 
 #### getPinnedRevision
@@ -51,8 +51,8 @@ Get the latest registered MBSM address
 
 ##### Return Values
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name        | Type    | Description     |
+| ----------- | ------- | --------------- |
 | mbsmAddress | address | The latest MBSM |
 
 #### getMBSMByRevision
@@ -65,14 +65,14 @@ Get an MBSM by explicit revision
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name     | Type   | Description                       |
+| -------- | ------ | --------------------------------- |
 | revision | uint32 | The registry revision (1-indexed) |
 
 ##### Return Values
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name        | Type    | Description                             |
+| ----------- | ------- | --------------------------------------- |
 | mbsmAddress | address | The registered address for the revision |
 
 #### getLatestRevision
@@ -98,4 +98,3 @@ function unpinBlueprint(uint64 blueprintId) external
 ```
 
 Unpin a blueprint (reverting to latest)
-

--- a/pages/developers/api/reference/IMasterBlueprintServiceManager.mdx
+++ b/pages/developers/api/reference/IMasterBlueprintServiceManager.mdx
@@ -5,7 +5,7 @@ description: Auto-generated Solidity API reference.
 
 # IMasterBlueprintServiceManager
 
-Source: https://github.com/tangle-network/tnt-core/blob/v2/src/v2/interfaces/IMasterBlueprintServiceManager.sol
+Source: https://github.com/tangle-network/tnt-core/blob/main/src/interfaces/IMasterBlueprintServiceManager.sol
 
 ### IMasterBlueprintServiceManager
 
@@ -23,9 +23,8 @@ Called when a new blueprint is created
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| blueprintId | uint64 | The newly assigned blueprint ID |
-| owner | address | The blueprint owner |
-| encodedDefinition | bytes | ABI-encoded blueprint definition data |
-
+| Name              | Type    | Description                           |
+| ----------------- | ------- | ------------------------------------- |
+| blueprintId       | uint64  | The newly assigned blueprint ID       |
+| owner             | address | The blueprint owner                   |
+| encodedDefinition | bytes   | ABI-encoded blueprint definition data |

--- a/pages/developers/api/reference/IMetricsRecorder.mdx
+++ b/pages/developers/api/reference/IMetricsRecorder.mdx
@@ -5,7 +5,7 @@ description: Auto-generated Solidity API reference.
 
 # IMetricsRecorder
 
-Source: https://github.com/tangle-network/tnt-core/blob/v2/src/v2/interfaces/IMetricsRecorder.sol
+Source: https://github.com/tangle-network/tnt-core/blob/main/src/interfaces/IMetricsRecorder.sol
 
 ### IMetricsRecorder
 
@@ -25,12 +25,12 @@ Record a stake/delegation event
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| delegator | address | The delegator address |
-| operator | address | The operator receiving delegation |
-| asset | address | The asset being staked (address(0) for native) |
-| amount | uint256 | The amount staked |
+| Name      | Type    | Description                                    |
+| --------- | ------- | ---------------------------------------------- |
+| delegator | address | The delegator address                          |
+| operator  | address | The operator receiving delegation              |
+| asset     | address | The asset being staked (address(0) for native) |
+| amount    | uint256 | The amount staked                              |
 
 #### recordUnstake
 
@@ -42,12 +42,12 @@ Record an unstake event
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| delegator | address | The delegator address |
-| operator | address | The operator losing delegation |
-| asset | address | The asset being unstaked |
-| amount | uint256 | The amount unstaked |
+| Name      | Type    | Description                    |
+| --------- | ------- | ------------------------------ |
+| delegator | address | The delegator address          |
+| operator  | address | The operator losing delegation |
+| asset     | address | The asset being unstaked       |
+| amount    | uint256 | The amount unstaked            |
 
 #### recordOperatorRegistered
 
@@ -59,11 +59,11 @@ Record operator registration
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name     | Type    | Description          |
+| -------- | ------- | -------------------- |
 | operator | address | The operator address |
-| asset | address | The asset staked |
-| amount | uint256 | Initial stake amount |
+| asset    | address | The asset staked     |
+| amount   | uint256 | Initial stake amount |
 
 #### recordHeartbeat
 
@@ -75,11 +75,11 @@ Record operator heartbeat (liveness proof)
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| operator | address | The operator address |
-| serviceId | uint64 | The service ID |
-| timestamp | uint64 | Block timestamp of heartbeat |
+| Name      | Type    | Description                  |
+| --------- | ------- | ---------------------------- |
+| operator  | address | The operator address         |
+| serviceId | uint64  | The service ID               |
+| timestamp | uint64  | Block timestamp of heartbeat |
 
 #### recordJobCompletion
 
@@ -91,12 +91,12 @@ Record job completion by operator
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| operator | address | The operator address |
-| serviceId | uint64 | The service ID |
-| jobCallId | uint64 | The job call ID |
-| success | bool | Whether the job succeeded |
+| Name      | Type    | Description               |
+| --------- | ------- | ------------------------- |
+| operator  | address | The operator address      |
+| serviceId | uint64  | The service ID            |
+| jobCallId | uint64  | The job call ID           |
+| success   | bool    | Whether the job succeeded |
 
 #### recordSlash
 
@@ -108,11 +108,11 @@ Record operator slashing (negative metric)
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| operator | address | The operator address |
-| serviceId | uint64 | The service ID |
-| amount | uint256 | Amount slashed |
+| Name      | Type    | Description          |
+| --------- | ------- | -------------------- |
+| operator  | address | The operator address |
+| serviceId | uint64  | The service ID       |
+| amount    | uint256 | Amount slashed       |
 
 #### recordServiceCreated
 
@@ -124,11 +124,11 @@ Record service creation/activation
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| serviceId | uint64 | The service ID |
-| blueprintId | uint64 | The blueprint ID |
-| owner | address | The service owner |
+| Name          | Type    | Description         |
+| ------------- | ------- | ------------------- |
+| serviceId     | uint64  | The service ID      |
+| blueprintId   | uint64  | The blueprint ID    |
+| owner         | address | The service owner   |
 | operatorCount | uint256 | Number of operators |
 
 #### recordServiceTerminated
@@ -141,10 +141,10 @@ Record service termination
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| serviceId | uint64 | The service ID |
-| duration | uint256 | How long the service ran (seconds) |
+| Name      | Type    | Description                        |
+| --------- | ------- | ---------------------------------- |
+| serviceId | uint64  | The service ID                     |
+| duration  | uint256 | How long the service ran (seconds) |
 
 #### recordJobCall
 
@@ -156,11 +156,11 @@ Record a job call on a service
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| serviceId | uint64 | The service ID |
-| caller | address | Who initiated the job |
-| jobCallId | uint64 | The job call ID |
+| Name      | Type    | Description           |
+| --------- | ------- | --------------------- |
+| serviceId | uint64  | The service ID        |
+| caller    | address | Who initiated the job |
+| jobCallId | uint64  | The job call ID       |
 
 #### recordPayment
 
@@ -172,12 +172,12 @@ Record fee payment for a service
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| payer | address | Who paid the fee |
-| serviceId | uint64 | The service ID |
-| token | address | The payment token (address(0) for native) |
-| amount | uint256 | The amount paid |
+| Name      | Type    | Description                               |
+| --------- | ------- | ----------------------------------------- |
+| payer     | address | Who paid the fee                          |
+| serviceId | uint64  | The service ID                            |
+| token     | address | The payment token (address(0) for native) |
+| amount    | uint256 | The amount paid                           |
 
 #### recordBlueprintCreated
 
@@ -189,10 +189,10 @@ Record blueprint creation
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| blueprintId | uint64 | The blueprint ID |
-| developer | address | The developer address |
+| Name        | Type    | Description           |
+| ----------- | ------- | --------------------- |
+| blueprintId | uint64  | The blueprint ID      |
+| developer   | address | The developer address |
 
 #### recordBlueprintRegistration
 
@@ -204,8 +204,7 @@ Record operator registration to a blueprint
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| blueprintId | uint64 | The blueprint ID |
-| operator | address | The operator address |
-
+| Name        | Type    | Description          |
+| ----------- | ------- | -------------------- |
+| blueprintId | uint64  | The blueprint ID     |
+| operator    | address | The operator address |

--- a/pages/developers/api/reference/IMultiAssetDelegation.mdx
+++ b/pages/developers/api/reference/IMultiAssetDelegation.mdx
@@ -5,7 +5,7 @@ description: Auto-generated Solidity API reference.
 
 # IMultiAssetDelegation
 
-Source: https://github.com/tangle-network/tnt-core/blob/v2/src/v2/interfaces/IMultiAssetDelegation.sol
+Source: https://github.com/tangle-network/tnt-core/blob/main/src/interfaces/IMultiAssetDelegation.sol
 
 ### IMultiAssetDelegation
 
@@ -154,22 +154,22 @@ function executeDelegatorUnstakeAndWithdraw(address operator, address token, uin
 Execute a specific matured unstake request and withdraw the resulting assets to `receiver`.
 
 _Convenience helper for integrations (e.g. ERC7540 liquid delegation vaults) to avoid a separate
-     scheduleWithdraw/executeWithdraw flow after bond-less delay has already elapsed._
+scheduleWithdraw/executeWithdraw flow after bond-less delay has already elapsed._
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| operator | address | Operator to unstake from |
-| token | address | Token address (address(0) for native) |
-| shares | uint256 | Shares to unstake (as stored in the underlying bond-less request) |
-| requestedRound | uint64 | Round in which the unstake was scheduled |
-| receiver | address | Recipient of the withdrawn assets |
+| Name           | Type    | Description                                                       |
+| -------------- | ------- | ----------------------------------------------------------------- |
+| operator       | address | Operator to unstake from                                          |
+| token          | address | Token address (address(0) for native)                             |
+| shares         | uint256 | Shares to unstake (as stored in the underlying bond-less request) |
+| requestedRound | uint64  | Round in which the unstake was scheduled                          |
+| receiver       | address | Recipient of the withdrawn assets                                 |
 
 ##### Return Values
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name   | Type    | Description                                                           |
+| ------ | ------- | --------------------------------------------------------------------- |
 | amount | uint256 | Actual amount returned (after exchange-rate + lazy-slash adjustments) |
 
 #### addBlueprintToDelegation
@@ -737,4 +737,3 @@ event AdapterRemoved(address token)
 ```solidity
 event RequireAdaptersUpdated(bool required)
 ```
-

--- a/pages/developers/api/reference/IPaymentAdapterRegistry.mdx
+++ b/pages/developers/api/reference/IPaymentAdapterRegistry.mdx
@@ -5,7 +5,7 @@ description: Auto-generated Solidity API reference.
 
 # IPaymentAdapterRegistry
 
-Source: https://github.com/tangle-network/tnt-core/blob/v2/src/v2/interfaces/IStreamingPaymentAdapter.sol
+Source: https://github.com/tangle-network/tnt-core/blob/main/src/interfaces/IStreamingPaymentAdapter.sol
 
 ### IPaymentAdapterRegistry
 
@@ -23,9 +23,9 @@ Register a new payment adapter
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| name | string | Adapter name |
+| Name    | Type    | Description     |
+| ------- | ------- | --------------- |
+| name    | string  | Adapter name    |
 | adapter | address | Adapter address |
 
 #### removeAdapter
@@ -38,8 +38,8 @@ Remove a payment adapter
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name | Type   | Description            |
+| ---- | ------ | ---------------------- |
 | name | string | Adapter name to remove |
 
 #### getAdapter
@@ -52,14 +52,14 @@ Get an adapter by name
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name | Type   | Description  |
+| ---- | ------ | ------------ |
 | name | string | Adapter name |
 
 ##### Return Values
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name    | Type    | Description     |
+| ------- | ------- | --------------- |
 | adapter | address | Adapter address |
 
 #### getDefaultAdapter
@@ -72,8 +72,8 @@ Get the default adapter
 
 ##### Return Values
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name    | Type    | Description             |
+| ------- | ------- | ----------------------- |
 | adapter | address | Default adapter address |
 
 #### setDefaultAdapter
@@ -86,8 +86,8 @@ Set the default adapter
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name | Type   | Description                       |
+| ---- | ------ | --------------------------------- |
 | name | string | Name of adapter to set as default |
 
 #### isRegistered
@@ -100,14 +100,14 @@ Check if an adapter is registered
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name | Type   | Description  |
+| ---- | ------ | ------------ |
 | name | string | Adapter name |
 
 ##### Return Values
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name       | Type | Description            |
+| ---------- | ---- | ---------------------- |
 | registered | bool | True if adapter exists |
 
 #### getRegisteredAdapters
@@ -120,7 +120,6 @@ Get all registered adapter names
 
 ##### Return Values
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name  | Type     | Description            |
+| ----- | -------- | ---------------------- |
 | names | string[] | Array of adapter names |
-

--- a/pages/developers/api/reference/IRestaking.mdx
+++ b/pages/developers/api/reference/IRestaking.mdx
@@ -5,19 +5,20 @@ description: Auto-generated Solidity API reference.
 
 # IStaking
 
-Source: https://github.com/tangle-network/tnt-core/blob/v2/src/v2/interfaces/IStaking.sol
+Source: https://github.com/tangle-network/tnt-core/blob/main/src/interfaces/IStaking.sol
 
 ### IStaking
 
 Abstract interface for staking/shared security protocols
 
-_Implement this to integrate with native staking, Symbiotic, or other staking systems.
+\_Implement this to integrate with native staking, Symbiotic, or other staking systems.
 
 Design principles:
+
 - Minimal interface - only what Tangle core needs
 - Read-heavy - most operations are queries
 - Write-light - only slash() modifies state
-- No assumptions about underlying implementation_
+- No assumptions about underlying implementation\_
 
 #### Functions
 
@@ -31,15 +32,15 @@ Check if an address is a registered operator
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name     | Type    | Description          |
+| -------- | ------- | -------------------- |
 | operator | address | The address to check |
 
 ##### Return Values
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| [0] | bool | True if registered as operator |
+| Name | Type | Description                    |
+| ---- | ---- | ------------------------------ |
+| [0]  | bool | True if registered as operator |
 
 #### isOperatorActive
 
@@ -51,15 +52,15 @@ Check if an operator is currently active (not leaving, not slashed out)
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name     | Type    | Description          |
+| -------- | ------- | -------------------- |
 | operator | address | The address to check |
 
 ##### Return Values
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| [0] | bool | True if active |
+| Name | Type | Description    |
+| ---- | ---- | -------------- |
+| [0]  | bool | True if active |
 
 #### getOperatorStake
 
@@ -71,15 +72,15 @@ Get an operator's total stake (self-stake + delegations)
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name     | Type    | Description          |
+| -------- | ------- | -------------------- |
 | operator | address | The operator address |
 
 ##### Return Values
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| [0] | uint256 | Total stake amount in native units |
+| Name | Type    | Description                        |
+| ---- | ------- | ---------------------------------- |
+| [0]  | uint256 | Total stake amount in native units |
 
 #### getOperatorSelfStake
 
@@ -91,15 +92,15 @@ Get an operator's self-stake only
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name     | Type    | Description          |
+| -------- | ------- | -------------------- |
 | operator | address | The operator address |
 
 ##### Return Values
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| [0] | uint256 | Self-stake amount |
+| Name | Type    | Description       |
+| ---- | ------- | ----------------- |
+| [0]  | uint256 | Self-stake amount |
 
 #### getOperatorDelegatedStake
 
@@ -111,15 +112,15 @@ Get total amount delegated to an operator
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name     | Type    | Description          |
+| -------- | ------- | -------------------- |
 | operator | address | The operator address |
 
 ##### Return Values
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| [0] | uint256 | Total delegated amount |
+| Name | Type    | Description            |
+| ---- | ------- | ---------------------- |
+| [0]  | uint256 | Total delegated amount |
 
 #### getDelegation
 
@@ -131,16 +132,16 @@ Get a delegator's delegation to a specific operator
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name      | Type    | Description           |
+| --------- | ------- | --------------------- |
 | delegator | address | The delegator address |
-| operator | address | The operator address |
+| operator  | address | The operator address  |
 
 ##### Return Values
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| [0] | uint256 | Delegation amount |
+| Name | Type    | Description       |
+| ---- | ------- | ----------------- |
+| [0]  | uint256 | Delegation amount |
 
 #### getTotalDelegation
 
@@ -152,15 +153,15 @@ Get a delegator's total delegations across all operators
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name      | Type    | Description           |
+| --------- | ------- | --------------------- |
 | delegator | address | The delegator address |
 
 ##### Return Values
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| [0] | uint256 | Total delegated amount |
+| Name | Type    | Description            |
+| ---- | ------- | ---------------------- |
+| [0]  | uint256 | Total delegated amount |
 
 #### minOperatorStake
 
@@ -172,9 +173,9 @@ Get minimum stake required to be an operator
 
 ##### Return Values
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| [0] | uint256 | Minimum stake amount |
+| Name | Type    | Description          |
+| ---- | ------- | -------------------- |
+| [0]  | uint256 | Minimum stake amount |
 
 #### meetsStakeRequirement
 
@@ -186,16 +187,16 @@ Check if operator meets a specific stake requirement
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| operator | address | The operator address |
+| Name     | Type    | Description               |
+| -------- | ------- | ------------------------- |
+| operator | address | The operator address      |
 | required | uint256 | The required stake amount |
 
 ##### Return Values
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| [0] | bool | True if operator has sufficient stake |
+| Name | Type | Description                           |
+| ---- | ---- | ------------------------------------- |
+| [0]  | bool | True if operator has sufficient stake |
 
 #### slashForBlueprint
 
@@ -209,18 +210,18 @@ _Only affects delegators exposed to this blueprint (All mode + Fixed mode who se
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| operator | address | The operator to slash |
-| blueprintId | uint64 | The blueprint where violation occurred |
-| serviceId | uint64 | The service where violation occurred |
-| amount | uint256 | Amount to slash |
-| evidence | bytes32 | Evidence hash (IPFS or other reference) |
+| Name        | Type    | Description                             |
+| ----------- | ------- | --------------------------------------- |
+| operator    | address | The operator to slash                   |
+| blueprintId | uint64  | The blueprint where violation occurred  |
+| serviceId   | uint64  | The service where violation occurred    |
+| amount      | uint256 | Amount to slash                         |
+| evidence    | bytes32 | Evidence hash (IPFS or other reference) |
 
 ##### Return Values
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name          | Type    | Description                                                   |
+| ------------- | ------- | ------------------------------------------------------------- |
 | actualSlashed | uint256 | The actual amount slashed (may be less if insufficient stake) |
 
 #### slashForService
@@ -235,19 +236,19 @@ _Only slashes assets the operator committed to this service, proportionally_
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| operator | address | The operator to slash |
-| blueprintId | uint64 | The blueprint where violation occurred |
-| serviceId | uint64 | The service where violation occurred |
+| Name        | Type                                   | Description                                                |
+| ----------- | -------------------------------------- | ---------------------------------------------------------- |
+| operator    | address                                | The operator to slash                                      |
+| blueprintId | uint64                                 | The blueprint where violation occurred                     |
+| serviceId   | uint64                                 | The service where violation occurred                       |
 | commitments | struct Types.AssetSecurityCommitment[] | The operator's asset security commitments for this service |
-| amount | uint256 | Amount to slash |
-| evidence | bytes32 | Evidence hash (IPFS or other reference) |
+| amount      | uint256                                | Amount to slash                                            |
+| evidence    | bytes32                                | Evidence hash (IPFS or other reference)                    |
 
 ##### Return Values
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name          | Type    | Description                                                             |
+| ------------- | ------- | ----------------------------------------------------------------------- |
 | actualSlashed | uint256 | The actual amount slashed (may be less if insufficient committed stake) |
 
 #### slash
@@ -262,17 +263,17 @@ _Only callable by authorized slashers (e.g., Tangle core contract)_
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| operator | address | The operator to slash |
-| serviceId | uint64 | The service where violation occurred |
-| amount | uint256 | Amount to slash |
-| evidence | bytes32 | Evidence hash (IPFS or other reference) |
+| Name      | Type    | Description                             |
+| --------- | ------- | --------------------------------------- |
+| operator  | address | The operator to slash                   |
+| serviceId | uint64  | The service where violation occurred    |
+| amount    | uint256 | Amount to slash                         |
+| evidence  | bytes32 | Evidence hash (IPFS or other reference) |
 
 ##### Return Values
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name          | Type    | Description                                                   |
+| ------------- | ------- | ------------------------------------------------------------- |
 | actualSlashed | uint256 | The actual amount slashed (may be less if insufficient stake) |
 
 #### isSlasher
@@ -285,15 +286,15 @@ Check if an address is authorized to call slash()
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name    | Type    | Description          |
+| ------- | ------- | -------------------- |
 | account | address | The address to check |
 
 ##### Return Values
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| [0] | bool | True if authorized |
+| Name | Type | Description        |
+| ---- | ---- | ------------------ |
+| [0]  | bool | True if authorized |
 
 #### Events
 

--- a/pages/developers/api/reference/IRestakingAdmin.mdx
+++ b/pages/developers/api/reference/IRestakingAdmin.mdx
@@ -5,7 +5,7 @@ description: Auto-generated Solidity API reference.
 
 # IStakingAdmin
 
-Source: https://github.com/tangle-network/tnt-core/blob/v2/src/v2/interfaces/IStaking.sol
+Source: https://github.com/tangle-network/tnt-core/blob/main/src/interfaces/IStaking.sol
 
 ### IStakingAdmin
 
@@ -25,8 +25,8 @@ Add an authorized slasher
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name    | Type    | Description          |
+| ------- | ------- | -------------------- |
 | slasher | address | Address to authorize |
 
 #### removeSlasher
@@ -39,8 +39,8 @@ Remove an authorized slasher
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name    | Type    | Description       |
+| ------- | ------- | ----------------- |
 | slasher | address | Address to remove |
 
 #### setMinOperatorStake
@@ -53,7 +53,6 @@ Update minimum operator stake
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name   | Type    | Description |
+| ------ | ------- | ----------- |
 | amount | uint256 | New minimum |
-

--- a/pages/developers/api/reference/IRewardsManager.mdx
+++ b/pages/developers/api/reference/IRewardsManager.mdx
@@ -5,7 +5,7 @@ description: Auto-generated Solidity API reference.
 
 # IRewardsManager
 
-Source: https://github.com/tangle-network/tnt-core/blob/v2/src/v2/interfaces/IRewardsManager.sol
+Source: https://github.com/tangle-network/tnt-core/blob/main/src/interfaces/IRewardsManager.sol
 
 ### IRewardsManager
 
@@ -23,13 +23,13 @@ Records a delegation for reward tracking
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| delegator | address | The account making the delegation |
-| operator | address | The operator being delegated to |
-| asset | address | The asset being delegated (address(0) for native) |
-| amount | uint256 | The amount being delegated |
-| lockMultiplierBps | uint16 | Lock multiplier in basis points (10000 = 1x, 0 = no lock) |
+| Name              | Type    | Description                                               |
+| ----------------- | ------- | --------------------------------------------------------- |
+| delegator         | address | The account making the delegation                         |
+| operator          | address | The operator being delegated to                           |
+| asset             | address | The asset being delegated (address(0) for native)         |
+| amount            | uint256 | The amount being delegated                                |
+| lockMultiplierBps | uint16  | Lock multiplier in basis points (10000 = 1x, 0 = no lock) |
 
 #### recordUndelegate
 
@@ -41,12 +41,12 @@ Records an undelegation
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name      | Type    | Description                         |
+| --------- | ------- | ----------------------------------- |
 | delegator | address | The account making the undelegation |
-| operator | address | The operator being undelegated from |
-| asset | address | The asset being undelegated |
-| amount | uint256 | The amount being undelegated |
+| operator  | address | The operator being undelegated from |
+| asset     | address | The asset being undelegated         |
+| amount    | uint256 | The amount being undelegated        |
 
 #### recordServiceReward
 
@@ -58,11 +58,11 @@ Records a service reward for an operator
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name     | Type    | Description                       |
+| -------- | ------- | --------------------------------- |
 | operator | address | The operator receiving the reward |
-| asset | address | The reward asset |
-| amount | uint256 | The reward amount |
+| asset    | address | The reward asset                  |
+| amount   | uint256 | The reward amount                 |
 
 #### getAssetDepositCapRemaining
 
@@ -74,13 +74,12 @@ Get remaining deposit capacity for an asset vault
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name  | Type    | Description        |
+| ----- | ------- | ------------------ |
 | asset | address | The asset to query |
 
 ##### Return Values
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name      | Type    | Description                    |
+| --------- | ------- | ------------------------------ |
 | remaining | uint256 | The remaining deposit capacity |
-

--- a/pages/developers/api/reference/ISablierAdapter.mdx
+++ b/pages/developers/api/reference/ISablierAdapter.mdx
@@ -5,7 +5,7 @@ description: Auto-generated Solidity API reference.
 
 # ISablierAdapter
 
-Source: https://github.com/tangle-network/tnt-core/blob/v2/src/v2/interfaces/IStreamingPaymentAdapter.sol
+Source: https://github.com/tangle-network/tnt-core/blob/main/src/interfaces/IStreamingPaymentAdapter.sol
 
 ### ISablierAdapter
 
@@ -49,18 +49,18 @@ Create a linear stream (constant rate)
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| serviceId | uint64 | The Tangle service ID |
-| token | address | The ERC-20 token |
-| totalAmount | uint128 | Total amount to stream |
-| durationSeconds | uint40 | Total duration |
-| cliffSeconds | uint40 | Cliff period |
+| Name            | Type    | Description            |
+| --------------- | ------- | ---------------------- |
+| serviceId       | uint64  | The Tangle service ID  |
+| token           | address | The ERC-20 token       |
+| totalAmount     | uint128 | Total amount to stream |
+| durationSeconds | uint40  | Total duration         |
+| cliffSeconds    | uint40  | Cliff period           |
 
 ##### Return Values
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name     | Type    | Description           |
+| -------- | ------- | --------------------- |
 | streamId | uint256 | The created stream ID |
 
 #### createDynamicStream
@@ -73,17 +73,17 @@ Create a dynamic stream with custom curve
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| serviceId | uint64 | The Tangle service ID |
-| token | address | The ERC-20 token |
-| totalAmount | uint128 | Total amount to stream |
-| segments | struct ISablierAdapter.Segment[] | Array of segments defining the curve |
+| Name        | Type                             | Description                          |
+| ----------- | -------------------------------- | ------------------------------------ |
+| serviceId   | uint64                           | The Tangle service ID                |
+| token       | address                          | The ERC-20 token                     |
+| totalAmount | uint128                          | Total amount to stream               |
+| segments    | struct ISablierAdapter.Segment[] | Array of segments defining the curve |
 
 ##### Return Values
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name     | Type    | Description           |
+| -------- | ------- | --------------------- |
 | streamId | uint256 | The created stream ID |
 
 #### isCancelable
@@ -96,14 +96,14 @@ Check if a stream is cancelable
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name     | Type    | Description   |
+| -------- | ------- | ------------- |
 | streamId | uint256 | The stream ID |
 
 ##### Return Values
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name       | Type | Description                     |
+| ---------- | ---- | ------------------------------- |
 | cancelable | bool | True if stream can be cancelled |
 
 #### wasCancelled
@@ -116,14 +116,14 @@ Check if a stream was cancelled
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name     | Type    | Description   |
+| -------- | ------- | ------------- |
 | streamId | uint256 | The stream ID |
 
 ##### Return Values
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name      | Type | Description                  |
+| --------- | ---- | ---------------------------- |
 | cancelled | bool | True if stream was cancelled |
 
 #### getStreamNFT
@@ -136,14 +136,14 @@ Get the NFT token ID for a stream (Sablier streams are NFTs)
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name     | Type    | Description   |
+| -------- | ------- | ------------- |
 | streamId | uint256 | The stream ID |
 
 ##### Return Values
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name    | Type    | Description          |
+| ------- | ------- | -------------------- |
 | tokenId | uint256 | The ERC-721 token ID |
 
 #### transferStream
@@ -156,8 +156,7 @@ Transfer stream ownership (NFT transfer)
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| streamId | uint256 | The stream ID |
+| Name         | Type    | Description           |
+| ------------ | ------- | --------------------- |
+| streamId     | uint256 | The stream ID         |
 | newRecipient | address | New recipient address |
-

--- a/pages/developers/api/reference/IServiceFeeDistributor.mdx
+++ b/pages/developers/api/reference/IServiceFeeDistributor.mdx
@@ -5,7 +5,7 @@ description: Auto-generated Solidity API reference.
 
 # IServiceFeeDistributor
 
-Source: https://github.com/tangle-network/tnt-core/blob/v2/src/v2/interfaces/IServiceFeeDistributor.sol
+Source: https://github.com/tangle-network/tnt-core/blob/main/src/interfaces/IServiceFeeDistributor.sol
 
 ### IServiceFeeDistributor
 
@@ -151,8 +151,7 @@ _Cancels streaming payments and refunds remaining amounts to the service owner_
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| serviceId | uint64 | The terminated service ID |
+| Name            | Type    | Description                                                   |
+| --------------- | ------- | ------------------------------------------------------------- |
+| serviceId       | uint64  | The terminated service ID                                     |
 | refundRecipient | address | Where to send the remaining payment (typically service owner) |
-

--- a/pages/developers/api/reference/IStreamingPaymentAdapter.mdx
+++ b/pages/developers/api/reference/IStreamingPaymentAdapter.mdx
@@ -5,14 +5,14 @@ description: Auto-generated Solidity API reference.
 
 # IStreamingPaymentAdapter
 
-Source: https://github.com/tangle-network/tnt-core/blob/v2/src/v2/interfaces/IStreamingPaymentAdapter.sol
+Source: https://github.com/tangle-network/tnt-core/blob/main/src/interfaces/IStreamingPaymentAdapter.sol
 
 ### IStreamingPaymentAdapter
 
 Common interface for streaming payment adapters (Superfluid, Sablier, etc.)
 
 _Adapters implement this interface to provide streaming payment capabilities
-     to Tangle services without tight coupling to specific protocols._
+to Tangle services without tight coupling to specific protocols._
 
 #### Functions
 
@@ -26,18 +26,18 @@ Create a streaming payment for a service
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| serviceId | uint64 | The Tangle service ID |
-| token | address | The ERC-20 token to stream (address(0) for native) |
-| totalAmount | uint256 | Total amount to stream |
-| durationSeconds | uint64 | Stream duration in seconds |
-| cliffSeconds | uint64 | Optional cliff period (0 for no cliff) |
+| Name            | Type    | Description                                        |
+| --------------- | ------- | -------------------------------------------------- |
+| serviceId       | uint64  | The Tangle service ID                              |
+| token           | address | The ERC-20 token to stream (address(0) for native) |
+| totalAmount     | uint256 | Total amount to stream                             |
+| durationSeconds | uint64  | Stream duration in seconds                         |
+| cliffSeconds    | uint64  | Optional cliff period (0 for no cliff)             |
 
 ##### Return Values
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name     | Type    | Description           |
+| -------- | ------- | --------------------- |
 | streamId | uint256 | The created stream ID |
 
 #### updateStreamRate
@@ -50,10 +50,10 @@ Update the rate of an existing stream
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| streamId | uint256 | The stream ID to update |
-| newRatePerSecond | uint256 | New streaming rate |
+| Name             | Type    | Description             |
+| ---------------- | ------- | ----------------------- |
+| streamId         | uint256 | The stream ID to update |
+| newRatePerSecond | uint256 | New streaming rate      |
 
 #### cancelStream
 
@@ -65,14 +65,14 @@ Cancel a stream and refund remaining balance
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name     | Type    | Description             |
+| -------- | ------- | ----------------------- |
 | streamId | uint256 | The stream ID to cancel |
 
 ##### Return Values
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name           | Type    | Description                  |
+| -------------- | ------- | ---------------------------- |
 | refundedAmount | uint256 | Amount refunded to the payer |
 
 #### withdrawFromStream
@@ -85,14 +85,14 @@ Withdraw available funds from a stream
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name     | Type    | Description   |
+| -------- | ------- | ------------- |
 | streamId | uint256 | The stream ID |
 
 ##### Return Values
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name            | Type    | Description      |
+| --------------- | ------- | ---------------- |
 | withdrawnAmount | uint256 | Amount withdrawn |
 
 #### settleAndDistribute
@@ -107,8 +107,8 @@ _This triggers distribution through Tangle's payment system_
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name     | Type    | Description             |
+| -------- | ------- | ----------------------- |
 | streamId | uint256 | The stream ID to settle |
 
 #### getWithdrawableAmount
@@ -121,14 +121,14 @@ Get the current withdrawable amount for a stream
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name     | Type    | Description   |
+| -------- | ------- | ------------- |
 | streamId | uint256 | The stream ID |
 
 ##### Return Values
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name   | Type    | Description                  |
+| ------ | ------- | ---------------------------- |
 | amount | uint256 | Amount available to withdraw |
 
 #### getStreamRate
@@ -141,14 +141,14 @@ Get the current streaming rate
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name     | Type    | Description   |
+| -------- | ------- | ------------- |
 | streamId | uint256 | The stream ID |
 
 ##### Return Values
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name          | Type    | Description                      |
+| ------------- | ------- | -------------------------------- |
 | ratePerSecond | uint256 | Tokens per second being streamed |
 
 #### getStreamInfo
@@ -161,23 +161,23 @@ Get full stream information
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name     | Type    | Description   |
+| -------- | ------- | ------------- |
 | streamId | uint256 | The stream ID |
 
 ##### Return Values
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| serviceId | uint64 | Associated Tangle service |
-| payer | address | Address funding the stream |
-| token | address | Token being streamed |
-| totalAmount | uint256 | Total stream amount |
-| withdrawnAmount | uint256 | Amount already withdrawn |
-| startTime | uint256 | Stream start timestamp |
-| endTime | uint256 | Stream end timestamp |
-| cliffTime | uint256 | Cliff timestamp (0 if no cliff) |
-| active | bool | Whether stream is active |
+| Name            | Type    | Description                     |
+| --------------- | ------- | ------------------------------- |
+| serviceId       | uint64  | Associated Tangle service       |
+| payer           | address | Address funding the stream      |
+| token           | address | Token being streamed            |
+| totalAmount     | uint256 | Total stream amount             |
+| withdrawnAmount | uint256 | Amount already withdrawn        |
+| startTime       | uint256 | Stream start timestamp          |
+| endTime         | uint256 | Stream end timestamp            |
+| cliffTime       | uint256 | Cliff timestamp (0 if no cliff) |
+| active          | bool    | Whether stream is active        |
 
 #### getStreamServiceId
 
@@ -189,14 +189,14 @@ Get the service ID associated with a stream
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name     | Type    | Description   |
+| -------- | ------- | ------------- |
 | streamId | uint256 | The stream ID |
 
 ##### Return Values
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name      | Type   | Description           |
+| --------- | ------ | --------------------- |
 | serviceId | uint64 | The Tangle service ID |
 
 #### getServiceStreams
@@ -209,14 +209,14 @@ Get all active streams for a service
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name      | Type   | Description           |
+| --------- | ------ | --------------------- |
 | serviceId | uint64 | The Tangle service ID |
 
 ##### Return Values
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name      | Type      | Description                |
+| --------- | --------- | -------------------------- |
 | streamIds | uint256[] | Array of active stream IDs |
 
 #### getAccruedAmount
@@ -229,14 +229,14 @@ Calculate real-time accrued amount (not yet settled)
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name     | Type    | Description   |
+| -------- | ------- | ------------- |
 | streamId | uint256 | The stream ID |
 
 ##### Return Values
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name          | Type    | Description                          |
+| ------------- | ------- | ------------------------------------ |
 | accruedAmount | uint256 | Amount accrued since last settlement |
 
 #### protocolName
@@ -249,8 +249,8 @@ Get the name of the underlying protocol
 
 ##### Return Values
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name | Type   | Description                                   |
+| ---- | ------ | --------------------------------------------- |
 | name | string | Protocol name (e.g., "Superfluid", "Sablier") |
 
 #### isTokenSupported
@@ -263,14 +263,14 @@ Check if a token is supported for streaming
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name  | Type    | Description       |
+| ----- | ------- | ----------------- |
 | token | address | The token address |
 
 ##### Return Values
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name      | Type | Description                   |
+| --------- | ---- | ----------------------------- |
 | supported | bool | True if token can be streamed |
 
 #### Events
@@ -314,4 +314,3 @@ event StreamSettled(uint64 serviceId, uint256 streamId, uint256 amount)
 ```
 
 Emitted when a stream is settled and distributed
-

--- a/pages/developers/api/reference/IStreamingPaymentManager.mdx
+++ b/pages/developers/api/reference/IStreamingPaymentManager.mdx
@@ -5,7 +5,7 @@ description: Auto-generated Solidity API reference.
 
 # IStreamingPaymentManager
 
-Source: https://github.com/tangle-network/tnt-core/blob/v2/src/v2/interfaces/IStreamingPaymentManager.sol
+Source: https://github.com/tangle-network/tnt-core/blob/main/src/interfaces/IStreamingPaymentManager.sol
 
 ### IStreamingPaymentManager
 
@@ -76,4 +76,3 @@ function pendingDrip(uint64 serviceId, address operator) external view returns (
 ```
 
 Calculate pending drip amount
-

--- a/pages/developers/api/reference/ISuperfluidAdapter.mdx
+++ b/pages/developers/api/reference/ISuperfluidAdapter.mdx
@@ -5,7 +5,7 @@ description: Auto-generated Solidity API reference.
 
 # ISuperfluidAdapter
 
-Source: https://github.com/tangle-network/tnt-core/blob/v2/src/v2/interfaces/IStreamingPaymentAdapter.sol
+Source: https://github.com/tangle-network/tnt-core/blob/main/src/interfaces/IStreamingPaymentAdapter.sol
 
 ### ISuperfluidAdapter
 
@@ -23,15 +23,15 @@ Get the net flow rate for an account (incoming - outgoing)
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name    | Type    | Description         |
+| ------- | ------- | ------------------- |
 | account | address | The account address |
-| token | address | The super token |
+| token   | address | The super token     |
 
 ##### Return Values
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name        | Type  | Description                     |
+| ----------- | ----- | ------------------------------- |
 | netFlowRate | int96 | Net flow rate (can be negative) |
 
 #### getRealtimeBalance
@@ -44,17 +44,17 @@ Get the real-time balance of an account
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name    | Type    | Description         |
+| ------- | ------- | ------------------- |
 | account | address | The account address |
-| token | address | The super token |
+| token   | address | The super token     |
 
 ##### Return Values
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| availableBalance | int256 | Current available balance |
-| deposit | uint256 | Required deposit/buffer |
+| Name             | Type    | Description               |
+| ---------------- | ------- | ------------------------- |
+| availableBalance | int256  | Current available balance |
+| deposit          | uint256 | Required deposit/buffer   |
 
 #### isSolvent
 
@@ -66,15 +66,15 @@ Check if an account is solvent (positive balance)
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name    | Type    | Description         |
+| ------- | ------- | ------------------- |
 | account | address | The account address |
-| token | address | The super token |
+| token   | address | The super token     |
 
 ##### Return Values
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name    | Type | Description                          |
+| ------- | ---- | ------------------------------------ |
 | solvent | bool | True if account has positive balance |
 
 #### getRequiredBuffer
@@ -87,15 +87,15 @@ Get the required buffer/deposit for a flow rate
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| token | address | The super token |
-| flowRate | int96 | Flow rate in wei/second |
+| Name     | Type    | Description             |
+| -------- | ------- | ----------------------- |
+| token    | address | The super token         |
+| flowRate | int96   | Flow rate in wei/second |
 
 ##### Return Values
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name         | Type    | Description             |
+| ------------ | ------- | ----------------------- |
 | bufferAmount | uint256 | Required buffer deposit |
 
 #### wrapTokens
@@ -108,10 +108,10 @@ Wrap underlying tokens to super tokens
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| token | address | The underlying token |
-| amount | uint256 | Amount to wrap |
+| Name   | Type    | Description          |
+| ------ | ------- | -------------------- |
+| token  | address | The underlying token |
+| amount | uint256 | Amount to wrap       |
 
 #### unwrapTokens
 
@@ -123,8 +123,7 @@ Unwrap super tokens to underlying
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| token | address | The super token |
+| Name   | Type    | Description      |
+| ------ | ------- | ---------------- |
+| token  | address | The super token  |
 | amount | uint256 | Amount to unwrap |
-

--- a/pages/developers/api/reference/ITangle.mdx
+++ b/pages/developers/api/reference/ITangle.mdx
@@ -5,12 +5,11 @@ description: Auto-generated Solidity API reference.
 
 # ITangle
 
-Source: https://github.com/tangle-network/tnt-core/blob/v2/src/v2/interfaces/ITangle.sol
+Source: https://github.com/tangle-network/tnt-core/blob/main/src/interfaces/ITangle.sol
 
 ### ITangle
 
 Core interface for Tangle Protocol
 
 _Consolidates all sub-interfaces into a single entry point.
-     Inherits from focused sub-interfaces for modularity._
-
+Inherits from focused sub-interfaces for modularity._

--- a/pages/developers/api/reference/ITangleAdmin.mdx
+++ b/pages/developers/api/reference/ITangleAdmin.mdx
@@ -5,7 +5,7 @@ description: Auto-generated Solidity API reference.
 
 # ITangleAdmin
 
-Source: https://github.com/tangle-network/tnt-core/blob/v2/src/v2/interfaces/ITangle.sol
+Source: https://github.com/tangle-network/tnt-core/blob/main/src/interfaces/ITangle.sol
 
 ### ITangleAdmin
 
@@ -23,8 +23,8 @@ Set the staking module
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name    | Type    | Description                 |
+| ------- | ------- | --------------------------- |
 | staking | address | The IStaking implementation |
 
 #### setTreasury
@@ -37,8 +37,8 @@ Set the protocol treasury
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name     | Type    | Description          |
+| -------- | ------- | -------------------- |
 | treasury | address | The treasury address |
 
 #### setPaymentSplit
@@ -51,8 +51,8 @@ Set the payment split configuration
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name  | Type                      | Description                 |
+| ----- | ------------------------- | --------------------------- |
 | split | struct Types.PaymentSplit | The new split configuration |
 
 #### paymentSplit
@@ -246,4 +246,3 @@ function setTntPaymentDiscountBps(uint16 discountBps) external
 ```
 
 Set TNT payment discount bps
-

--- a/pages/developers/api/reference/ITangleBlueprints.mdx
+++ b/pages/developers/api/reference/ITangleBlueprints.mdx
@@ -5,7 +5,7 @@ description: Auto-generated Solidity API reference.
 
 # ITangleBlueprints
 
-Source: https://github.com/tangle-network/tnt-core/blob/v2/src/v2/interfaces/ITangleBlueprints.sol
+Source: https://github.com/tangle-network/tnt-core/blob/main/src/interfaces/ITangleBlueprints.sol
 
 ### ITangleBlueprints
 
@@ -23,14 +23,14 @@ Create a blueprint from an encoded definition that includes schemas and job meta
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name       | Type                             | Description                                 |
+| ---------- | -------------------------------- | ------------------------------------------- |
 | definition | struct Types.BlueprintDefinition | Fully populated blueprint definition struct |
 
 ##### Return Values
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name        | Type   | Description          |
+| ----------- | ------ | -------------------- |
 | blueprintId | uint64 | The new blueprint ID |
 
 #### updateBlueprint
@@ -154,4 +154,3 @@ event BlueprintTransferred(uint64 blueprintId, address from, address to)
 ```solidity
 event BlueprintDeactivated(uint64 blueprintId)
 ```
-

--- a/pages/developers/api/reference/ITangleFull.mdx
+++ b/pages/developers/api/reference/ITangleFull.mdx
@@ -5,9 +5,8 @@ description: Auto-generated Solidity API reference.
 
 # ITangleFull
 
-Source: https://github.com/tangle-network/tnt-core/blob/v2/src/v2/interfaces/ITangle.sol
+Source: https://github.com/tangle-network/tnt-core/blob/main/src/interfaces/ITangle.sol
 
 ### ITangleFull
 
 Complete Tangle interface including admin and slashing
-

--- a/pages/developers/api/reference/ITangleGovernance.mdx
+++ b/pages/developers/api/reference/ITangleGovernance.mdx
@@ -5,7 +5,7 @@ description: Auto-generated Solidity API reference.
 
 # ITangleGovernance
 
-Source: https://github.com/tangle-network/tnt-core/blob/v2/src/v2/interfaces/ITangleGovernance.sol
+Source: https://github.com/tangle-network/tnt-core/blob/main/src/interfaces/ITangleGovernance.sol
 
 ### ITangleGovernance
 
@@ -42,17 +42,17 @@ Create a new proposal
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| targets | address[] | Contract addresses to call |
-| values | uint256[] | ETH values to send |
-| calldatas | bytes[] | Encoded function calls |
-| description | string | Human-readable description |
+| Name        | Type      | Description                |
+| ----------- | --------- | -------------------------- |
+| targets     | address[] | Contract addresses to call |
+| values      | uint256[] | ETH values to send         |
+| calldatas   | bytes[]   | Encoded function calls     |
+| description | string    | Human-readable description |
 
 ##### Return Values
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name       | Type    | Description                    |
+| ---------- | ------- | ------------------------------ |
 | proposalId | uint256 | The unique proposal identifier |
 
 #### queue
@@ -65,17 +65,17 @@ Queue a successful proposal for execution
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| targets | address[] | Contract addresses to call |
-| values | uint256[] | ETH values to send |
-| calldatas | bytes[] | Encoded function calls |
-| descriptionHash | bytes32 | Hash of the proposal description |
+| Name            | Type      | Description                      |
+| --------------- | --------- | -------------------------------- |
+| targets         | address[] | Contract addresses to call       |
+| values          | uint256[] | ETH values to send               |
+| calldatas       | bytes[]   | Encoded function calls           |
+| descriptionHash | bytes32   | Hash of the proposal description |
 
 ##### Return Values
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name       | Type    | Description             |
+| ---------- | ------- | ----------------------- |
 | proposalId | uint256 | The proposal identifier |
 
 #### execute
@@ -88,17 +88,17 @@ Execute a queued proposal
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| targets | address[] | Contract addresses to call |
-| values | uint256[] | ETH values to send |
-| calldatas | bytes[] | Encoded function calls |
-| descriptionHash | bytes32 | Hash of the proposal description |
+| Name            | Type      | Description                      |
+| --------------- | --------- | -------------------------------- |
+| targets         | address[] | Contract addresses to call       |
+| values          | uint256[] | ETH values to send               |
+| calldatas       | bytes[]   | Encoded function calls           |
+| descriptionHash | bytes32   | Hash of the proposal description |
 
 ##### Return Values
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name       | Type    | Description             |
+| ---------- | ------- | ----------------------- |
 | proposalId | uint256 | The proposal identifier |
 
 #### cancel
@@ -111,17 +111,17 @@ Cancel a proposal
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| targets | address[] | Contract addresses to call |
-| values | uint256[] | ETH values to send |
-| calldatas | bytes[] | Encoded function calls |
-| descriptionHash | bytes32 | Hash of the proposal description |
+| Name            | Type      | Description                      |
+| --------------- | --------- | -------------------------------- |
+| targets         | address[] | Contract addresses to call       |
+| values          | uint256[] | ETH values to send               |
+| calldatas       | bytes[]   | Encoded function calls           |
+| descriptionHash | bytes32   | Hash of the proposal description |
 
 ##### Return Values
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name       | Type    | Description             |
+| ---------- | ------- | ----------------------- |
 | proposalId | uint256 | The proposal identifier |
 
 #### castVote
@@ -134,15 +134,15 @@ Cast a vote on a proposal
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| proposalId | uint256 | The proposal to vote on |
-| support | uint8 | 0=Against, 1=For, 2=Abstain |
+| Name       | Type    | Description                 |
+| ---------- | ------- | --------------------------- |
+| proposalId | uint256 | The proposal to vote on     |
+| support    | uint8   | 0=Against, 1=For, 2=Abstain |
 
 ##### Return Values
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name   | Type    | Description            |
+| ------ | ------- | ---------------------- |
 | weight | uint256 | The voting weight used |
 
 #### castVoteWithReason
@@ -155,16 +155,16 @@ Cast a vote with reason
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| proposalId | uint256 | The proposal to vote on |
-| support | uint8 | 0=Against, 1=For, 2=Abstain |
-| reason | string | Explanation for the vote |
+| Name       | Type    | Description                 |
+| ---------- | ------- | --------------------------- |
+| proposalId | uint256 | The proposal to vote on     |
+| support    | uint8   | 0=Against, 1=For, 2=Abstain |
+| reason     | string  | Explanation for the vote    |
 
 ##### Return Values
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name   | Type    | Description            |
+| ------ | ------- | ---------------------- |
 | weight | uint256 | The voting weight used |
 
 #### castVoteBySig
@@ -177,17 +177,17 @@ Cast a vote using EIP-712 signature
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| proposalId | uint256 | The proposal to vote on |
-| support | uint8 | 0=Against, 1=For, 2=Abstain |
-| voter | address | The voter address |
-| signature | bytes | The EIP-712 signature |
+| Name       | Type    | Description                 |
+| ---------- | ------- | --------------------------- |
+| proposalId | uint256 | The proposal to vote on     |
+| support    | uint8   | 0=Against, 1=For, 2=Abstain |
+| voter      | address | The voter address           |
+| signature  | bytes   | The EIP-712 signature       |
 
 ##### Return Values
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name   | Type    | Description            |
+| ------ | ------- | ---------------------- |
 | weight | uint256 | The voting weight used |
 
 #### state
@@ -269,4 +269,3 @@ function proposalThreshold() external view returns (uint256)
 ```
 
 Get the proposal threshold (tokens needed to propose)
-

--- a/pages/developers/api/reference/ITangleJobs.mdx
+++ b/pages/developers/api/reference/ITangleJobs.mdx
@@ -5,7 +5,7 @@ description: Auto-generated Solidity API reference.
 
 # ITangleJobs
 
-Source: https://github.com/tangle-network/tnt-core/blob/v2/src/v2/interfaces/ITangleJobs.sol
+Source: https://github.com/tangle-network/tnt-core/blob/main/src/interfaces/ITangleJobs.sol
 
 ### ITangleJobs
 
@@ -49,14 +49,14 @@ _Only valid for jobs where requiresAggregation returns true_
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| serviceId | uint64 | The service ID |
-| callId | uint64 | The job call ID |
-| output | bytes | The aggregated output data |
-| signerBitmap | uint256 | Bitmap indicating which operators signed (bit i = operator i in service) |
-| aggregatedSignature | uint256[2] | The aggregated BLS signature [x, y] |
-| aggregatedPubkey | uint256[4] | The aggregated public key [x0, x1, y0, y1] |
+| Name                | Type       | Description                                                              |
+| ------------------- | ---------- | ------------------------------------------------------------------------ |
+| serviceId           | uint64     | The service ID                                                           |
+| callId              | uint64     | The job call ID                                                          |
+| output              | bytes      | The aggregated output data                                               |
+| signerBitmap        | uint256    | Bitmap indicating which operators signed (bit i = operator i in service) |
+| aggregatedSignature | uint256[2] | The aggregated BLS signature [x, y]                                      |
+| aggregatedPubkey    | uint256[4] | The aggregated public key [x0, x1, y0, y1]                               |
 
 #### getJobCall
 
@@ -89,4 +89,3 @@ event JobCompleted(uint64 serviceId, uint64 callId)
 Emitted when a job reaches its required result threshold
 
 _Derive resultCount from getJobCall(serviceId, callId).resultCount_
-

--- a/pages/developers/api/reference/ITangleOperators.mdx
+++ b/pages/developers/api/reference/ITangleOperators.mdx
@@ -5,15 +5,15 @@ description: Auto-generated Solidity API reference.
 
 # ITangleOperators
 
-Source: https://github.com/tangle-network/tnt-core/blob/v2/src/v2/interfaces/ITangleOperators.sol
+Source: https://github.com/tangle-network/tnt-core/blob/main/src/interfaces/ITangleOperators.sol
 
 ### ITangleOperators
 
 Operator registration and management interface
 
 _Operator liveness is tracked via OperatorStatusRegistry heartbeats,
-     not a setOperatorOnline call. Use submitHeartbeat/isOnline/getOperatorStatus
-     on the registry for liveness signals._
+not a setOperatorOnline call. Use submitHeartbeat/isOnline/getOperatorStatus
+on the registry for liveness signals._
 
 #### Functions
 
@@ -35,11 +35,11 @@ Register as operator for a blueprint
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| blueprintId | uint64 | The blueprint to register for |
-| ecdsaPublicKey | bytes | The ECDSA public key for gossip network identity        This key is used for signing/verifying messages in the P2P gossip network        and may differ from the wallet key (msg.sender) |
-| rpcAddress | string | The operator's RPC endpoint URL |
+| Name           | Type   | Description                                                                                                                                                                |
+| -------------- | ------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| blueprintId    | uint64 | The blueprint to register for                                                                                                                                              |
+| ecdsaPublicKey | bytes  | The ECDSA public key for gossip network identity This key is used for signing/verifying messages in the P2P gossip network and may differ from the wallet key (msg.sender) |
+| rpcAddress     | string | The operator's RPC endpoint URL                                                                                                                                            |
 
 #### registerOperator
 
@@ -51,12 +51,12 @@ Register as operator providing blueprint-specific registration inputs
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| blueprintId | uint64 |  |
-| ecdsaPublicKey | bytes |  |
-| rpcAddress | string |  |
-| registrationInputs | bytes | Encoded payload validated by blueprint's schema |
+| Name               | Type   | Description                                     |
+| ------------------ | ------ | ----------------------------------------------- |
+| blueprintId        | uint64 |                                                 |
+| ecdsaPublicKey     | bytes  |                                                 |
+| rpcAddress         | string |                                                 |
+| registrationInputs | bytes  | Encoded payload validated by blueprint's schema |
 
 #### unregisterOperator
 
@@ -76,11 +76,11 @@ Update operator preferences for a blueprint
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| blueprintId | uint64 | The blueprint to update preferences for |
-| ecdsaPublicKey | bytes | New ECDSA public key (pass empty bytes to keep unchanged) |
-| rpcAddress | string | New RPC endpoint (pass empty string to keep unchanged) |
+| Name           | Type   | Description                                               |
+| -------------- | ------ | --------------------------------------------------------- |
+| blueprintId    | uint64 | The blueprint to update preferences for                   |
+| ecdsaPublicKey | bytes  | New ECDSA public key (pass empty bytes to keep unchanged) |
+| rpcAddress     | string | New RPC endpoint (pass empty string to keep unchanged)    |
 
 #### getOperatorRegistration
 
@@ -128,12 +128,12 @@ Emitted when an operator registers for a blueprint
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| blueprintId | uint64 | The blueprint ID |
-| operator | address | The operator address (wallet) |
-| ecdsaPublicKey | bytes | The ECDSA public key for gossip network identity |
-| rpcAddress | string | The operator's RPC endpoint |
+| Name           | Type    | Description                                      |
+| -------------- | ------- | ------------------------------------------------ |
+| blueprintId    | uint64  | The blueprint ID                                 |
+| operator       | address | The operator address (wallet)                    |
+| ecdsaPublicKey | bytes   | The ECDSA public key for gossip network identity |
+| rpcAddress     | string  | The operator's RPC endpoint                      |
 
 #### OperatorUnregistered
 
@@ -151,10 +151,9 @@ Emitted when an operator updates their preferences
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| blueprintId | uint64 | The blueprint ID |
-| operator | address | The operator address |
-| ecdsaPublicKey | bytes | The updated ECDSA public key (may be empty if unchanged) |
-| rpcAddress | string | The updated RPC endpoint (may be empty if unchanged) |
-
+| Name           | Type    | Description                                              |
+| -------------- | ------- | -------------------------------------------------------- |
+| blueprintId    | uint64  | The blueprint ID                                         |
+| operator       | address | The operator address                                     |
+| ecdsaPublicKey | bytes   | The updated ECDSA public key (may be empty if unchanged) |
+| rpcAddress     | string  | The updated RPC endpoint (may be empty if unchanged)     |

--- a/pages/developers/api/reference/ITanglePaymentsInternal.mdx
+++ b/pages/developers/api/reference/ITanglePaymentsInternal.mdx
@@ -5,7 +5,7 @@ description: Auto-generated Solidity API reference.
 
 # ITanglePaymentsInternal
 
-Source: https://github.com/tangle-network/tnt-core/blob/v2/src/v2/interfaces/ITanglePaymentsInternal.sol
+Source: https://github.com/tangle-network/tnt-core/blob/main/src/interfaces/ITanglePaymentsInternal.sol
 
 ### ITanglePaymentsInternal
 
@@ -22,4 +22,3 @@ function distributePayment(uint64 serviceId, uint64 blueprintId, address token, 
 ```solidity
 function depositToEscrow(uint64 serviceId, address token, uint256 amount) external
 ```
-

--- a/pages/developers/api/reference/ITangleRewards.mdx
+++ b/pages/developers/api/reference/ITangleRewards.mdx
@@ -5,7 +5,7 @@ description: Auto-generated Solidity API reference.
 
 # ITangleRewards
 
-Source: https://github.com/tangle-network/tnt-core/blob/v2/src/v2/interfaces/ITangleRewards.sol
+Source: https://github.com/tangle-network/tnt-core/blob/main/src/interfaces/ITangleRewards.sol
 
 ### ITangleRewards
 
@@ -78,4 +78,3 @@ _Convenience view; mappings are not enumerable._
 ```solidity
 event RewardsClaimed(address account, address token, uint256 amount)
 ```
-

--- a/pages/developers/api/reference/ITangleSecurityView.mdx
+++ b/pages/developers/api/reference/ITangleSecurityView.mdx
@@ -5,7 +5,7 @@ description: Auto-generated Solidity API reference.
 
 # ITangleSecurityView
 
-Source: https://github.com/tangle-network/tnt-core/blob/v2/src/v2/interfaces/ITangleSecurityView.sol
+Source: https://github.com/tangle-network/tnt-core/blob/main/src/interfaces/ITangleSecurityView.sol
 
 ### ITangleSecurityView
 
@@ -42,4 +42,3 @@ function getService(uint64 serviceId) external view returns (struct Types.Servic
 ```solidity
 function getServiceOperators(uint64 serviceId) external view returns (address[])
 ```
-

--- a/pages/developers/api/reference/ITangleServices.mdx
+++ b/pages/developers/api/reference/ITangleServices.mdx
@@ -5,7 +5,7 @@ description: Auto-generated Solidity API reference.
 
 # ITangleServices
 
-Source: https://github.com/tangle-network/tnt-core/blob/v2/src/v2/interfaces/ITangleServices.sol
+Source: https://github.com/tangle-network/tnt-core/blob/main/src/interfaces/ITangleServices.sol
 
 ### ITangleServices
 
@@ -77,13 +77,13 @@ _No approval flow needed - operators have pre-committed via signatures_
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| blueprintId | uint64 | The blueprint to use |
-| quotes | struct Types.SignedQuote[] | Array of signed quotes from operators |
-| config | bytes | Service configuration |
-| permittedCallers | address[] | Addresses allowed to call jobs |
-| ttl | uint64 | Service time-to-live (must match quotes) |
+| Name             | Type                       | Description                              |
+| ---------------- | -------------------------- | ---------------------------------------- |
+| blueprintId      | uint64                     | The blueprint to use                     |
+| quotes           | struct Types.SignedQuote[] | Array of signed quotes from operators    |
+| config           | bytes                      | Service configuration                    |
+| permittedCallers | address[]                  | Addresses allowed to call jobs           |
+| ttl              | uint64                     | Service time-to-live (must match quotes) |
 
 #### extendServiceFromQuotes
 
@@ -183,10 +183,10 @@ Force remove an operator from a service (blueprint manager only)
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| serviceId | uint64 | The service ID |
-| operator | address | The operator to remove |
+| Name      | Type    | Description            |
+| --------- | ------- | ---------------------- |
+| serviceId | uint64  | The service ID         |
+| operator  | address | The operator to remove |
 
 #### billSubscription
 
@@ -411,4 +411,3 @@ event OperatorLeftService(uint64 serviceId, address operator)
 ```solidity
 event SubscriptionBilled(uint64 serviceId, uint256 amount, uint64 period)
 ```
-

--- a/pages/developers/api/reference/ITangleSlashing.mdx
+++ b/pages/developers/api/reference/ITangleSlashing.mdx
@@ -5,7 +5,7 @@ description: Auto-generated Solidity API reference.
 
 # ITangleSlashing
 
-Source: https://github.com/tangle-network/tnt-core/blob/v2/src/v2/interfaces/ITangleSlashing.sol
+Source: https://github.com/tangle-network/tnt-core/blob/main/src/interfaces/ITangleSlashing.sol
 
 ### ITangleSlashing
 
@@ -23,17 +23,17 @@ Propose a slash against an operator
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| serviceId | uint64 | The service where violation occurred |
-| operator | address | The operator to slash |
-| amount | uint256 | Amount to slash |
-| evidence | bytes32 | Evidence hash |
+| Name      | Type    | Description                          |
+| --------- | ------- | ------------------------------------ |
+| serviceId | uint64  | The service where violation occurred |
+| operator  | address | The operator to slash                |
+| amount    | uint256 | Amount to slash                      |
+| evidence  | bytes32 | Evidence hash                        |
 
 ##### Return Values
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name    | Type   | Description                          |
+| ------- | ------ | ------------------------------------ |
 | slashId | uint64 | The ID of the created slash proposal |
 
 #### disputeSlash
@@ -105,4 +105,3 @@ event SlashProposed(uint64 serviceId, address operator, uint256 amount, bytes32 
 ```solidity
 event SlashExecuted(uint64 serviceId, address operator, uint256 amount)
 ```
-

--- a/pages/developers/api/reference/ITangleToken.mdx
+++ b/pages/developers/api/reference/ITangleToken.mdx
@@ -5,7 +5,7 @@ description: Auto-generated Solidity API reference.
 
 # ITangleToken
 
-Source: https://github.com/tangle-network/tnt-core/blob/v2/src/v2/interfaces/ITangleGovernance.sol
+Source: https://github.com/tangle-network/tnt-core/blob/main/src/interfaces/ITangleGovernance.sol
 
 ### ITangleToken
 
@@ -92,4 +92,3 @@ function approve(address spender, uint256 amount) external returns (bool)
 ```solidity
 function transferFrom(address from, address to, uint256 amount) external returns (bool)
 ```
-

--- a/pages/developers/api/reference/generated/BlueprintHookBase.mdx
+++ b/pages/developers/api/reference/generated/BlueprintHookBase.mdx
@@ -5,7 +5,7 @@ description: Auto-generated Solidity API reference.
 
 # BlueprintHookBase
 
-Source: https://github.com/tangle-network/tnt-core/blob/v2/src/v2/interfaces/IBlueprintHook.sol
+Source: https://github.com/tangle-network/tnt-core/blob/main/src/interfaces/IBlueprintHook.sol
 
 ### BlueprintHookBase
 
@@ -140,4 +140,3 @@ function getAggregationThreshold(uint64, uint8) external view virtual returns (u
 ```solidity
 function onAggregatedResult(uint64, uint64, uint256, bytes) external virtual
 ```
-

--- a/pages/developers/api/reference/generated/IBlueprintHook.mdx
+++ b/pages/developers/api/reference/generated/IBlueprintHook.mdx
@@ -5,18 +5,19 @@ description: Auto-generated Solidity API reference.
 
 # IBlueprintHook
 
-Source: https://github.com/tangle-network/tnt-core/blob/v2/src/v2/interfaces/IBlueprintHook.sol
+Source: https://github.com/tangle-network/tnt-core/blob/main/src/interfaces/IBlueprintHook.sol
 
 ### IBlueprintHook
 
 Simplified hook interface for basic blueprint customization
 
-_For full control, implement IBlueprintServiceManager directly.
-     This interface provides a simpler subset for common use cases.
+\_For full control, implement IBlueprintServiceManager directly.
+This interface provides a simpler subset for common use cases.
 
 Migration path:
+
 - Simple blueprints: Use IBlueprintHook / BlueprintHookBase
-- Full-featured blueprints: Use IBlueprintServiceManager / BlueprintServiceManagerBase_
+- Full-featured blueprints: Use IBlueprintServiceManager / BlueprintServiceManagerBase\_
 
 #### Functions
 
@@ -38,8 +39,8 @@ Called when an operator registers
 
 ##### Return Values
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name   | Type | Description                 |
+| ------ | ---- | --------------------------- |
 | accept | bool | True to accept registration |
 
 #### onOperatorUnregister
@@ -60,8 +61,8 @@ Called when a service is requested
 
 ##### Return Values
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name   | Type | Description            |
+| ------ | ---- | ---------------------- |
 | accept | bool | True to accept request |
 
 #### onServiceApprove
@@ -122,8 +123,8 @@ Called when a job is submitted
 
 ##### Return Values
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name   | Type | Description        |
+| ------ | ---- | ------------------ |
 | accept | bool | True to accept job |
 
 #### onJobResult
@@ -136,8 +137,8 @@ Called when an operator submits a result
 
 ##### Return Values
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name   | Type | Description           |
+| ------ | ---- | --------------------- |
 | accept | bool | True to accept result |
 
 #### onJobCompleted
@@ -158,8 +159,8 @@ Called before a slash is applied
 
 ##### Return Values
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name    | Type | Description           |
+| ------- | ---- | --------------------- |
 | approve | bool | True to approve slash |
 
 #### onSlashApplied
@@ -212,10 +213,10 @@ Get the aggregation threshold configuration for a job
 
 ##### Return Values
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| thresholdBps | uint16 | Threshold in basis points (6700 = 67%) |
-| thresholdType | uint8 | 0 = CountBased (% of operators), 1 = StakeWeighted (% of total stake) |
+| Name          | Type   | Description                                                           |
+| ------------- | ------ | --------------------------------------------------------------------- |
+| thresholdBps  | uint16 | Threshold in basis points (6700 = 67%)                                |
+| thresholdType | uint8  | 0 = CountBased (% of operators), 1 = StakeWeighted (% of total stake) |
 
 #### onAggregatedResult
 
@@ -224,4 +225,3 @@ function onAggregatedResult(uint64 serviceId, uint64 callId, uint256 signerBitma
 ```
 
 Called when an aggregated result is submitted
-

--- a/pages/developers/api/reference/generated/IBlueprintServiceManager.mdx
+++ b/pages/developers/api/reference/generated/IBlueprintServiceManager.mdx
@@ -5,17 +5,18 @@ description: Auto-generated Solidity API reference.
 
 # IBlueprintServiceManager
 
-Source: https://github.com/tangle-network/tnt-core/blob/v2/src/v2/interfaces/IBlueprintServiceManager.sol
+Source: https://github.com/tangle-network/tnt-core/blob/main/src/interfaces/IBlueprintServiceManager.sol
 
 ### IBlueprintServiceManager
 
 Full interface for blueprint-specific service managers
 
-_Blueprint developers implement this to customize all aspects of their blueprint.
-     This is the primary integration point for blueprint developers - implement the hooks
-     you need and leave others as default (via BlueprintServiceManagerBase).
+\_Blueprint developers implement this to customize all aspects of their blueprint.
+This is the primary integration point for blueprint developers - implement the hooks
+you need and leave others as default (via BlueprintServiceManagerBase).
 
 The lifecycle flow:
+
 1. Blueprint created → onBlueprintCreated
 2. Operators register → onRegister
 3. Service requested → onRequest
@@ -23,7 +24,7 @@ The lifecycle flow:
 5. Service activated → onServiceInitialized
 6. Jobs submitted → onJobCall
 7. Results submitted → onJobResult
-8. Service terminated → onServiceTermination_
+8. Service terminated → onServiceTermination\_
 
 #### Functions
 
@@ -39,11 +40,11 @@ _Store the blueprintId and tangleCore address for future reference_
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| blueprintId | uint64 | The new blueprint ID |
-| owner | address | The blueprint owner |
-| tangleCore | address | The address of the Tangle core contract |
+| Name        | Type    | Description                             |
+| ----------- | ------- | --------------------------------------- |
+| blueprintId | uint64  | The new blueprint ID                    |
+| owner       | address | The blueprint owner                     |
+| tangleCore  | address | The address of the Tangle core contract |
 
 #### onRegister
 
@@ -57,10 +58,10 @@ _Validate operator requirements here (stake, reputation, etc.)_
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| operator | address | The operator's address |
-| registrationInputs | bytes | Custom registration data (blueprint-specific encoding) |
+| Name               | Type    | Description                                            |
+| ------------------ | ------- | ------------------------------------------------------ |
+| operator           | address | The operator's address                                 |
+| registrationInputs | bytes   | Custom registration data (blueprint-specific encoding) |
 
 #### onUnregister
 
@@ -72,8 +73,8 @@ Called when an operator unregisters from this blueprint
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name     | Type    | Description            |
+| -------- | ------- | ---------------------- |
 | operator | address | The operator's address |
 
 #### onUpdatePreferences
@@ -86,10 +87,10 @@ Called when an operator updates their preferences (RPC address, etc.)
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| operator | address | The operator's address |
-| newPreferences | bytes | Updated preferences data |
+| Name           | Type    | Description              |
+| -------------- | ------- | ------------------------ |
+| operator       | address | The operator's address   |
+| newPreferences | bytes   | Updated preferences data |
 
 #### getHeartbeatInterval
 
@@ -103,16 +104,16 @@ _Operators must submit heartbeats within this interval_
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name      | Type   | Description    |
+| --------- | ------ | -------------- |
 | serviceId | uint64 | The service ID |
 
 ##### Return Values
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| useDefault | bool | True to use protocol default, false to use custom value |
-| interval | uint64 | Heartbeat interval in blocks (0 = disabled) |
+| Name       | Type   | Description                                             |
+| ---------- | ------ | ------------------------------------------------------- |
+| useDefault | bool   | True to use protocol default, false to use custom value |
+| interval   | uint64 | Heartbeat interval in blocks (0 = disabled)             |
 
 #### getHeartbeatThreshold
 
@@ -126,16 +127,16 @@ _Percentage of operators that must respond within interval_
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name      | Type   | Description    |
+| --------- | ------ | -------------- |
 | serviceId | uint64 | The service ID |
 
 ##### Return Values
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| useDefault | bool | True to use protocol default |
-| threshold | uint8 | Threshold percentage (0-100) |
+| Name       | Type  | Description                  |
+| ---------- | ----- | ---------------------------- |
+| useDefault | bool  | True to use protocol default |
+| threshold  | uint8 | Threshold percentage (0-100) |
 
 #### getSlashingWindow
 
@@ -149,16 +150,16 @@ _Time window for disputes before slash is finalized_
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name      | Type   | Description    |
+| --------- | ------ | -------------- |
 | serviceId | uint64 | The service ID |
 
 ##### Return Values
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| useDefault | bool | True to use protocol default |
-| window | uint64 | Slashing window in blocks |
+| Name       | Type   | Description                  |
+| ---------- | ------ | ---------------------------- |
+| useDefault | bool   | True to use protocol default |
+| window     | uint64 | Slashing window in blocks    |
 
 #### getExitConfig
 
@@ -172,18 +173,18 @@ _Defines minimum commitment and exit queue timing_
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name      | Type   | Description    |
+| --------- | ------ | -------------- |
 | serviceId | uint64 | The service ID |
 
 ##### Return Values
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| useDefault | bool | True to use protocol default |
-| minCommitmentDuration | uint64 | Minimum time operator must stay after joining (seconds) |
-| exitQueueDuration | uint64 | Time between scheduling exit and completing it (seconds) |
-| forceExitAllowed | bool | Whether service owner can force-exit operators |
+| Name                  | Type   | Description                                              |
+| --------------------- | ------ | -------------------------------------------------------- |
+| useDefault            | bool   | True to use protocol default                             |
+| minCommitmentDuration | uint64 | Minimum time operator must stay after joining (seconds)  |
+| exitQueueDuration     | uint64 | Time between scheduling exit and completing it (seconds) |
+| forceExitAllowed      | bool   | Whether service owner can force-exit operators           |
 
 #### onRequest
 
@@ -197,15 +198,15 @@ _Validate service configuration, operator selection, payment amount_
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| requestId | uint64 | The request ID |
-| requester | address | Who is requesting the service |
-| operators | address[] | Requested operators |
-| requestInputs | bytes | Service configuration (blueprint-specific encoding) |
-| ttl | uint64 | Time-to-live for the service |
-| paymentAsset | address | Payment token address (address(0) for native) |
-| paymentAmount | uint256 | Payment amount |
+| Name          | Type      | Description                                         |
+| ------------- | --------- | --------------------------------------------------- |
+| requestId     | uint64    | The request ID                                      |
+| requester     | address   | Who is requesting the service                       |
+| operators     | address[] | Requested operators                                 |
+| requestInputs | bytes     | Service configuration (blueprint-specific encoding) |
+| ttl           | uint64    | Time-to-live for the service                        |
+| paymentAsset  | address   | Payment token address (address(0) for native)       |
+| paymentAmount | uint256   | Payment amount                                      |
 
 #### onApprove
 
@@ -217,11 +218,11 @@ Called when an operator approves a service request
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| operator | address | The approving operator |
-| requestId | uint64 | The request ID |
-| stakingPercent | uint8 | Percentage of stake committed to this service (0-100) |
+| Name           | Type    | Description                                           |
+| -------------- | ------- | ----------------------------------------------------- |
+| operator       | address | The approving operator                                |
+| requestId      | uint64  | The request ID                                        |
+| stakingPercent | uint8   | Percentage of stake committed to this service (0-100) |
 
 #### onReject
 
@@ -233,10 +234,10 @@ Called when an operator rejects a service request
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| operator | address | The rejecting operator |
-| requestId | uint64 | The request ID |
+| Name      | Type    | Description            |
+| --------- | ------- | ---------------------- |
+| operator  | address | The rejecting operator |
+| requestId | uint64  | The request ID         |
 
 #### onServiceInitialized
 
@@ -248,14 +249,14 @@ Called when service becomes active (all operators approved)
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| blueprintId | uint64 | The blueprint ID |
-| requestId | uint64 | The original request ID |
-| serviceId | uint64 | The new service ID |
-| owner | address | The service owner |
+| Name             | Type      | Description                      |
+| ---------------- | --------- | -------------------------------- |
+| blueprintId      | uint64    | The blueprint ID                 |
+| requestId        | uint64    | The original request ID          |
+| serviceId        | uint64    | The new service ID               |
+| owner            | address   | The service owner                |
 | permittedCallers | address[] | Addresses allowed to submit jobs |
-| ttl | uint64 | Service time-to-live |
+| ttl              | uint64    | Service time-to-live             |
 
 #### onServiceTermination
 
@@ -267,10 +268,10 @@ Called when service is terminated
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| serviceId | uint64 | The service ID |
-| owner | address | The service owner |
+| Name      | Type    | Description       |
+| --------- | ------- | ----------------- |
+| serviceId | uint64  | The service ID    |
+| owner     | address | The service owner |
 
 #### canJoin
 
@@ -284,15 +285,15 @@ _Called before operator joins - return false to reject_
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| serviceId | uint64 | The service ID |
-| operator | address | The operator wanting to join |
+| Name      | Type    | Description                  |
+| --------- | ------- | ---------------------------- |
+| serviceId | uint64  | The service ID               |
+| operator  | address | The operator wanting to join |
 
 ##### Return Values
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name    | Type | Description               |
+| ------- | ---- | ------------------------- |
 | allowed | bool | True if operator can join |
 
 #### onOperatorJoined
@@ -305,11 +306,11 @@ Called after an operator successfully joins a service
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| serviceId | uint64 | The service ID |
-| operator | address | The operator that joined |
-| exposureBps | uint16 | The operator's stake exposure in basis points |
+| Name        | Type    | Description                                   |
+| ----------- | ------- | --------------------------------------------- |
+| serviceId   | uint64  | The service ID                                |
+| operator    | address | The operator that joined                      |
+| exposureBps | uint16  | The operator's stake exposure in basis points |
 
 #### canLeave
 
@@ -320,19 +321,19 @@ function canLeave(uint64 serviceId, address operator) external view returns (boo
 Check if an operator can leave a dynamic service
 
 _Called before operator leaves - return false to reject
-     Note: This is called AFTER the exit queue check. Use getExitConfig to customize timing._
+Note: This is called AFTER the exit queue check. Use getExitConfig to customize timing._
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| serviceId | uint64 | The service ID |
-| operator | address | The operator wanting to leave |
+| Name      | Type    | Description                   |
+| --------- | ------- | ----------------------------- |
+| serviceId | uint64  | The service ID                |
+| operator  | address | The operator wanting to leave |
 
 ##### Return Values
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name    | Type | Description                |
+| ------- | ---- | -------------------------- |
 | allowed | bool | True if operator can leave |
 
 #### onOperatorLeft
@@ -345,10 +346,10 @@ Called after an operator successfully leaves a service
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| serviceId | uint64 | The service ID |
-| operator | address | The operator that left |
+| Name      | Type    | Description            |
+| --------- | ------- | ---------------------- |
+| serviceId | uint64  | The service ID         |
+| operator  | address | The operator that left |
 
 #### onExitScheduled
 
@@ -362,11 +363,11 @@ _Allows manager to track pending exits, notify other parties, etc._
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| serviceId | uint64 | The service ID |
-| operator | address | The operator scheduling exit |
-| executeAfter | uint64 | Timestamp when exit can be executed |
+| Name         | Type    | Description                         |
+| ------------ | ------- | ----------------------------------- |
+| serviceId    | uint64  | The service ID                      |
+| operator     | address | The operator scheduling exit        |
+| executeAfter | uint64  | Timestamp when exit can be executed |
 
 #### onExitCanceled
 
@@ -378,10 +379,10 @@ Called when an operator cancels their scheduled exit
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| serviceId | uint64 | The service ID |
-| operator | address | The operator canceling exit |
+| Name      | Type    | Description                 |
+| --------- | ------- | --------------------------- |
+| serviceId | uint64  | The service ID              |
+| operator  | address | The operator canceling exit |
 
 #### onJobCall
 
@@ -395,12 +396,12 @@ _Validate job inputs, check caller permissions, etc._
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| serviceId | uint64 | The service ID |
-| job | uint8 | The job index in the blueprint |
-| jobCallId | uint64 | Unique ID for this job call |
-| inputs | bytes | Job inputs (blueprint-specific encoding) |
+| Name      | Type   | Description                              |
+| --------- | ------ | ---------------------------------------- |
+| serviceId | uint64 | The service ID                           |
+| job       | uint8  | The job index in the blueprint           |
+| jobCallId | uint64 | Unique ID for this job call              |
+| inputs    | bytes  | Job inputs (blueprint-specific encoding) |
 
 #### onJobResult
 
@@ -414,14 +415,14 @@ _Validate result format, check operator eligibility, aggregate results_
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| serviceId | uint64 | The service ID |
-| job | uint8 | The job index |
-| jobCallId | uint64 | The job call ID |
-| operator | address | The operator submitting |
-| inputs | bytes | Original job inputs |
-| outputs | bytes | Result outputs (blueprint-specific encoding) |
+| Name      | Type    | Description                                  |
+| --------- | ------- | -------------------------------------------- |
+| serviceId | uint64  | The service ID                               |
+| job       | uint8   | The job index                                |
+| jobCallId | uint64  | The job call ID                              |
+| operator  | address | The operator submitting                      |
+| inputs    | bytes   | Original job inputs                          |
+| outputs   | bytes   | Result outputs (blueprint-specific encoding) |
 
 #### onUnappliedSlash
 
@@ -435,11 +436,11 @@ _This is the dispute window - gather evidence, notify parties_
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| serviceId | uint64 | The service ID |
-| offender | bytes | The operator being slashed (encoded as bytes for flexibility) |
-| slashPercent | uint8 | Percentage of stake to slash |
+| Name         | Type   | Description                                                   |
+| ------------ | ------ | ------------------------------------------------------------- |
+| serviceId    | uint64 | The service ID                                                |
+| offender     | bytes  | The operator being slashed (encoded as bytes for flexibility) |
+| slashPercent | uint8  | Percentage of stake to slash                                  |
 
 #### onSlash
 
@@ -451,11 +452,11 @@ Called when a slash is finalized and applied
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| serviceId | uint64 | The service ID |
-| offender | bytes | The slashed operator |
-| slashPercent | uint8 | Percentage slashed |
+| Name         | Type   | Description          |
+| ------------ | ------ | -------------------- |
+| serviceId    | uint64 | The service ID       |
+| offender     | bytes  | The slashed operator |
+| slashPercent | uint8  | Percentage slashed   |
 
 #### querySlashingOrigin
 
@@ -469,14 +470,14 @@ _Override to allow custom slashing authorities (dispute contracts, etc.)_
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name      | Type   | Description    |
+| --------- | ------ | -------------- |
 | serviceId | uint64 | The service ID |
 
 ##### Return Values
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name           | Type    | Description                                     |
+| -------------- | ------- | ----------------------------------------------- |
 | slashingOrigin | address | Address that can slash (default: this contract) |
 
 #### queryDisputeOrigin
@@ -491,14 +492,14 @@ _Override to allow custom dispute resolution_
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name      | Type   | Description    |
+| --------- | ------ | -------------- |
 | serviceId | uint64 | The service ID |
 
 ##### Return Values
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name          | Type    | Description                                       |
+| ------------- | ------- | ------------------------------------------------- |
 | disputeOrigin | address | Address that can dispute (default: this contract) |
 
 #### queryDeveloperPaymentAddress
@@ -513,14 +514,14 @@ _Override to route payments to different addresses per service_
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name      | Type   | Description    |
+| --------- | ------ | -------------- |
 | serviceId | uint64 | The service ID |
 
 ##### Return Values
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name                    | Type            | Description                        |
+| ----------------------- | --------------- | ---------------------------------- |
 | developerPaymentAddress | address payable | Address to receive developer share |
 
 #### queryIsPaymentAssetAllowed
@@ -533,15 +534,15 @@ Check if a payment asset is allowed for this blueprint
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| serviceId | uint64 | The service ID |
-| asset | address | The payment asset address (address(0) for native) |
+| Name      | Type    | Description                                       |
+| --------- | ------- | ------------------------------------------------- |
+| serviceId | uint64  | The service ID                                    |
+| asset     | address | The payment asset address (address(0) for native) |
 
 ##### Return Values
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name      | Type | Description                               |
+| --------- | ---- | ----------------------------------------- |
 | isAllowed | bool | True if the asset can be used for payment |
 
 #### getRequiredResultCount
@@ -556,15 +557,15 @@ _Override for consensus requirements (e.g., 2/3 majority)_
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name      | Type   | Description    |
+| --------- | ------ | -------------- |
 | serviceId | uint64 | The service ID |
-| jobIndex | uint8 | The job index |
+| jobIndex  | uint8  | The job index  |
 
 ##### Return Values
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name     | Type   | Description                                           |
+| -------- | ------ | ----------------------------------------------------- |
 | required | uint32 | Number of results needed (0 = service operator count) |
 
 #### requiresAggregation
@@ -576,19 +577,19 @@ function requiresAggregation(uint64 serviceId, uint8 jobIndex) external view ret
 Check if a job requires BLS aggregated results
 
 _When true, operators must submit individual signatures that are aggregated
-     off-chain, then submitted via submitAggregatedResult instead of submitResult_
+off-chain, then submitted via submitAggregatedResult instead of submitResult_
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name      | Type   | Description    |
+| --------- | ------ | -------------- |
 | serviceId | uint64 | The service ID |
-| jobIndex | uint8 | The job index |
+| jobIndex  | uint8  | The job index  |
 
 ##### Return Values
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name     | Type | Description                                      |
+| -------- | ---- | ------------------------------------------------ |
 | required | bool | True if BLS aggregation is required for this job |
 
 #### getAggregationThreshold
@@ -603,17 +604,17 @@ _Only relevant if requiresAggregation returns true_
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name      | Type   | Description    |
+| --------- | ------ | -------------- |
 | serviceId | uint64 | The service ID |
-| jobIndex | uint8 | The job index |
+| jobIndex  | uint8  | The job index  |
 
 ##### Return Values
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| thresholdBps | uint16 | Threshold in basis points (6700 = 67%) |
-| thresholdType | uint8 | 0 = CountBased (% of operators), 1 = StakeWeighted (% of total stake) |
+| Name          | Type   | Description                                                           |
+| ------------- | ------ | --------------------------------------------------------------------- |
+| thresholdBps  | uint16 | Threshold in basis points (6700 = 67%)                                |
+| thresholdType | uint8  | 0 = CountBased (% of operators), 1 = StakeWeighted (% of total stake) |
 
 #### onAggregatedResult
 
@@ -627,15 +628,15 @@ _Validate the aggregated result, verify BLS signature, check threshold_
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| serviceId | uint64 | The service ID |
-| job | uint8 | The job index |
-| jobCallId | uint64 | The job call ID |
-| output | bytes | The aggregated output |
-| signerBitmap | uint256 | Bitmap of which operators signed |
-| aggregatedSignature | uint256[2] | The aggregated BLS signature (G1 point x, y) |
-| aggregatedPubkey | uint256[4] | The aggregated public key of signers (G2 point) |
+| Name                | Type       | Description                                     |
+| ------------------- | ---------- | ----------------------------------------------- |
+| serviceId           | uint64     | The service ID                                  |
+| job                 | uint8      | The job index                                   |
+| jobCallId           | uint64     | The job call ID                                 |
+| output              | bytes      | The aggregated output                           |
+| signerBitmap        | uint256    | Bitmap of which operators signed                |
+| aggregatedSignature | uint256[2] | The aggregated BLS signature (G1 point x, y)    |
+| aggregatedPubkey    | uint256[4] | The aggregated public key of signers (G2 point) |
 
 #### getMinOperatorStake
 
@@ -649,7 +650,7 @@ _Called during operator registration to validate stake requirements_
 
 ##### Return Values
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| useDefault | bool | True to use protocol default from staking module |
-| minStake | uint256 | Custom minimum stake amount (only used if useDefault=false) |
+| Name       | Type    | Description                                                 |
+| ---------- | ------- | ----------------------------------------------------------- |
+| useDefault | bool    | True to use protocol default from staking module            |
+| minStake   | uint256 | Custom minimum stake amount (only used if useDefault=false) |

--- a/pages/developers/api/reference/generated/IERC7540.mdx
+++ b/pages/developers/api/reference/generated/IERC7540.mdx
@@ -5,11 +5,10 @@ description: Auto-generated Solidity API reference.
 
 # IERC7540
 
-Source: https://github.com/tangle-network/tnt-core/blob/v2/src/v2/interfaces/IERC7540.sol
+Source: https://github.com/tangle-network/tnt-core/blob/main/src/interfaces/IERC7540.sol
 
 ### IERC7540
 
 Full ERC7540 interface combining deposit, redeem, and operator management
 
 _Extends ERC4626 with asynchronous request patterns_
-

--- a/pages/developers/api/reference/generated/IERC7540Deposit.mdx
+++ b/pages/developers/api/reference/generated/IERC7540Deposit.mdx
@@ -5,7 +5,7 @@ description: Auto-generated Solidity API reference.
 
 # IERC7540Deposit
 
-Source: https://github.com/tangle-network/tnt-core/blob/v2/src/v2/interfaces/IERC7540.sol
+Source: https://github.com/tangle-network/tnt-core/blob/main/src/interfaces/IERC7540.sol
 
 ### IERC7540Deposit
 
@@ -25,16 +25,16 @@ Request an asynchronous deposit
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| assets | uint256 | Amount of assets to deposit |
+| Name       | Type    | Description                       |
+| ---------- | ------- | --------------------------------- |
+| assets     | uint256 | Amount of assets to deposit       |
 | controller | address | Address that controls the request |
-| owner | address | Address that owns the assets |
+| owner      | address | Address that owns the assets      |
 
 ##### Return Values
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name      | Type    | Description                        |
+| --------- | ------- | ---------------------------------- |
 | requestId | uint256 | Unique identifier for this request |
 
 #### pendingDepositRequest
@@ -47,15 +47,15 @@ Get pending deposit request amount
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| requestId | uint256 | The request identifier |
+| Name       | Type    | Description            |
+| ---------- | ------- | ---------------------- |
+| requestId  | uint256 | The request identifier |
 | controller | address | The controller address |
 
 ##### Return Values
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name   | Type    | Description              |
+| ------ | ------- | ------------------------ |
 | assets | uint256 | Amount of assets pending |
 
 #### claimableDepositRequest
@@ -68,15 +68,15 @@ Get claimable deposit request amount
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| requestId | uint256 | The request identifier |
+| Name       | Type    | Description            |
+| ---------- | ------- | ---------------------- |
+| requestId  | uint256 | The request identifier |
 | controller | address | The controller address |
 
 ##### Return Values
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name   | Type    | Description                |
+| ------ | ------- | -------------------------- |
 | assets | uint256 | Amount of assets claimable |
 
 #### Events
@@ -88,4 +88,3 @@ event DepositRequest(address controller, address owner, uint256 requestId, addre
 ```
 
 Emitted when a deposit request is created
-

--- a/pages/developers/api/reference/generated/IERC7540Operator.mdx
+++ b/pages/developers/api/reference/generated/IERC7540Operator.mdx
@@ -5,7 +5,7 @@ description: Auto-generated Solidity API reference.
 
 # IERC7540Operator
 
-Source: https://github.com/tangle-network/tnt-core/blob/v2/src/v2/interfaces/IERC7540.sol
+Source: https://github.com/tangle-network/tnt-core/blob/main/src/interfaces/IERC7540.sol
 
 ### IERC7540Operator
 
@@ -23,15 +23,15 @@ Check if operator is approved for controller
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name       | Type    | Description            |
+| ---------- | ------- | ---------------------- |
 | controller | address | The controller address |
-| operator | address | The operator address |
+| operator   | address | The operator address   |
 
 ##### Return Values
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name   | Type | Description      |
+| ------ | ---- | ---------------- |
 | status | bool | True if approved |
 
 #### setOperator
@@ -44,15 +44,15 @@ Grant or revoke operator permissions
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| operator | address | The operator address |
-| approved | bool | True to approve, false to revoke |
+| Name     | Type    | Description                      |
+| -------- | ------- | -------------------------------- |
+| operator | address | The operator address             |
+| approved | bool    | True to approve, false to revoke |
 
 ##### Return Values
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name    | Type | Description        |
+| ------- | ---- | ------------------ |
 | success | bool | True if successful |
 
 #### Events
@@ -64,4 +64,3 @@ event OperatorSet(address controller, address operator, bool approved)
 ```
 
 Emitted when operator approval changes
-

--- a/pages/developers/api/reference/generated/IERC7540Redeem.mdx
+++ b/pages/developers/api/reference/generated/IERC7540Redeem.mdx
@@ -5,7 +5,7 @@ description: Auto-generated Solidity API reference.
 
 # IERC7540Redeem
 
-Source: https://github.com/tangle-network/tnt-core/blob/v2/src/v2/interfaces/IERC7540.sol
+Source: https://github.com/tangle-network/tnt-core/blob/main/src/interfaces/IERC7540.sol
 
 ### IERC7540Redeem
 
@@ -25,16 +25,16 @@ Request an asynchronous redemption
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| shares | uint256 | Amount of shares to redeem |
+| Name       | Type    | Description                       |
+| ---------- | ------- | --------------------------------- |
+| shares     | uint256 | Amount of shares to redeem        |
 | controller | address | Address that controls the request |
-| owner | address | Address that owns the shares |
+| owner      | address | Address that owns the shares      |
 
 ##### Return Values
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name      | Type    | Description                        |
+| --------- | ------- | ---------------------------------- |
 | requestId | uint256 | Unique identifier for this request |
 
 #### pendingRedeemRequest
@@ -47,15 +47,15 @@ Get pending redeem request amount
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| requestId | uint256 | The request identifier |
+| Name       | Type    | Description            |
+| ---------- | ------- | ---------------------- |
+| requestId  | uint256 | The request identifier |
 | controller | address | The controller address |
 
 ##### Return Values
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name   | Type    | Description              |
+| ------ | ------- | ------------------------ |
 | shares | uint256 | Amount of shares pending |
 
 #### claimableRedeemRequest
@@ -68,15 +68,15 @@ Get claimable redeem request amount
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| requestId | uint256 | The request identifier |
+| Name       | Type    | Description            |
+| ---------- | ------- | ---------------------- |
+| requestId  | uint256 | The request identifier |
 | controller | address | The controller address |
 
 ##### Return Values
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name   | Type    | Description                |
+| ------ | ------- | -------------------------- |
 | shares | uint256 | Amount of shares claimable |
 
 #### Events
@@ -88,4 +88,3 @@ event RedeemRequest(address controller, address owner, uint256 requestId, addres
 ```
 
 Emitted when a redeem request is created
-

--- a/pages/developers/api/reference/generated/IFacetSelectors.mdx
+++ b/pages/developers/api/reference/generated/IFacetSelectors.mdx
@@ -5,7 +5,7 @@ description: Auto-generated Solidity API reference.
 
 # IFacetSelectors
 
-Source: https://github.com/tangle-network/tnt-core/blob/v2/src/v2/interfaces/IFacetSelectors.sol
+Source: https://github.com/tangle-network/tnt-core/blob/main/src/interfaces/IFacetSelectors.sol
 
 ### IFacetSelectors
 
@@ -20,4 +20,3 @@ function selectors() external pure returns (bytes4[])
 ```
 
 Return the selectors this facet wants registered
-

--- a/pages/developers/api/reference/generated/IMBSMRegistry.mdx
+++ b/pages/developers/api/reference/generated/IMBSMRegistry.mdx
@@ -5,7 +5,7 @@ description: Auto-generated Solidity API reference.
 
 # IMBSMRegistry
 
-Source: https://github.com/tangle-network/tnt-core/blob/v2/src/v2/interfaces/IMBSMRegistry.sol
+Source: https://github.com/tangle-network/tnt-core/blob/main/src/interfaces/IMBSMRegistry.sol
 
 ### IMBSMRegistry
 
@@ -23,14 +23,14 @@ Get the MBSM address currently pinned for a blueprint
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name        | Type   | Description              |
+| ----------- | ------ | ------------------------ |
 | blueprintId | uint64 | The blueprint identifier |
 
 ##### Return Values
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name        | Type    | Description                               |
+| ----------- | ------- | ----------------------------------------- |
 | mbsmAddress | address | The pinned MBSM (or latest if not pinned) |
 
 #### getPinnedRevision
@@ -51,8 +51,8 @@ Get the latest registered MBSM address
 
 ##### Return Values
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name        | Type    | Description     |
+| ----------- | ------- | --------------- |
 | mbsmAddress | address | The latest MBSM |
 
 #### getMBSMByRevision
@@ -65,14 +65,14 @@ Get an MBSM by explicit revision
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name     | Type   | Description                       |
+| -------- | ------ | --------------------------------- |
 | revision | uint32 | The registry revision (1-indexed) |
 
 ##### Return Values
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name        | Type    | Description                             |
+| ----------- | ------- | --------------------------------------- |
 | mbsmAddress | address | The registered address for the revision |
 
 #### getLatestRevision
@@ -98,4 +98,3 @@ function unpinBlueprint(uint64 blueprintId) external
 ```
 
 Unpin a blueprint (reverting to latest)
-

--- a/pages/developers/api/reference/generated/IMasterBlueprintServiceManager.mdx
+++ b/pages/developers/api/reference/generated/IMasterBlueprintServiceManager.mdx
@@ -5,7 +5,7 @@ description: Auto-generated Solidity API reference.
 
 # IMasterBlueprintServiceManager
 
-Source: https://github.com/tangle-network/tnt-core/blob/v2/src/v2/interfaces/IMasterBlueprintServiceManager.sol
+Source: https://github.com/tangle-network/tnt-core/blob/main/src/interfaces/IMasterBlueprintServiceManager.sol
 
 ### IMasterBlueprintServiceManager
 
@@ -23,9 +23,8 @@ Called when a new blueprint is created
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| blueprintId | uint64 | The newly assigned blueprint ID |
-| owner | address | The blueprint owner |
-| encodedDefinition | bytes | ABI-encoded blueprint definition data |
-
+| Name              | Type    | Description                           |
+| ----------------- | ------- | ------------------------------------- |
+| blueprintId       | uint64  | The newly assigned blueprint ID       |
+| owner             | address | The blueprint owner                   |
+| encodedDefinition | bytes   | ABI-encoded blueprint definition data |

--- a/pages/developers/api/reference/generated/IMetricsRecorder.mdx
+++ b/pages/developers/api/reference/generated/IMetricsRecorder.mdx
@@ -5,7 +5,7 @@ description: Auto-generated Solidity API reference.
 
 # IMetricsRecorder
 
-Source: https://github.com/tangle-network/tnt-core/blob/v2/src/v2/interfaces/IMetricsRecorder.sol
+Source: https://github.com/tangle-network/tnt-core/blob/main/src/interfaces/IMetricsRecorder.sol
 
 ### IMetricsRecorder
 
@@ -25,12 +25,12 @@ Record a stake/delegation event
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| delegator | address | The delegator address |
-| operator | address | The operator receiving delegation |
-| asset | address | The asset being staked (address(0) for native) |
-| amount | uint256 | The amount staked |
+| Name      | Type    | Description                                    |
+| --------- | ------- | ---------------------------------------------- |
+| delegator | address | The delegator address                          |
+| operator  | address | The operator receiving delegation              |
+| asset     | address | The asset being staked (address(0) for native) |
+| amount    | uint256 | The amount staked                              |
 
 #### recordUnstake
 
@@ -42,12 +42,12 @@ Record an unstake event
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| delegator | address | The delegator address |
-| operator | address | The operator losing delegation |
-| asset | address | The asset being unstaked |
-| amount | uint256 | The amount unstaked |
+| Name      | Type    | Description                    |
+| --------- | ------- | ------------------------------ |
+| delegator | address | The delegator address          |
+| operator  | address | The operator losing delegation |
+| asset     | address | The asset being unstaked       |
+| amount    | uint256 | The amount unstaked            |
 
 #### recordOperatorRegistered
 
@@ -59,11 +59,11 @@ Record operator registration
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name     | Type    | Description          |
+| -------- | ------- | -------------------- |
 | operator | address | The operator address |
-| asset | address | The asset staked |
-| amount | uint256 | Initial stake amount |
+| asset    | address | The asset staked     |
+| amount   | uint256 | Initial stake amount |
 
 #### recordHeartbeat
 
@@ -75,11 +75,11 @@ Record operator heartbeat (liveness proof)
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| operator | address | The operator address |
-| serviceId | uint64 | The service ID |
-| timestamp | uint64 | Block timestamp of heartbeat |
+| Name      | Type    | Description                  |
+| --------- | ------- | ---------------------------- |
+| operator  | address | The operator address         |
+| serviceId | uint64  | The service ID               |
+| timestamp | uint64  | Block timestamp of heartbeat |
 
 #### recordJobCompletion
 
@@ -91,12 +91,12 @@ Record job completion by operator
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| operator | address | The operator address |
-| serviceId | uint64 | The service ID |
-| jobCallId | uint64 | The job call ID |
-| success | bool | Whether the job succeeded |
+| Name      | Type    | Description               |
+| --------- | ------- | ------------------------- |
+| operator  | address | The operator address      |
+| serviceId | uint64  | The service ID            |
+| jobCallId | uint64  | The job call ID           |
+| success   | bool    | Whether the job succeeded |
 
 #### recordSlash
 
@@ -108,11 +108,11 @@ Record operator slashing (negative metric)
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| operator | address | The operator address |
-| serviceId | uint64 | The service ID |
-| amount | uint256 | Amount slashed |
+| Name      | Type    | Description          |
+| --------- | ------- | -------------------- |
+| operator  | address | The operator address |
+| serviceId | uint64  | The service ID       |
+| amount    | uint256 | Amount slashed       |
 
 #### recordServiceCreated
 
@@ -124,11 +124,11 @@ Record service creation/activation
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| serviceId | uint64 | The service ID |
-| blueprintId | uint64 | The blueprint ID |
-| owner | address | The service owner |
+| Name          | Type    | Description         |
+| ------------- | ------- | ------------------- |
+| serviceId     | uint64  | The service ID      |
+| blueprintId   | uint64  | The blueprint ID    |
+| owner         | address | The service owner   |
 | operatorCount | uint256 | Number of operators |
 
 #### recordServiceTerminated
@@ -141,10 +141,10 @@ Record service termination
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| serviceId | uint64 | The service ID |
-| duration | uint256 | How long the service ran (seconds) |
+| Name      | Type    | Description                        |
+| --------- | ------- | ---------------------------------- |
+| serviceId | uint64  | The service ID                     |
+| duration  | uint256 | How long the service ran (seconds) |
 
 #### recordJobCall
 
@@ -156,11 +156,11 @@ Record a job call on a service
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| serviceId | uint64 | The service ID |
-| caller | address | Who initiated the job |
-| jobCallId | uint64 | The job call ID |
+| Name      | Type    | Description           |
+| --------- | ------- | --------------------- |
+| serviceId | uint64  | The service ID        |
+| caller    | address | Who initiated the job |
+| jobCallId | uint64  | The job call ID       |
 
 #### recordPayment
 
@@ -172,12 +172,12 @@ Record fee payment for a service
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| payer | address | Who paid the fee |
-| serviceId | uint64 | The service ID |
-| token | address | The payment token (address(0) for native) |
-| amount | uint256 | The amount paid |
+| Name      | Type    | Description                               |
+| --------- | ------- | ----------------------------------------- |
+| payer     | address | Who paid the fee                          |
+| serviceId | uint64  | The service ID                            |
+| token     | address | The payment token (address(0) for native) |
+| amount    | uint256 | The amount paid                           |
 
 #### recordBlueprintCreated
 
@@ -189,10 +189,10 @@ Record blueprint creation
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| blueprintId | uint64 | The blueprint ID |
-| developer | address | The developer address |
+| Name        | Type    | Description           |
+| ----------- | ------- | --------------------- |
+| blueprintId | uint64  | The blueprint ID      |
+| developer   | address | The developer address |
 
 #### recordBlueprintRegistration
 
@@ -204,8 +204,7 @@ Record operator registration to a blueprint
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| blueprintId | uint64 | The blueprint ID |
-| operator | address | The operator address |
-
+| Name        | Type    | Description          |
+| ----------- | ------- | -------------------- |
+| blueprintId | uint64  | The blueprint ID     |
+| operator    | address | The operator address |

--- a/pages/developers/api/reference/generated/IMultiAssetDelegation.mdx
+++ b/pages/developers/api/reference/generated/IMultiAssetDelegation.mdx
@@ -5,7 +5,7 @@ description: Auto-generated Solidity API reference.
 
 # IMultiAssetDelegation
 
-Source: https://github.com/tangle-network/tnt-core/blob/v2/src/v2/interfaces/IMultiAssetDelegation.sol
+Source: https://github.com/tangle-network/tnt-core/blob/main/src/interfaces/IMultiAssetDelegation.sol
 
 ### IMultiAssetDelegation
 
@@ -154,22 +154,22 @@ function executeDelegatorUnstakeAndWithdraw(address operator, address token, uin
 Execute a specific matured unstake request and withdraw the resulting assets to `receiver`.
 
 _Convenience helper for integrations (e.g. ERC7540 liquid delegation vaults) to avoid a separate
-     scheduleWithdraw/executeWithdraw flow after bond-less delay has already elapsed._
+scheduleWithdraw/executeWithdraw flow after bond-less delay has already elapsed._
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| operator | address | Operator to unstake from |
-| token | address | Token address (address(0) for native) |
-| shares | uint256 | Shares to unstake (as stored in the underlying bond-less request) |
-| requestedRound | uint64 | Round in which the unstake was scheduled |
-| receiver | address | Recipient of the withdrawn assets |
+| Name           | Type    | Description                                                       |
+| -------------- | ------- | ----------------------------------------------------------------- |
+| operator       | address | Operator to unstake from                                          |
+| token          | address | Token address (address(0) for native)                             |
+| shares         | uint256 | Shares to unstake (as stored in the underlying bond-less request) |
+| requestedRound | uint64  | Round in which the unstake was scheduled                          |
+| receiver       | address | Recipient of the withdrawn assets                                 |
 
 ##### Return Values
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name   | Type    | Description                                                           |
+| ------ | ------- | --------------------------------------------------------------------- |
 | amount | uint256 | Actual amount returned (after exchange-rate + lazy-slash adjustments) |
 
 #### addBlueprintToDelegation
@@ -737,4 +737,3 @@ event AdapterRemoved(address token)
 ```solidity
 event RequireAdaptersUpdated(bool required)
 ```
-

--- a/pages/developers/api/reference/generated/IPaymentAdapterRegistry.mdx
+++ b/pages/developers/api/reference/generated/IPaymentAdapterRegistry.mdx
@@ -5,7 +5,7 @@ description: Auto-generated Solidity API reference.
 
 # IPaymentAdapterRegistry
 
-Source: https://github.com/tangle-network/tnt-core/blob/v2/src/v2/interfaces/IStreamingPaymentAdapter.sol
+Source: https://github.com/tangle-network/tnt-core/blob/main/src/interfaces/IStreamingPaymentAdapter.sol
 
 ### IPaymentAdapterRegistry
 
@@ -23,9 +23,9 @@ Register a new payment adapter
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| name | string | Adapter name |
+| Name    | Type    | Description     |
+| ------- | ------- | --------------- |
+| name    | string  | Adapter name    |
 | adapter | address | Adapter address |
 
 #### removeAdapter
@@ -38,8 +38,8 @@ Remove a payment adapter
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name | Type   | Description            |
+| ---- | ------ | ---------------------- |
 | name | string | Adapter name to remove |
 
 #### getAdapter
@@ -52,14 +52,14 @@ Get an adapter by name
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name | Type   | Description  |
+| ---- | ------ | ------------ |
 | name | string | Adapter name |
 
 ##### Return Values
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name    | Type    | Description     |
+| ------- | ------- | --------------- |
 | adapter | address | Adapter address |
 
 #### getDefaultAdapter
@@ -72,8 +72,8 @@ Get the default adapter
 
 ##### Return Values
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name    | Type    | Description             |
+| ------- | ------- | ----------------------- |
 | adapter | address | Default adapter address |
 
 #### setDefaultAdapter
@@ -86,8 +86,8 @@ Set the default adapter
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name | Type   | Description                       |
+| ---- | ------ | --------------------------------- |
 | name | string | Name of adapter to set as default |
 
 #### isRegistered
@@ -100,14 +100,14 @@ Check if an adapter is registered
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name | Type   | Description  |
+| ---- | ------ | ------------ |
 | name | string | Adapter name |
 
 ##### Return Values
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name       | Type | Description            |
+| ---------- | ---- | ---------------------- |
 | registered | bool | True if adapter exists |
 
 #### getRegisteredAdapters
@@ -120,7 +120,6 @@ Get all registered adapter names
 
 ##### Return Values
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name  | Type     | Description            |
+| ----- | -------- | ---------------------- |
 | names | string[] | Array of adapter names |
-

--- a/pages/developers/api/reference/generated/IRestaking.mdx
+++ b/pages/developers/api/reference/generated/IRestaking.mdx
@@ -5,19 +5,20 @@ description: Auto-generated Solidity API reference.
 
 # IStaking
 
-Source: https://github.com/tangle-network/tnt-core/blob/v2/src/v2/interfaces/IStaking.sol
+Source: https://github.com/tangle-network/tnt-core/blob/main/src/interfaces/IStaking.sol
 
 ### IStaking
 
 Abstract interface for staking/shared security protocols
 
-_Implement this to integrate with native staking, Symbiotic, or other staking systems.
+\_Implement this to integrate with native staking, Symbiotic, or other staking systems.
 
 Design principles:
+
 - Minimal interface - only what Tangle core needs
 - Read-heavy - most operations are queries
 - Write-light - only slash() modifies state
-- No assumptions about underlying implementation_
+- No assumptions about underlying implementation\_
 
 #### Functions
 
@@ -31,15 +32,15 @@ Check if an address is a registered operator
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name     | Type    | Description          |
+| -------- | ------- | -------------------- |
 | operator | address | The address to check |
 
 ##### Return Values
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| [0] | bool | True if registered as operator |
+| Name | Type | Description                    |
+| ---- | ---- | ------------------------------ |
+| [0]  | bool | True if registered as operator |
 
 #### isOperatorActive
 
@@ -51,15 +52,15 @@ Check if an operator is currently active (not leaving, not slashed out)
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name     | Type    | Description          |
+| -------- | ------- | -------------------- |
 | operator | address | The address to check |
 
 ##### Return Values
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| [0] | bool | True if active |
+| Name | Type | Description    |
+| ---- | ---- | -------------- |
+| [0]  | bool | True if active |
 
 #### getOperatorStake
 
@@ -71,15 +72,15 @@ Get an operator's total stake (self-stake + delegations)
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name     | Type    | Description          |
+| -------- | ------- | -------------------- |
 | operator | address | The operator address |
 
 ##### Return Values
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| [0] | uint256 | Total stake amount in native units |
+| Name | Type    | Description                        |
+| ---- | ------- | ---------------------------------- |
+| [0]  | uint256 | Total stake amount in native units |
 
 #### getOperatorSelfStake
 
@@ -91,15 +92,15 @@ Get an operator's self-stake only
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name     | Type    | Description          |
+| -------- | ------- | -------------------- |
 | operator | address | The operator address |
 
 ##### Return Values
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| [0] | uint256 | Self-stake amount |
+| Name | Type    | Description       |
+| ---- | ------- | ----------------- |
+| [0]  | uint256 | Self-stake amount |
 
 #### getOperatorDelegatedStake
 
@@ -111,15 +112,15 @@ Get total amount delegated to an operator
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name     | Type    | Description          |
+| -------- | ------- | -------------------- |
 | operator | address | The operator address |
 
 ##### Return Values
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| [0] | uint256 | Total delegated amount |
+| Name | Type    | Description            |
+| ---- | ------- | ---------------------- |
+| [0]  | uint256 | Total delegated amount |
 
 #### getDelegation
 
@@ -131,16 +132,16 @@ Get a delegator's delegation to a specific operator
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name      | Type    | Description           |
+| --------- | ------- | --------------------- |
 | delegator | address | The delegator address |
-| operator | address | The operator address |
+| operator  | address | The operator address  |
 
 ##### Return Values
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| [0] | uint256 | Delegation amount |
+| Name | Type    | Description       |
+| ---- | ------- | ----------------- |
+| [0]  | uint256 | Delegation amount |
 
 #### getTotalDelegation
 
@@ -152,15 +153,15 @@ Get a delegator's total delegations across all operators
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name      | Type    | Description           |
+| --------- | ------- | --------------------- |
 | delegator | address | The delegator address |
 
 ##### Return Values
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| [0] | uint256 | Total delegated amount |
+| Name | Type    | Description            |
+| ---- | ------- | ---------------------- |
+| [0]  | uint256 | Total delegated amount |
 
 #### minOperatorStake
 
@@ -172,9 +173,9 @@ Get minimum stake required to be an operator
 
 ##### Return Values
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| [0] | uint256 | Minimum stake amount |
+| Name | Type    | Description          |
+| ---- | ------- | -------------------- |
+| [0]  | uint256 | Minimum stake amount |
 
 #### meetsStakeRequirement
 
@@ -186,16 +187,16 @@ Check if operator meets a specific stake requirement
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| operator | address | The operator address |
+| Name     | Type    | Description               |
+| -------- | ------- | ------------------------- |
+| operator | address | The operator address      |
 | required | uint256 | The required stake amount |
 
 ##### Return Values
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| [0] | bool | True if operator has sufficient stake |
+| Name | Type | Description                           |
+| ---- | ---- | ------------------------------------- |
+| [0]  | bool | True if operator has sufficient stake |
 
 #### slashForBlueprint
 
@@ -209,18 +210,18 @@ _Only affects delegators exposed to this blueprint (All mode + Fixed mode who se
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| operator | address | The operator to slash |
-| blueprintId | uint64 | The blueprint where violation occurred |
-| serviceId | uint64 | The service where violation occurred |
-| amount | uint256 | Amount to slash |
-| evidence | bytes32 | Evidence hash (IPFS or other reference) |
+| Name        | Type    | Description                             |
+| ----------- | ------- | --------------------------------------- |
+| operator    | address | The operator to slash                   |
+| blueprintId | uint64  | The blueprint where violation occurred  |
+| serviceId   | uint64  | The service where violation occurred    |
+| amount      | uint256 | Amount to slash                         |
+| evidence    | bytes32 | Evidence hash (IPFS or other reference) |
 
 ##### Return Values
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name          | Type    | Description                                                   |
+| ------------- | ------- | ------------------------------------------------------------- |
 | actualSlashed | uint256 | The actual amount slashed (may be less if insufficient stake) |
 
 #### slashForService
@@ -235,19 +236,19 @@ _Only slashes assets the operator committed to this service, proportionally_
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| operator | address | The operator to slash |
-| blueprintId | uint64 | The blueprint where violation occurred |
-| serviceId | uint64 | The service where violation occurred |
+| Name        | Type                                   | Description                                                |
+| ----------- | -------------------------------------- | ---------------------------------------------------------- |
+| operator    | address                                | The operator to slash                                      |
+| blueprintId | uint64                                 | The blueprint where violation occurred                     |
+| serviceId   | uint64                                 | The service where violation occurred                       |
 | commitments | struct Types.AssetSecurityCommitment[] | The operator's asset security commitments for this service |
-| amount | uint256 | Amount to slash |
-| evidence | bytes32 | Evidence hash (IPFS or other reference) |
+| amount      | uint256                                | Amount to slash                                            |
+| evidence    | bytes32                                | Evidence hash (IPFS or other reference)                    |
 
 ##### Return Values
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name          | Type    | Description                                                             |
+| ------------- | ------- | ----------------------------------------------------------------------- |
 | actualSlashed | uint256 | The actual amount slashed (may be less if insufficient committed stake) |
 
 #### slash
@@ -262,17 +263,17 @@ _Only callable by authorized slashers (e.g., Tangle core contract)_
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| operator | address | The operator to slash |
-| serviceId | uint64 | The service where violation occurred |
-| amount | uint256 | Amount to slash |
-| evidence | bytes32 | Evidence hash (IPFS or other reference) |
+| Name      | Type    | Description                             |
+| --------- | ------- | --------------------------------------- |
+| operator  | address | The operator to slash                   |
+| serviceId | uint64  | The service where violation occurred    |
+| amount    | uint256 | Amount to slash                         |
+| evidence  | bytes32 | Evidence hash (IPFS or other reference) |
 
 ##### Return Values
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name          | Type    | Description                                                   |
+| ------------- | ------- | ------------------------------------------------------------- |
 | actualSlashed | uint256 | The actual amount slashed (may be less if insufficient stake) |
 
 #### isSlasher
@@ -285,15 +286,15 @@ Check if an address is authorized to call slash()
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name    | Type    | Description          |
+| ------- | ------- | -------------------- |
 | account | address | The address to check |
 
 ##### Return Values
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| [0] | bool | True if authorized |
+| Name | Type | Description        |
+| ---- | ---- | ------------------ |
+| [0]  | bool | True if authorized |
 
 #### Events
 

--- a/pages/developers/api/reference/generated/IRestakingAdmin.mdx
+++ b/pages/developers/api/reference/generated/IRestakingAdmin.mdx
@@ -5,7 +5,7 @@ description: Auto-generated Solidity API reference.
 
 # IStakingAdmin
 
-Source: https://github.com/tangle-network/tnt-core/blob/v2/src/v2/interfaces/IStaking.sol
+Source: https://github.com/tangle-network/tnt-core/blob/main/src/interfaces/IStaking.sol
 
 ### IStakingAdmin
 
@@ -25,8 +25,8 @@ Add an authorized slasher
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name    | Type    | Description          |
+| ------- | ------- | -------------------- |
 | slasher | address | Address to authorize |
 
 #### removeSlasher
@@ -39,8 +39,8 @@ Remove an authorized slasher
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name    | Type    | Description       |
+| ------- | ------- | ----------------- |
 | slasher | address | Address to remove |
 
 #### setMinOperatorStake
@@ -53,7 +53,6 @@ Update minimum operator stake
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name   | Type    | Description |
+| ------ | ------- | ----------- |
 | amount | uint256 | New minimum |
-

--- a/pages/developers/api/reference/generated/IRewardsManager.mdx
+++ b/pages/developers/api/reference/generated/IRewardsManager.mdx
@@ -5,7 +5,7 @@ description: Auto-generated Solidity API reference.
 
 # IRewardsManager
 
-Source: https://github.com/tangle-network/tnt-core/blob/v2/src/v2/interfaces/IRewardsManager.sol
+Source: https://github.com/tangle-network/tnt-core/blob/main/src/interfaces/IRewardsManager.sol
 
 ### IRewardsManager
 
@@ -23,13 +23,13 @@ Records a delegation for reward tracking
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| delegator | address | The account making the delegation |
-| operator | address | The operator being delegated to |
-| asset | address | The asset being delegated (address(0) for native) |
-| amount | uint256 | The amount being delegated |
-| lockMultiplierBps | uint16 | Lock multiplier in basis points (10000 = 1x, 0 = no lock) |
+| Name              | Type    | Description                                               |
+| ----------------- | ------- | --------------------------------------------------------- |
+| delegator         | address | The account making the delegation                         |
+| operator          | address | The operator being delegated to                           |
+| asset             | address | The asset being delegated (address(0) for native)         |
+| amount            | uint256 | The amount being delegated                                |
+| lockMultiplierBps | uint16  | Lock multiplier in basis points (10000 = 1x, 0 = no lock) |
 
 #### recordUndelegate
 
@@ -41,12 +41,12 @@ Records an undelegation
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name      | Type    | Description                         |
+| --------- | ------- | ----------------------------------- |
 | delegator | address | The account making the undelegation |
-| operator | address | The operator being undelegated from |
-| asset | address | The asset being undelegated |
-| amount | uint256 | The amount being undelegated |
+| operator  | address | The operator being undelegated from |
+| asset     | address | The asset being undelegated         |
+| amount    | uint256 | The amount being undelegated        |
 
 #### recordServiceReward
 
@@ -58,11 +58,11 @@ Records a service reward for an operator
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name     | Type    | Description                       |
+| -------- | ------- | --------------------------------- |
 | operator | address | The operator receiving the reward |
-| asset | address | The reward asset |
-| amount | uint256 | The reward amount |
+| asset    | address | The reward asset                  |
+| amount   | uint256 | The reward amount                 |
 
 #### getAssetDepositCapRemaining
 
@@ -74,13 +74,12 @@ Get remaining deposit capacity for an asset vault
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name  | Type    | Description        |
+| ----- | ------- | ------------------ |
 | asset | address | The asset to query |
 
 ##### Return Values
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name      | Type    | Description                    |
+| --------- | ------- | ------------------------------ |
 | remaining | uint256 | The remaining deposit capacity |
-

--- a/pages/developers/api/reference/generated/ISablierAdapter.mdx
+++ b/pages/developers/api/reference/generated/ISablierAdapter.mdx
@@ -5,7 +5,7 @@ description: Auto-generated Solidity API reference.
 
 # ISablierAdapter
 
-Source: https://github.com/tangle-network/tnt-core/blob/v2/src/v2/interfaces/IStreamingPaymentAdapter.sol
+Source: https://github.com/tangle-network/tnt-core/blob/main/src/interfaces/IStreamingPaymentAdapter.sol
 
 ### ISablierAdapter
 
@@ -49,18 +49,18 @@ Create a linear stream (constant rate)
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| serviceId | uint64 | The Tangle service ID |
-| token | address | The ERC-20 token |
-| totalAmount | uint128 | Total amount to stream |
-| durationSeconds | uint40 | Total duration |
-| cliffSeconds | uint40 | Cliff period |
+| Name            | Type    | Description            |
+| --------------- | ------- | ---------------------- |
+| serviceId       | uint64  | The Tangle service ID  |
+| token           | address | The ERC-20 token       |
+| totalAmount     | uint128 | Total amount to stream |
+| durationSeconds | uint40  | Total duration         |
+| cliffSeconds    | uint40  | Cliff period           |
 
 ##### Return Values
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name     | Type    | Description           |
+| -------- | ------- | --------------------- |
 | streamId | uint256 | The created stream ID |
 
 #### createDynamicStream
@@ -73,17 +73,17 @@ Create a dynamic stream with custom curve
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| serviceId | uint64 | The Tangle service ID |
-| token | address | The ERC-20 token |
-| totalAmount | uint128 | Total amount to stream |
-| segments | struct ISablierAdapter.Segment[] | Array of segments defining the curve |
+| Name        | Type                             | Description                          |
+| ----------- | -------------------------------- | ------------------------------------ |
+| serviceId   | uint64                           | The Tangle service ID                |
+| token       | address                          | The ERC-20 token                     |
+| totalAmount | uint128                          | Total amount to stream               |
+| segments    | struct ISablierAdapter.Segment[] | Array of segments defining the curve |
 
 ##### Return Values
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name     | Type    | Description           |
+| -------- | ------- | --------------------- |
 | streamId | uint256 | The created stream ID |
 
 #### isCancelable
@@ -96,14 +96,14 @@ Check if a stream is cancelable
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name     | Type    | Description   |
+| -------- | ------- | ------------- |
 | streamId | uint256 | The stream ID |
 
 ##### Return Values
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name       | Type | Description                     |
+| ---------- | ---- | ------------------------------- |
 | cancelable | bool | True if stream can be cancelled |
 
 #### wasCancelled
@@ -116,14 +116,14 @@ Check if a stream was cancelled
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name     | Type    | Description   |
+| -------- | ------- | ------------- |
 | streamId | uint256 | The stream ID |
 
 ##### Return Values
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name      | Type | Description                  |
+| --------- | ---- | ---------------------------- |
 | cancelled | bool | True if stream was cancelled |
 
 #### getStreamNFT
@@ -136,14 +136,14 @@ Get the NFT token ID for a stream (Sablier streams are NFTs)
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name     | Type    | Description   |
+| -------- | ------- | ------------- |
 | streamId | uint256 | The stream ID |
 
 ##### Return Values
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name    | Type    | Description          |
+| ------- | ------- | -------------------- |
 | tokenId | uint256 | The ERC-721 token ID |
 
 #### transferStream
@@ -156,8 +156,7 @@ Transfer stream ownership (NFT transfer)
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| streamId | uint256 | The stream ID |
+| Name         | Type    | Description           |
+| ------------ | ------- | --------------------- |
+| streamId     | uint256 | The stream ID         |
 | newRecipient | address | New recipient address |
-

--- a/pages/developers/api/reference/generated/IServiceFeeDistributor.mdx
+++ b/pages/developers/api/reference/generated/IServiceFeeDistributor.mdx
@@ -5,7 +5,7 @@ description: Auto-generated Solidity API reference.
 
 # IServiceFeeDistributor
 
-Source: https://github.com/tangle-network/tnt-core/blob/v2/src/v2/interfaces/IServiceFeeDistributor.sol
+Source: https://github.com/tangle-network/tnt-core/blob/main/src/interfaces/IServiceFeeDistributor.sol
 
 ### IServiceFeeDistributor
 
@@ -151,8 +151,7 @@ _Cancels streaming payments and refunds remaining amounts to the service owner_
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| serviceId | uint64 | The terminated service ID |
+| Name            | Type    | Description                                                   |
+| --------------- | ------- | ------------------------------------------------------------- |
+| serviceId       | uint64  | The terminated service ID                                     |
 | refundRecipient | address | Where to send the remaining payment (typically service owner) |
-

--- a/pages/developers/api/reference/generated/IStreamingPaymentAdapter.mdx
+++ b/pages/developers/api/reference/generated/IStreamingPaymentAdapter.mdx
@@ -5,14 +5,14 @@ description: Auto-generated Solidity API reference.
 
 # IStreamingPaymentAdapter
 
-Source: https://github.com/tangle-network/tnt-core/blob/v2/src/v2/interfaces/IStreamingPaymentAdapter.sol
+Source: https://github.com/tangle-network/tnt-core/blob/main/src/interfaces/IStreamingPaymentAdapter.sol
 
 ### IStreamingPaymentAdapter
 
 Common interface for streaming payment adapters (Superfluid, Sablier, etc.)
 
 _Adapters implement this interface to provide streaming payment capabilities
-     to Tangle services without tight coupling to specific protocols._
+to Tangle services without tight coupling to specific protocols._
 
 #### Functions
 
@@ -26,18 +26,18 @@ Create a streaming payment for a service
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| serviceId | uint64 | The Tangle service ID |
-| token | address | The ERC-20 token to stream (address(0) for native) |
-| totalAmount | uint256 | Total amount to stream |
-| durationSeconds | uint64 | Stream duration in seconds |
-| cliffSeconds | uint64 | Optional cliff period (0 for no cliff) |
+| Name            | Type    | Description                                        |
+| --------------- | ------- | -------------------------------------------------- |
+| serviceId       | uint64  | The Tangle service ID                              |
+| token           | address | The ERC-20 token to stream (address(0) for native) |
+| totalAmount     | uint256 | Total amount to stream                             |
+| durationSeconds | uint64  | Stream duration in seconds                         |
+| cliffSeconds    | uint64  | Optional cliff period (0 for no cliff)             |
 
 ##### Return Values
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name     | Type    | Description           |
+| -------- | ------- | --------------------- |
 | streamId | uint256 | The created stream ID |
 
 #### updateStreamRate
@@ -50,10 +50,10 @@ Update the rate of an existing stream
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| streamId | uint256 | The stream ID to update |
-| newRatePerSecond | uint256 | New streaming rate |
+| Name             | Type    | Description             |
+| ---------------- | ------- | ----------------------- |
+| streamId         | uint256 | The stream ID to update |
+| newRatePerSecond | uint256 | New streaming rate      |
 
 #### cancelStream
 
@@ -65,14 +65,14 @@ Cancel a stream and refund remaining balance
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name     | Type    | Description             |
+| -------- | ------- | ----------------------- |
 | streamId | uint256 | The stream ID to cancel |
 
 ##### Return Values
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name           | Type    | Description                  |
+| -------------- | ------- | ---------------------------- |
 | refundedAmount | uint256 | Amount refunded to the payer |
 
 #### withdrawFromStream
@@ -85,14 +85,14 @@ Withdraw available funds from a stream
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name     | Type    | Description   |
+| -------- | ------- | ------------- |
 | streamId | uint256 | The stream ID |
 
 ##### Return Values
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name            | Type    | Description      |
+| --------------- | ------- | ---------------- |
 | withdrawnAmount | uint256 | Amount withdrawn |
 
 #### settleAndDistribute
@@ -107,8 +107,8 @@ _This triggers distribution through Tangle's payment system_
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name     | Type    | Description             |
+| -------- | ------- | ----------------------- |
 | streamId | uint256 | The stream ID to settle |
 
 #### getWithdrawableAmount
@@ -121,14 +121,14 @@ Get the current withdrawable amount for a stream
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name     | Type    | Description   |
+| -------- | ------- | ------------- |
 | streamId | uint256 | The stream ID |
 
 ##### Return Values
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name   | Type    | Description                  |
+| ------ | ------- | ---------------------------- |
 | amount | uint256 | Amount available to withdraw |
 
 #### getStreamRate
@@ -141,14 +141,14 @@ Get the current streaming rate
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name     | Type    | Description   |
+| -------- | ------- | ------------- |
 | streamId | uint256 | The stream ID |
 
 ##### Return Values
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name          | Type    | Description                      |
+| ------------- | ------- | -------------------------------- |
 | ratePerSecond | uint256 | Tokens per second being streamed |
 
 #### getStreamInfo
@@ -161,23 +161,23 @@ Get full stream information
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name     | Type    | Description   |
+| -------- | ------- | ------------- |
 | streamId | uint256 | The stream ID |
 
 ##### Return Values
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| serviceId | uint64 | Associated Tangle service |
-| payer | address | Address funding the stream |
-| token | address | Token being streamed |
-| totalAmount | uint256 | Total stream amount |
-| withdrawnAmount | uint256 | Amount already withdrawn |
-| startTime | uint256 | Stream start timestamp |
-| endTime | uint256 | Stream end timestamp |
-| cliffTime | uint256 | Cliff timestamp (0 if no cliff) |
-| active | bool | Whether stream is active |
+| Name            | Type    | Description                     |
+| --------------- | ------- | ------------------------------- |
+| serviceId       | uint64  | Associated Tangle service       |
+| payer           | address | Address funding the stream      |
+| token           | address | Token being streamed            |
+| totalAmount     | uint256 | Total stream amount             |
+| withdrawnAmount | uint256 | Amount already withdrawn        |
+| startTime       | uint256 | Stream start timestamp          |
+| endTime         | uint256 | Stream end timestamp            |
+| cliffTime       | uint256 | Cliff timestamp (0 if no cliff) |
+| active          | bool    | Whether stream is active        |
 
 #### getStreamServiceId
 
@@ -189,14 +189,14 @@ Get the service ID associated with a stream
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name     | Type    | Description   |
+| -------- | ------- | ------------- |
 | streamId | uint256 | The stream ID |
 
 ##### Return Values
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name      | Type   | Description           |
+| --------- | ------ | --------------------- |
 | serviceId | uint64 | The Tangle service ID |
 
 #### getServiceStreams
@@ -209,14 +209,14 @@ Get all active streams for a service
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name      | Type   | Description           |
+| --------- | ------ | --------------------- |
 | serviceId | uint64 | The Tangle service ID |
 
 ##### Return Values
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name      | Type      | Description                |
+| --------- | --------- | -------------------------- |
 | streamIds | uint256[] | Array of active stream IDs |
 
 #### getAccruedAmount
@@ -229,14 +229,14 @@ Calculate real-time accrued amount (not yet settled)
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name     | Type    | Description   |
+| -------- | ------- | ------------- |
 | streamId | uint256 | The stream ID |
 
 ##### Return Values
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name          | Type    | Description                          |
+| ------------- | ------- | ------------------------------------ |
 | accruedAmount | uint256 | Amount accrued since last settlement |
 
 #### protocolName
@@ -249,8 +249,8 @@ Get the name of the underlying protocol
 
 ##### Return Values
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name | Type   | Description                                   |
+| ---- | ------ | --------------------------------------------- |
 | name | string | Protocol name (e.g., "Superfluid", "Sablier") |
 
 #### isTokenSupported
@@ -263,14 +263,14 @@ Check if a token is supported for streaming
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name  | Type    | Description       |
+| ----- | ------- | ----------------- |
 | token | address | The token address |
 
 ##### Return Values
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name      | Type | Description                   |
+| --------- | ---- | ----------------------------- |
 | supported | bool | True if token can be streamed |
 
 #### Events
@@ -314,4 +314,3 @@ event StreamSettled(uint64 serviceId, uint256 streamId, uint256 amount)
 ```
 
 Emitted when a stream is settled and distributed
-

--- a/pages/developers/api/reference/generated/IStreamingPaymentManager.mdx
+++ b/pages/developers/api/reference/generated/IStreamingPaymentManager.mdx
@@ -5,7 +5,7 @@ description: Auto-generated Solidity API reference.
 
 # IStreamingPaymentManager
 
-Source: https://github.com/tangle-network/tnt-core/blob/v2/src/v2/interfaces/IStreamingPaymentManager.sol
+Source: https://github.com/tangle-network/tnt-core/blob/main/src/interfaces/IStreamingPaymentManager.sol
 
 ### IStreamingPaymentManager
 
@@ -76,4 +76,3 @@ function pendingDrip(uint64 serviceId, address operator) external view returns (
 ```
 
 Calculate pending drip amount
-

--- a/pages/developers/api/reference/generated/ISuperfluidAdapter.mdx
+++ b/pages/developers/api/reference/generated/ISuperfluidAdapter.mdx
@@ -5,7 +5,7 @@ description: Auto-generated Solidity API reference.
 
 # ISuperfluidAdapter
 
-Source: https://github.com/tangle-network/tnt-core/blob/v2/src/v2/interfaces/IStreamingPaymentAdapter.sol
+Source: https://github.com/tangle-network/tnt-core/blob/main/src/interfaces/IStreamingPaymentAdapter.sol
 
 ### ISuperfluidAdapter
 
@@ -23,15 +23,15 @@ Get the net flow rate for an account (incoming - outgoing)
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name    | Type    | Description         |
+| ------- | ------- | ------------------- |
 | account | address | The account address |
-| token | address | The super token |
+| token   | address | The super token     |
 
 ##### Return Values
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name        | Type  | Description                     |
+| ----------- | ----- | ------------------------------- |
 | netFlowRate | int96 | Net flow rate (can be negative) |
 
 #### getRealtimeBalance
@@ -44,17 +44,17 @@ Get the real-time balance of an account
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name    | Type    | Description         |
+| ------- | ------- | ------------------- |
 | account | address | The account address |
-| token | address | The super token |
+| token   | address | The super token     |
 
 ##### Return Values
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| availableBalance | int256 | Current available balance |
-| deposit | uint256 | Required deposit/buffer |
+| Name             | Type    | Description               |
+| ---------------- | ------- | ------------------------- |
+| availableBalance | int256  | Current available balance |
+| deposit          | uint256 | Required deposit/buffer   |
 
 #### isSolvent
 
@@ -66,15 +66,15 @@ Check if an account is solvent (positive balance)
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name    | Type    | Description         |
+| ------- | ------- | ------------------- |
 | account | address | The account address |
-| token | address | The super token |
+| token   | address | The super token     |
 
 ##### Return Values
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name    | Type | Description                          |
+| ------- | ---- | ------------------------------------ |
 | solvent | bool | True if account has positive balance |
 
 #### getRequiredBuffer
@@ -87,15 +87,15 @@ Get the required buffer/deposit for a flow rate
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| token | address | The super token |
-| flowRate | int96 | Flow rate in wei/second |
+| Name     | Type    | Description             |
+| -------- | ------- | ----------------------- |
+| token    | address | The super token         |
+| flowRate | int96   | Flow rate in wei/second |
 
 ##### Return Values
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name         | Type    | Description             |
+| ------------ | ------- | ----------------------- |
 | bufferAmount | uint256 | Required buffer deposit |
 
 #### wrapTokens
@@ -108,10 +108,10 @@ Wrap underlying tokens to super tokens
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| token | address | The underlying token |
-| amount | uint256 | Amount to wrap |
+| Name   | Type    | Description          |
+| ------ | ------- | -------------------- |
+| token  | address | The underlying token |
+| amount | uint256 | Amount to wrap       |
 
 #### unwrapTokens
 
@@ -123,8 +123,7 @@ Unwrap super tokens to underlying
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| token | address | The super token |
+| Name   | Type    | Description      |
+| ------ | ------- | ---------------- |
+| token  | address | The super token  |
 | amount | uint256 | Amount to unwrap |
-

--- a/pages/developers/api/reference/generated/ITangle.mdx
+++ b/pages/developers/api/reference/generated/ITangle.mdx
@@ -5,12 +5,11 @@ description: Auto-generated Solidity API reference.
 
 # ITangle
 
-Source: https://github.com/tangle-network/tnt-core/blob/v2/src/v2/interfaces/ITangle.sol
+Source: https://github.com/tangle-network/tnt-core/blob/main/src/interfaces/ITangle.sol
 
 ### ITangle
 
 Core interface for Tangle Protocol
 
 _Consolidates all sub-interfaces into a single entry point.
-     Inherits from focused sub-interfaces for modularity._
-
+Inherits from focused sub-interfaces for modularity._

--- a/pages/developers/api/reference/generated/ITangleAdmin.mdx
+++ b/pages/developers/api/reference/generated/ITangleAdmin.mdx
@@ -5,7 +5,7 @@ description: Auto-generated Solidity API reference.
 
 # ITangleAdmin
 
-Source: https://github.com/tangle-network/tnt-core/blob/v2/src/v2/interfaces/ITangle.sol
+Source: https://github.com/tangle-network/tnt-core/blob/main/src/interfaces/ITangle.sol
 
 ### ITangleAdmin
 
@@ -23,8 +23,8 @@ Set the staking module
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name    | Type    | Description                 |
+| ------- | ------- | --------------------------- |
 | staking | address | The IStaking implementation |
 
 #### setTreasury
@@ -37,8 +37,8 @@ Set the protocol treasury
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name     | Type    | Description          |
+| -------- | ------- | -------------------- |
 | treasury | address | The treasury address |
 
 #### setPaymentSplit
@@ -51,8 +51,8 @@ Set the payment split configuration
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name  | Type                      | Description                 |
+| ----- | ------------------------- | --------------------------- |
 | split | struct Types.PaymentSplit | The new split configuration |
 
 #### paymentSplit
@@ -246,4 +246,3 @@ function setTntPaymentDiscountBps(uint16 discountBps) external
 ```
 
 Set TNT payment discount bps
-

--- a/pages/developers/api/reference/generated/ITangleBlueprints.mdx
+++ b/pages/developers/api/reference/generated/ITangleBlueprints.mdx
@@ -5,7 +5,7 @@ description: Auto-generated Solidity API reference.
 
 # ITangleBlueprints
 
-Source: https://github.com/tangle-network/tnt-core/blob/v2/src/v2/interfaces/ITangleBlueprints.sol
+Source: https://github.com/tangle-network/tnt-core/blob/main/src/interfaces/ITangleBlueprints.sol
 
 ### ITangleBlueprints
 
@@ -23,14 +23,14 @@ Create a blueprint from an encoded definition that includes schemas and job meta
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name       | Type                             | Description                                 |
+| ---------- | -------------------------------- | ------------------------------------------- |
 | definition | struct Types.BlueprintDefinition | Fully populated blueprint definition struct |
 
 ##### Return Values
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name        | Type   | Description          |
+| ----------- | ------ | -------------------- |
 | blueprintId | uint64 | The new blueprint ID |
 
 #### updateBlueprint
@@ -154,4 +154,3 @@ event BlueprintTransferred(uint64 blueprintId, address from, address to)
 ```solidity
 event BlueprintDeactivated(uint64 blueprintId)
 ```
-

--- a/pages/developers/api/reference/generated/ITangleFull.mdx
+++ b/pages/developers/api/reference/generated/ITangleFull.mdx
@@ -5,9 +5,8 @@ description: Auto-generated Solidity API reference.
 
 # ITangleFull
 
-Source: https://github.com/tangle-network/tnt-core/blob/v2/src/v2/interfaces/ITangle.sol
+Source: https://github.com/tangle-network/tnt-core/blob/main/src/interfaces/ITangle.sol
 
 ### ITangleFull
 
 Complete Tangle interface including admin and slashing
-

--- a/pages/developers/api/reference/generated/ITangleGovernance.mdx
+++ b/pages/developers/api/reference/generated/ITangleGovernance.mdx
@@ -5,7 +5,7 @@ description: Auto-generated Solidity API reference.
 
 # ITangleGovernance
 
-Source: https://github.com/tangle-network/tnt-core/blob/v2/src/v2/interfaces/ITangleGovernance.sol
+Source: https://github.com/tangle-network/tnt-core/blob/main/src/interfaces/ITangleGovernance.sol
 
 ### ITangleGovernance
 
@@ -42,17 +42,17 @@ Create a new proposal
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| targets | address[] | Contract addresses to call |
-| values | uint256[] | ETH values to send |
-| calldatas | bytes[] | Encoded function calls |
-| description | string | Human-readable description |
+| Name        | Type      | Description                |
+| ----------- | --------- | -------------------------- |
+| targets     | address[] | Contract addresses to call |
+| values      | uint256[] | ETH values to send         |
+| calldatas   | bytes[]   | Encoded function calls     |
+| description | string    | Human-readable description |
 
 ##### Return Values
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name       | Type    | Description                    |
+| ---------- | ------- | ------------------------------ |
 | proposalId | uint256 | The unique proposal identifier |
 
 #### queue
@@ -65,17 +65,17 @@ Queue a successful proposal for execution
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| targets | address[] | Contract addresses to call |
-| values | uint256[] | ETH values to send |
-| calldatas | bytes[] | Encoded function calls |
-| descriptionHash | bytes32 | Hash of the proposal description |
+| Name            | Type      | Description                      |
+| --------------- | --------- | -------------------------------- |
+| targets         | address[] | Contract addresses to call       |
+| values          | uint256[] | ETH values to send               |
+| calldatas       | bytes[]   | Encoded function calls           |
+| descriptionHash | bytes32   | Hash of the proposal description |
 
 ##### Return Values
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name       | Type    | Description             |
+| ---------- | ------- | ----------------------- |
 | proposalId | uint256 | The proposal identifier |
 
 #### execute
@@ -88,17 +88,17 @@ Execute a queued proposal
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| targets | address[] | Contract addresses to call |
-| values | uint256[] | ETH values to send |
-| calldatas | bytes[] | Encoded function calls |
-| descriptionHash | bytes32 | Hash of the proposal description |
+| Name            | Type      | Description                      |
+| --------------- | --------- | -------------------------------- |
+| targets         | address[] | Contract addresses to call       |
+| values          | uint256[] | ETH values to send               |
+| calldatas       | bytes[]   | Encoded function calls           |
+| descriptionHash | bytes32   | Hash of the proposal description |
 
 ##### Return Values
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name       | Type    | Description             |
+| ---------- | ------- | ----------------------- |
 | proposalId | uint256 | The proposal identifier |
 
 #### cancel
@@ -111,17 +111,17 @@ Cancel a proposal
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| targets | address[] | Contract addresses to call |
-| values | uint256[] | ETH values to send |
-| calldatas | bytes[] | Encoded function calls |
-| descriptionHash | bytes32 | Hash of the proposal description |
+| Name            | Type      | Description                      |
+| --------------- | --------- | -------------------------------- |
+| targets         | address[] | Contract addresses to call       |
+| values          | uint256[] | ETH values to send               |
+| calldatas       | bytes[]   | Encoded function calls           |
+| descriptionHash | bytes32   | Hash of the proposal description |
 
 ##### Return Values
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name       | Type    | Description             |
+| ---------- | ------- | ----------------------- |
 | proposalId | uint256 | The proposal identifier |
 
 #### castVote
@@ -134,15 +134,15 @@ Cast a vote on a proposal
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| proposalId | uint256 | The proposal to vote on |
-| support | uint8 | 0=Against, 1=For, 2=Abstain |
+| Name       | Type    | Description                 |
+| ---------- | ------- | --------------------------- |
+| proposalId | uint256 | The proposal to vote on     |
+| support    | uint8   | 0=Against, 1=For, 2=Abstain |
 
 ##### Return Values
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name   | Type    | Description            |
+| ------ | ------- | ---------------------- |
 | weight | uint256 | The voting weight used |
 
 #### castVoteWithReason
@@ -155,16 +155,16 @@ Cast a vote with reason
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| proposalId | uint256 | The proposal to vote on |
-| support | uint8 | 0=Against, 1=For, 2=Abstain |
-| reason | string | Explanation for the vote |
+| Name       | Type    | Description                 |
+| ---------- | ------- | --------------------------- |
+| proposalId | uint256 | The proposal to vote on     |
+| support    | uint8   | 0=Against, 1=For, 2=Abstain |
+| reason     | string  | Explanation for the vote    |
 
 ##### Return Values
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name   | Type    | Description            |
+| ------ | ------- | ---------------------- |
 | weight | uint256 | The voting weight used |
 
 #### castVoteBySig
@@ -177,17 +177,17 @@ Cast a vote using EIP-712 signature
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| proposalId | uint256 | The proposal to vote on |
-| support | uint8 | 0=Against, 1=For, 2=Abstain |
-| voter | address | The voter address |
-| signature | bytes | The EIP-712 signature |
+| Name       | Type    | Description                 |
+| ---------- | ------- | --------------------------- |
+| proposalId | uint256 | The proposal to vote on     |
+| support    | uint8   | 0=Against, 1=For, 2=Abstain |
+| voter      | address | The voter address           |
+| signature  | bytes   | The EIP-712 signature       |
 
 ##### Return Values
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name   | Type    | Description            |
+| ------ | ------- | ---------------------- |
 | weight | uint256 | The voting weight used |
 
 #### state
@@ -269,4 +269,3 @@ function proposalThreshold() external view returns (uint256)
 ```
 
 Get the proposal threshold (tokens needed to propose)
-

--- a/pages/developers/api/reference/generated/ITangleJobs.mdx
+++ b/pages/developers/api/reference/generated/ITangleJobs.mdx
@@ -5,7 +5,7 @@ description: Auto-generated Solidity API reference.
 
 # ITangleJobs
 
-Source: https://github.com/tangle-network/tnt-core/blob/v2/src/v2/interfaces/ITangleJobs.sol
+Source: https://github.com/tangle-network/tnt-core/blob/main/src/interfaces/ITangleJobs.sol
 
 ### ITangleJobs
 
@@ -49,14 +49,14 @@ _Only valid for jobs where requiresAggregation returns true_
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| serviceId | uint64 | The service ID |
-| callId | uint64 | The job call ID |
-| output | bytes | The aggregated output data |
-| signerBitmap | uint256 | Bitmap indicating which operators signed (bit i = operator i in service) |
-| aggregatedSignature | uint256[2] | The aggregated BLS signature [x, y] |
-| aggregatedPubkey | uint256[4] | The aggregated public key [x0, x1, y0, y1] |
+| Name                | Type       | Description                                                              |
+| ------------------- | ---------- | ------------------------------------------------------------------------ |
+| serviceId           | uint64     | The service ID                                                           |
+| callId              | uint64     | The job call ID                                                          |
+| output              | bytes      | The aggregated output data                                               |
+| signerBitmap        | uint256    | Bitmap indicating which operators signed (bit i = operator i in service) |
+| aggregatedSignature | uint256[2] | The aggregated BLS signature [x, y]                                      |
+| aggregatedPubkey    | uint256[4] | The aggregated public key [x0, x1, y0, y1]                               |
 
 #### getJobCall
 
@@ -89,4 +89,3 @@ event JobCompleted(uint64 serviceId, uint64 callId)
 Emitted when a job reaches its required result threshold
 
 _Derive resultCount from getJobCall(serviceId, callId).resultCount_
-

--- a/pages/developers/api/reference/generated/ITangleOperators.mdx
+++ b/pages/developers/api/reference/generated/ITangleOperators.mdx
@@ -5,15 +5,15 @@ description: Auto-generated Solidity API reference.
 
 # ITangleOperators
 
-Source: https://github.com/tangle-network/tnt-core/blob/v2/src/v2/interfaces/ITangleOperators.sol
+Source: https://github.com/tangle-network/tnt-core/blob/main/src/interfaces/ITangleOperators.sol
 
 ### ITangleOperators
 
 Operator registration and management interface
 
 _Operator liveness is tracked via OperatorStatusRegistry heartbeats,
-     not a setOperatorOnline call. Use submitHeartbeat/isOnline/getOperatorStatus
-     on the registry for liveness signals._
+not a setOperatorOnline call. Use submitHeartbeat/isOnline/getOperatorStatus
+on the registry for liveness signals._
 
 #### Functions
 
@@ -35,11 +35,11 @@ Register as operator for a blueprint
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| blueprintId | uint64 | The blueprint to register for |
-| ecdsaPublicKey | bytes | The ECDSA public key for gossip network identity        This key is used for signing/verifying messages in the P2P gossip network        and may differ from the wallet key (msg.sender) |
-| rpcAddress | string | The operator's RPC endpoint URL |
+| Name           | Type   | Description                                                                                                                                                                |
+| -------------- | ------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| blueprintId    | uint64 | The blueprint to register for                                                                                                                                              |
+| ecdsaPublicKey | bytes  | The ECDSA public key for gossip network identity This key is used for signing/verifying messages in the P2P gossip network and may differ from the wallet key (msg.sender) |
+| rpcAddress     | string | The operator's RPC endpoint URL                                                                                                                                            |
 
 #### registerOperator
 
@@ -51,12 +51,12 @@ Register as operator providing blueprint-specific registration inputs
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| blueprintId | uint64 |  |
-| ecdsaPublicKey | bytes |  |
-| rpcAddress | string |  |
-| registrationInputs | bytes | Encoded payload validated by blueprint's schema |
+| Name               | Type   | Description                                     |
+| ------------------ | ------ | ----------------------------------------------- |
+| blueprintId        | uint64 |                                                 |
+| ecdsaPublicKey     | bytes  |                                                 |
+| rpcAddress         | string |                                                 |
+| registrationInputs | bytes  | Encoded payload validated by blueprint's schema |
 
 #### unregisterOperator
 
@@ -76,11 +76,11 @@ Update operator preferences for a blueprint
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| blueprintId | uint64 | The blueprint to update preferences for |
-| ecdsaPublicKey | bytes | New ECDSA public key (pass empty bytes to keep unchanged) |
-| rpcAddress | string | New RPC endpoint (pass empty string to keep unchanged) |
+| Name           | Type   | Description                                               |
+| -------------- | ------ | --------------------------------------------------------- |
+| blueprintId    | uint64 | The blueprint to update preferences for                   |
+| ecdsaPublicKey | bytes  | New ECDSA public key (pass empty bytes to keep unchanged) |
+| rpcAddress     | string | New RPC endpoint (pass empty string to keep unchanged)    |
 
 #### getOperatorRegistration
 
@@ -128,12 +128,12 @@ Emitted when an operator registers for a blueprint
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| blueprintId | uint64 | The blueprint ID |
-| operator | address | The operator address (wallet) |
-| ecdsaPublicKey | bytes | The ECDSA public key for gossip network identity |
-| rpcAddress | string | The operator's RPC endpoint |
+| Name           | Type    | Description                                      |
+| -------------- | ------- | ------------------------------------------------ |
+| blueprintId    | uint64  | The blueprint ID                                 |
+| operator       | address | The operator address (wallet)                    |
+| ecdsaPublicKey | bytes   | The ECDSA public key for gossip network identity |
+| rpcAddress     | string  | The operator's RPC endpoint                      |
 
 #### OperatorUnregistered
 
@@ -151,10 +151,9 @@ Emitted when an operator updates their preferences
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| blueprintId | uint64 | The blueprint ID |
-| operator | address | The operator address |
-| ecdsaPublicKey | bytes | The updated ECDSA public key (may be empty if unchanged) |
-| rpcAddress | string | The updated RPC endpoint (may be empty if unchanged) |
-
+| Name           | Type    | Description                                              |
+| -------------- | ------- | -------------------------------------------------------- |
+| blueprintId    | uint64  | The blueprint ID                                         |
+| operator       | address | The operator address                                     |
+| ecdsaPublicKey | bytes   | The updated ECDSA public key (may be empty if unchanged) |
+| rpcAddress     | string  | The updated RPC endpoint (may be empty if unchanged)     |

--- a/pages/developers/api/reference/generated/ITanglePaymentsInternal.mdx
+++ b/pages/developers/api/reference/generated/ITanglePaymentsInternal.mdx
@@ -5,7 +5,7 @@ description: Auto-generated Solidity API reference.
 
 # ITanglePaymentsInternal
 
-Source: https://github.com/tangle-network/tnt-core/blob/v2/src/v2/interfaces/ITanglePaymentsInternal.sol
+Source: https://github.com/tangle-network/tnt-core/blob/main/src/interfaces/ITanglePaymentsInternal.sol
 
 ### ITanglePaymentsInternal
 
@@ -22,4 +22,3 @@ function distributePayment(uint64 serviceId, uint64 blueprintId, address token, 
 ```solidity
 function depositToEscrow(uint64 serviceId, address token, uint256 amount) external
 ```
-

--- a/pages/developers/api/reference/generated/ITangleRewards.mdx
+++ b/pages/developers/api/reference/generated/ITangleRewards.mdx
@@ -5,7 +5,7 @@ description: Auto-generated Solidity API reference.
 
 # ITangleRewards
 
-Source: https://github.com/tangle-network/tnt-core/blob/v2/src/v2/interfaces/ITangleRewards.sol
+Source: https://github.com/tangle-network/tnt-core/blob/main/src/interfaces/ITangleRewards.sol
 
 ### ITangleRewards
 
@@ -78,4 +78,3 @@ _Convenience view; mappings are not enumerable._
 ```solidity
 event RewardsClaimed(address account, address token, uint256 amount)
 ```
-

--- a/pages/developers/api/reference/generated/ITangleSecurityView.mdx
+++ b/pages/developers/api/reference/generated/ITangleSecurityView.mdx
@@ -5,7 +5,7 @@ description: Auto-generated Solidity API reference.
 
 # ITangleSecurityView
 
-Source: https://github.com/tangle-network/tnt-core/blob/v2/src/v2/interfaces/ITangleSecurityView.sol
+Source: https://github.com/tangle-network/tnt-core/blob/main/src/interfaces/ITangleSecurityView.sol
 
 ### ITangleSecurityView
 
@@ -42,4 +42,3 @@ function getService(uint64 serviceId) external view returns (struct Types.Servic
 ```solidity
 function getServiceOperators(uint64 serviceId) external view returns (address[])
 ```
-

--- a/pages/developers/api/reference/generated/ITangleServices.mdx
+++ b/pages/developers/api/reference/generated/ITangleServices.mdx
@@ -5,7 +5,7 @@ description: Auto-generated Solidity API reference.
 
 # ITangleServices
 
-Source: https://github.com/tangle-network/tnt-core/blob/v2/src/v2/interfaces/ITangleServices.sol
+Source: https://github.com/tangle-network/tnt-core/blob/main/src/interfaces/ITangleServices.sol
 
 ### ITangleServices
 
@@ -77,13 +77,13 @@ _No approval flow needed - operators have pre-committed via signatures_
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| blueprintId | uint64 | The blueprint to use |
-| quotes | struct Types.SignedQuote[] | Array of signed quotes from operators |
-| config | bytes | Service configuration |
-| permittedCallers | address[] | Addresses allowed to call jobs |
-| ttl | uint64 | Service time-to-live (must match quotes) |
+| Name             | Type                       | Description                              |
+| ---------------- | -------------------------- | ---------------------------------------- |
+| blueprintId      | uint64                     | The blueprint to use                     |
+| quotes           | struct Types.SignedQuote[] | Array of signed quotes from operators    |
+| config           | bytes                      | Service configuration                    |
+| permittedCallers | address[]                  | Addresses allowed to call jobs           |
+| ttl              | uint64                     | Service time-to-live (must match quotes) |
 
 #### extendServiceFromQuotes
 
@@ -183,10 +183,10 @@ Force remove an operator from a service (blueprint manager only)
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| serviceId | uint64 | The service ID |
-| operator | address | The operator to remove |
+| Name      | Type    | Description            |
+| --------- | ------- | ---------------------- |
+| serviceId | uint64  | The service ID         |
+| operator  | address | The operator to remove |
 
 #### billSubscription
 
@@ -411,4 +411,3 @@ event OperatorLeftService(uint64 serviceId, address operator)
 ```solidity
 event SubscriptionBilled(uint64 serviceId, uint256 amount, uint64 period)
 ```
-

--- a/pages/developers/api/reference/generated/ITangleSlashing.mdx
+++ b/pages/developers/api/reference/generated/ITangleSlashing.mdx
@@ -5,7 +5,7 @@ description: Auto-generated Solidity API reference.
 
 # ITangleSlashing
 
-Source: https://github.com/tangle-network/tnt-core/blob/v2/src/v2/interfaces/ITangleSlashing.sol
+Source: https://github.com/tangle-network/tnt-core/blob/main/src/interfaces/ITangleSlashing.sol
 
 ### ITangleSlashing
 
@@ -23,17 +23,17 @@ Propose a slash against an operator
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| serviceId | uint64 | The service where violation occurred |
-| operator | address | The operator to slash |
-| amount | uint256 | Amount to slash |
-| evidence | bytes32 | Evidence hash |
+| Name      | Type    | Description                          |
+| --------- | ------- | ------------------------------------ |
+| serviceId | uint64  | The service where violation occurred |
+| operator  | address | The operator to slash                |
+| amount    | uint256 | Amount to slash                      |
+| evidence  | bytes32 | Evidence hash                        |
 
 ##### Return Values
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name    | Type   | Description                          |
+| ------- | ------ | ------------------------------------ |
 | slashId | uint64 | The ID of the created slash proposal |
 
 #### disputeSlash
@@ -105,4 +105,3 @@ event SlashProposed(uint64 serviceId, address operator, uint256 amount, bytes32 
 ```solidity
 event SlashExecuted(uint64 serviceId, address operator, uint256 amount)
 ```
-

--- a/pages/developers/api/reference/generated/ITangleToken.mdx
+++ b/pages/developers/api/reference/generated/ITangleToken.mdx
@@ -5,7 +5,7 @@ description: Auto-generated Solidity API reference.
 
 # ITangleToken
 
-Source: https://github.com/tangle-network/tnt-core/blob/v2/src/v2/interfaces/ITangleGovernance.sol
+Source: https://github.com/tangle-network/tnt-core/blob/main/src/interfaces/ITangleGovernance.sol
 
 ### ITangleToken
 
@@ -92,4 +92,3 @@ function approve(address spender, uint256 amount) external returns (bool)
 ```solidity
 function transferFrom(address from, address to, uint256 amount) external returns (bool)
 ```
-

--- a/pages/developers/blueprint-contexts/evm-provider-context.mdx
+++ b/pages/developers/blueprint-contexts/evm-provider-context.mdx
@@ -8,7 +8,6 @@ import GithubFileReaderDisplay from '/components/GithubFileReaderDisplay';
 
 SDK source (GitHub): https://github.com/tangle-network/blueprint/tree/v2/crates/contexts
 
-
 The `EvmInstrumentedClientContext` trait provides a standardized [alloy-rs](https://github.com/alloy-rs) EVM provider for interacting with EVM-compatible blockchain networks in your Blueprint.
 
 ## Context Summary

--- a/pages/developers/blueprint-contexts/keystore-context.mdx
+++ b/pages/developers/blueprint-contexts/keystore-context.mdx
@@ -8,7 +8,6 @@ import GithubFileReaderDisplay from '/components/GithubFileReaderDisplay';
 
 SDK source (GitHub): https://github.com/tangle-network/blueprint/tree/v2/crates/contexts
 
-
 The `KeystoreContext` trait provides a standardized interface for accessing, managing, and signing using cryptographic keys in your Blueprint.
 
 ## Context Summary

--- a/pages/developers/blueprint-contexts/tangle-client-context.mdx
+++ b/pages/developers/blueprint-contexts/tangle-client-context.mdx
@@ -8,7 +8,6 @@ import GithubFileReaderDisplay from '/components/GithubFileReaderDisplay';
 
 SDK source (GitHub): https://github.com/tangle-network/blueprint/tree/v2/crates/contexts
 
-
 The `TangleEvmClientContext` trait provides a standardized interface for interacting with the Tangle EVM protocol from a Blueprint. It exposes a typed `TangleEvmClient` configured from the blueprint environment.
 
 ## Context Summary

--- a/pages/developers/blueprint-qos.mdx
+++ b/pages/developers/blueprint-qos.mdx
@@ -22,11 +22,11 @@ The Blueprint QoS system provides a complete observability stack:
 
 QoS always exposes a Prometheus-compatible metrics endpoint when metrics are enabled. Grafana and Loki are optional and can be managed by QoS or connected externally.
 
-| Component | Default Endpoint | Notes |
-| --- | --- | --- |
-| Prometheus metrics | `http://<host>:9090/metrics` | Includes `/health` plus Prometheus v1 API routes like `/api/v1/query`. |
-| Grafana UI | `http://<host>:3000` | Only when configured or managed by QoS. |
-| Loki push API | `http://<host>:3100/loki/api/v1/push` | Only when configured or managed by QoS. |
+| Component          | Default Endpoint                      | Notes                                                                  |
+| ------------------ | ------------------------------------- | ---------------------------------------------------------------------- |
+| Prometheus metrics | `http://<host>:9090/metrics`          | Includes `/health` plus Prometheus v1 API routes like `/api/v1/query`. |
+| Grafana UI         | `http://<host>:3000`                  | Only when configured or managed by QoS.                                |
+| Loki push API      | `http://<host>:3100/loki/api/v1/push` | Only when configured or managed by QoS.                                |
 
 ## Integrating QoS with BlueprintRunner
 
@@ -240,11 +240,11 @@ if let Some(qos) = &ctx.qos_service {
 
 ## QoS Components Reference
 
-| Component | Primary Struct | Config | Purpose |
-| --- | --- | --- | --- |
-| Unified Service | `QoSService` | `QoSConfig` | Main entry point for QoS integration |
-| Heartbeat | `HeartbeatService` | `HeartbeatConfig` | Liveness signals to the status registry |
-| Metrics | `MetricsService` | `MetricsConfig` | System + job metrics and Prometheus export |
-| Logging | N/A | `LokiConfig` | Log aggregation via Loki |
-| Dashboards | `GrafanaClient` | `GrafanaConfig` | Dashboards and datasources |
-| Server Management | `ServerManager` | Server configs | Manages Docker containers for the stack |
+| Component         | Primary Struct     | Config            | Purpose                                    |
+| ----------------- | ------------------ | ----------------- | ------------------------------------------ |
+| Unified Service   | `QoSService`       | `QoSConfig`       | Main entry point for QoS integration       |
+| Heartbeat         | `HeartbeatService` | `HeartbeatConfig` | Liveness signals to the status registry    |
+| Metrics           | `MetricsService`   | `MetricsConfig`   | System + job metrics and Prometheus export |
+| Logging           | N/A                | `LokiConfig`      | Log aggregation via Loki                   |
+| Dashboards        | `GrafanaClient`    | `GrafanaConfig`   | Dashboards and datasources                 |
+| Server Management | `ServerManager`    | Server configs    | Manages Docker containers for the stack    |

--- a/pages/developers/blueprint-runner/background-services.mdx
+++ b/pages/developers/blueprint-runner/background-services.mdx
@@ -8,7 +8,6 @@ import GithubFileReaderDisplay from '/components/GithubFileReaderDisplay';
 
 SDK source (GitHub): https://github.com/tangle-network/blueprint/tree/v2/crates/runner
 
-
 Background services are optional components in the [Blueprint Runner](/developers/blueprint-runner/introduction) architecture that run continuously to support the operation of your blueprint. This document explains how background services work, how to configure them, and best practices for implementation.
 
 ## What are Background Services?

--- a/pages/developers/blueprint-runner/building.mdx
+++ b/pages/developers/blueprint-runner/building.mdx
@@ -8,7 +8,6 @@ import GithubFileReaderDisplay from '/components/GithubFileReaderDisplay';
 
 SDK source (GitHub): https://github.com/tangle-network/blueprint/tree/v2/crates/runner
 
-
 This guide provides a step-by-step approach to building a Blueprint Runner, the primary component of a Blueprint.
 
 ## Prerequisites

--- a/pages/developers/blueprint-runner/consumers.mdx
+++ b/pages/developers/blueprint-runner/consumers.mdx
@@ -8,7 +8,6 @@ import GithubFileReaderDisplay from '/components/GithubFileReaderDisplay';
 
 SDK source (GitHub): https://github.com/tangle-network/blueprint/tree/v2/crates/runner
 
-
 Consumers are a vital component of the [Blueprint Runner](/developers/blueprint-runner/introduction) architecture that handle the results of processed jobs. This document explains how consumers work, how to configure them, and best practices for implementation.
 
 ## What are Consumers?

--- a/pages/developers/blueprint-runner/introduction.mdx
+++ b/pages/developers/blueprint-runner/introduction.mdx
@@ -8,7 +8,6 @@ import CardGrid from "../../../components/CardGrid.tsx"
 
 SDK source (GitHub): https://github.com/tangle-network/blueprint/tree/v2/crates/runner
 
-
 Blueprint Runners are the core orchestration components that execute Tangle Blueprints. They manage the lifecycle of jobs, coordinate between different components, and ensure reliable execution of your blueprint service.
 
 ## Getting Started

--- a/pages/developers/blueprint-runner/jobs.mdx
+++ b/pages/developers/blueprint-runner/jobs.mdx
@@ -8,7 +8,6 @@ import GithubFileReaderDisplay from '/components/GithubFileReaderDisplay';
 
 SDK source (GitHub): https://github.com/tangle-network/blueprint/tree/v2/crates/runner
 
-
 Jobs are the core building blocks of a [Blueprint Runner](/developers/blueprint-runner/introduction). They define the computational tasks that your Blueprint will execute in response to events. This document explains how jobs work, how to define them, and how to integrate them with other components of your Blueprint.
 
 ## What are Jobs?

--- a/pages/developers/blueprint-runner/producers.mdx
+++ b/pages/developers/blueprint-runner/producers.mdx
@@ -8,7 +8,6 @@ import GithubFileReaderDisplay from '/components/GithubFileReaderDisplay';
 
 SDK source (GitHub): https://github.com/tangle-network/blueprint/tree/v2/crates/runner
 
-
 Producers are a key component of the [Blueprint Runner](/developers/blueprint-runner/introduction) architecture that capture events and prepare them for processing. This document explains how producers work, how to configure them, and how to implement them.
 
 ## What are Producers?

--- a/pages/developers/blueprint-runner/routers.mdx
+++ b/pages/developers/blueprint-runner/routers.mdx
@@ -8,7 +8,6 @@ import GithubFileReaderDisplay from '/components/GithubFileReaderDisplay';
 
 SDK source (GitHub): https://github.com/tangle-network/blueprint/tree/v2/crates/runner
 
-
 Routers are a critical component of the [Blueprint Runner](/developers/blueprint-runner/introduction) architecture. They are responsible for directing job calls to the appropriate job handlers based on job IDs. This document explains how routers work, how to configure them, and best practices for implementation.
 
 ## What are Routers?

--- a/pages/developers/cli/debugging.mdx
+++ b/pages/developers/cli/debugging.mdx
@@ -2,7 +2,6 @@
 
 CLI source (GitHub): https://github.com/tangle-network/blueprint/tree/v2/cli
 
-
 Blueprints can be deployed to multiple different [sources](/developers/deployment/sources/introduction), with each one
 having its own constraints. The CLI has commands to test your blueprint in these environments, assuming your machine is
 capable of hosting them, see [requirements](/operators/manager/requirements).

--- a/pages/developers/cli/installation.mdx
+++ b/pages/developers/cli/installation.mdx
@@ -6,7 +6,6 @@ title: Installation
 
 CLI source (GitHub): https://github.com/tangle-network/blueprint/tree/v2/cli
 
-
 ## Prerequisites
 
 1. Install Rust

--- a/pages/developers/cli/keys.mdx
+++ b/pages/developers/cli/keys.mdx
@@ -6,7 +6,6 @@ title: Tangle CLI Key Commands
 
 CLI source (GitHub): https://github.com/tangle-network/blueprint/tree/v2/cli
 
-
 This guide covers the key management commands available in the Tangle CLI tool. These commands allow you to generate, import, export, and list cryptographic keys used by Tangle protocols.
 
 ## Key Commands
@@ -67,8 +66,8 @@ cargo tangle key import --keystore-path <PATH> [OPTIONS]
 - `-k, --keystore-path <PATH>` (**required**): The path to the keystore
 - `-t, --key-type <KEY_TYPE>` (optional): The type of key to import (sr25519, ed25519, ecdsa, bls381, bls377, bn254)
 - `-x, --secret <SECRET>` (optional): The secret key to import (hex format without 0x prefix). Only required if key type is also specified
-When importing a key, you must specify the key type and secret key. If you don't specify a key type and secret, the CLI will prompt you interactively. Specifying the secret but not
-the key type will also prompt you to select a key type.
+  When importing a key, you must specify the key type and secret key. If you don't specify a key type and secret, the CLI will prompt you interactively. Specifying the secret but not
+  the key type will also prompt you to select a key type.
 
 ### Examples
 

--- a/pages/developers/cli/quickstart.mdx
+++ b/pages/developers/cli/quickstart.mdx
@@ -6,7 +6,6 @@ title: Quickstart
 
 CLI source (GitHub): https://github.com/tangle-network/blueprint/tree/v2/cli
 
-
 ## Pre-requisites
 
 - [git](https://git-scm.org)

--- a/pages/developers/cli/tangle.mdx
+++ b/pages/developers/cli/tangle.mdx
@@ -6,7 +6,6 @@ title: Tangle CLI Blueprint Commands
 
 CLI source (GitHub): https://github.com/tangle-network/blueprint/tree/v2/cli
 
-
 This page covers the `cargo-tangle` CLI surface for creating and operating blueprints on Tangle’s EVM protocol.
 
 Note: the CLI still uses the legacy flag name `--restaking-contract`. It refers to the staking contract (`MultiAssetDelegation`).

--- a/pages/developers/p2p-networking/overview.mdx
+++ b/pages/developers/p2p-networking/overview.mdx
@@ -9,7 +9,6 @@ import CardGrid from "../../../components/CardGrid.tsx"
 
 SDK source (GitHub): https://github.com/tangle-network/blueprint/tree/v2/crates/networking
 
-
 The [Blueprint SDK](https://github.com/tangle-network/blueprint/tree/v2) provides P2P networking utilities that allow developers to securely orchestrate
 communications among multiple service operators.
 

--- a/pages/developers/system-architecture/overview.mdx
+++ b/pages/developers/system-architecture/overview.mdx
@@ -34,16 +34,16 @@ Tangle is an EVM protocol for instantiating and operating **services (“bluepri
 
 ### On-Chain (tnt-core)
 
-| Component                | Responsibility                                                       | Code                                                                                                |
-| ------------------------ | -------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------- |
-| `Tangle`                 | Facet router (dispatches calls by selector)                          | https://github.com/tangle-network/tnt-core/blob/v2/src/v2/Tangle.sol                                |
-| `Tangle*Facet` modules   | Public protocol surface (blueprints/services/jobs/payments/quotes/…) | https://github.com/tangle-network/tnt-core/tree/v2/src/v2/facets/tangle                             |
-| `core/*` modules         | Shared implementations used by facets                                | https://github.com/tangle-network/tnt-core/tree/v2/src/v2/core                                      |
-| `MultiAssetDelegation`   | Staking + delegation + exits + slashing application                 | [MultiAssetDelegation.sol](https://github.com/tangle-network/tnt-core/blob/v2/src/v2/restaking/MultiAssetDelegation.sol)      |
-| `ServiceFeeDistributor`  | Staker fee distribution (USD-weighted, per-asset commitments)      | https://github.com/tangle-network/tnt-core/blob/v2/src/v2/rewards/ServiceFeeDistributor.sol         |
-| `OperatorStatusRegistry` | Heartbeats, QoS signals, and optional metric forwarding              | [OperatorStatusRegistry.sol](https://github.com/tangle-network/tnt-core/blob/v2/src/v2/restaking/OperatorStatusRegistry.sol)    |
-| `TangleMetrics`          | Lightweight activity recorder used by incentives                     | https://github.com/tangle-network/tnt-core/blob/v2/src/v2/rewards/TangleMetrics.sol                 |
-| `TangleMigration`        | TNT legacy-chain migration claim (Merkle + SP1/ZK)                   | https://github.com/tangle-network/tnt-core/blob/v2/packages/migration-claim/src/TangleMigration.sol |
+| Component                | Responsibility                                                       | Code                                                                                                                      |
+| ------------------------ | -------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------- |
+| `Tangle`                 | Facet router (dispatches calls by selector)                          | https://github.com/tangle-network/tnt-core/blob/main/src/Tangle.sol                                                       |
+| `Tangle*Facet` modules   | Public protocol surface (blueprints/services/jobs/payments/quotes/…) | https://github.com/tangle-network/tnt-core/tree/main/src/facets/tangle                                                    |
+| `core/*` modules         | Shared implementations used by facets                                | https://github.com/tangle-network/tnt-core/tree/main/src/core                                                             |
+| `MultiAssetDelegation`   | Staking + delegation + exits + slashing application                  | [MultiAssetDelegation.sol](https://github.com/tangle-network/tnt-core/blob/main/src/staking/MultiAssetDelegation.sol)     |
+| `ServiceFeeDistributor`  | Staker fee distribution (USD-weighted, per-asset commitments)        | https://github.com/tangle-network/tnt-core/blob/main/src/rewards/ServiceFeeDistributor.sol                                |
+| `OperatorStatusRegistry` | Heartbeats, QoS signals, and optional metric forwarding              | [OperatorStatusRegistry.sol](https://github.com/tangle-network/tnt-core/blob/main/src/staking/OperatorStatusRegistry.sol) |
+| `TangleMetrics`          | Lightweight activity recorder used by incentives                     | https://github.com/tangle-network/tnt-core/blob/main/src/rewards/TangleMetrics.sol                                        |
+| `TangleMigration`        | TNT legacy-chain migration claim (Merkle + SP1/ZK)                   | https://github.com/tangle-network/tnt-core/blob/v2/packages/migration-claim/src/TangleMigration.sol                       |
 
 ### Off-Chain ([Blueprint SDK](https://github.com/tangle-network/blueprint/tree/v2))
 
@@ -58,7 +58,7 @@ Tangle is an EVM protocol for instantiating and operating **services (“bluepri
 The protocol is exposed as a set of **facets** registered on the `Tangle` router. The router maps function selectors to facet implementations and delegates calls.
 
 <GithubFileReaderDisplay
-  url="https://github.com/tangle-network/tnt-core/blob/v2/src/v2/Tangle.sol"
+  url="https://github.com/tangle-network/tnt-core/blob/main/src/Tangle.sol"
   fromLine={1}
   toLine={95}
   title="Tangle.sol: facet router + selector registration"

--- a/pages/developers/system-architecture/rewards.mdx
+++ b/pages/developers/system-architecture/rewards.mdx
@@ -22,7 +22,7 @@ Tangle separates **service fees** (paid by customers) from **incentives** (TNT b
 
 Claim paths: staker fees + staker inflation via `ServiceFeeDistributor`, TNT staking incentives via `RewardVaults`, and operator/customer/developer TNT via `InflationPool`.
 
-Code references: [Payments.sol](https://github.com/tangle-network/tnt-core/blob/v2/src/v2/core/Payments.sol), [ServiceFeeDistributor.sol](https://github.com/tangle-network/tnt-core/blob/v2/src/v2/rewards/ServiceFeeDistributor.sol), [InflationPool.sol](https://github.com/tangle-network/tnt-core/blob/v2/src/v2/rewards/InflationPool.sol), [RewardVaults.sol](https://github.com/tangle-network/tnt-core/blob/v2/src/v2/rewards/RewardVaults.sol), [TangleMetrics.sol](https://github.com/tangle-network/tnt-core/blob/v2/src/v2/rewards/TangleMetrics.sol)
+Code references: [Payments.sol](https://github.com/tangle-network/tnt-core/blob/main/src/core/Payments.sol), [ServiceFeeDistributor.sol](https://github.com/tangle-network/tnt-core/blob/main/src/rewards/ServiceFeeDistributor.sol), [InflationPool.sol](https://github.com/tangle-network/tnt-core/blob/main/src/rewards/InflationPool.sol), [RewardVaults.sol](https://github.com/tangle-network/tnt-core/blob/main/src/rewards/RewardVaults.sol), [TangleMetrics.sol](https://github.com/tangle-network/tnt-core/blob/main/src/rewards/TangleMetrics.sol)
 
 ## Service Fee Split (Developer / Protocol / Operator / Stakers)
 
@@ -34,7 +34,7 @@ When a service pays a fee, `Payments.sol` calculates and routes the split:
 - Staker share (via `ServiceFeeDistributor`, when configured)
 
 <GithubFileReaderDisplay
-  url="https://github.com/tangle-network/tnt-core/blob/v2/src/v2/core/Payments.sol"
+  url="https://github.com/tangle-network/tnt-core/blob/main/src/core/Payments.sol"
   fromLine={259}
   toLine={403}
   title="Payments: fee distribution + staker routing via ServiceFeeDistributor"
@@ -87,7 +87,7 @@ Service pays 10 ETH with a 20/20/40/20 split:
   - `test/v2/InflationPool.t.sol`
 
 <GithubFileReaderDisplay
-  url="https://github.com/tangle-network/tnt-core/blob/v2/src/v2/rewards/ServiceFeeDistributor.sol"
+  url="https://github.com/tangle-network/tnt-core/blob/main/src/rewards/ServiceFeeDistributor.sol"
   fromLine={19}
   toLine={241}
   title="ServiceFeeDistributor: state + delegation-change hook"

--- a/pages/network/claim-airdrop.mdx
+++ b/pages/network/claim-airdrop.mdx
@@ -9,6 +9,7 @@ TNT migration moves balances from the legacy Substrate system and direct EVM all
 </Callout>
 
 Contract sources (GitHub):
+
 - https://github.com/tangle-network/tnt-core/blob/v2/packages/migration-claim/src/TangleMigration.sol
 - https://github.com/tangle-network/tnt-core/blob/v2/packages/migration-claim/src/lockups/TNTLinearVesting.sol
 

--- a/pages/network/incentives-developers.mdx
+++ b/pages/network/incentives-developers.mdx
@@ -17,9 +17,9 @@ If the protocol is running `InflationPool` incentives, developers can earn addit
 
 ## Where This Lives in Code
 
-- `InflationPool`: https://github.com/tangle-network/tnt-core/blob/v2/src/v2/rewards/InflationPool.sol
-- `TangleMetrics`: https://github.com/tangle-network/tnt-core/blob/v2/src/v2/rewards/TangleMetrics.sol
-- `Payments` (fee split + payouts): https://github.com/tangle-network/tnt-core/blob/v2/src/v2/core/Payments.sol
+- `InflationPool`: https://github.com/tangle-network/tnt-core/blob/main/src/rewards/InflationPool.sol
+- `TangleMetrics`: https://github.com/tangle-network/tnt-core/blob/main/src/rewards/TangleMetrics.sol
+- `Payments` (fee split + payouts): https://github.com/tangle-network/tnt-core/blob/main/src/core/Payments.sol
 
 For a readable breakdown and links to contracts, see [Rewards Architecture](/developers/system-architecture/rewards).
 

--- a/pages/network/incentives-operators.mdx
+++ b/pages/network/incentives-operators.mdx
@@ -5,10 +5,12 @@ Operators earn revenue from service usage and optional TNT budgets. This page ou
 ## Revenue Sources
 
 1. **Service fees (default split)**
+
    - Fees paid by customers are split across developers, the protocol, operators, and stakers.
    - The default split is **20% developer / 20% protocol / 40% operators / 20% stakers** (governance configurable).
 
 2. **Optional TNT incentives (pre-funded)**
+
    - If governance funds `InflationPool`, operators can earn TNT based on activity metrics.
 
 3. **Optional operator commission (delegation incentives)**
@@ -24,9 +26,9 @@ See [Incentives](/network/incentives-overview) for the full fee flow.
 
 ## Where This Lives in Code
 
-- `ServiceFeeDistributor`: https://github.com/tangle-network/tnt-core/blob/v2/src/v2/rewards/ServiceFeeDistributor.sol
-- `InflationPool`: https://github.com/tangle-network/tnt-core/blob/v2/src/v2/rewards/InflationPool.sol
-- `RewardVaults`: https://github.com/tangle-network/tnt-core/blob/v2/src/v2/rewards/RewardVaults.sol
+- `ServiceFeeDistributor`: https://github.com/tangle-network/tnt-core/blob/main/src/rewards/ServiceFeeDistributor.sol
+- `InflationPool`: https://github.com/tangle-network/tnt-core/blob/main/src/rewards/InflationPool.sol
+- `RewardVaults`: https://github.com/tangle-network/tnt-core/blob/main/src/rewards/RewardVaults.sol
 
 For a readable breakdown and links to contracts, see [Rewards Architecture](/developers/system-architecture/rewards).
 

--- a/pages/network/incentives-overview.mdx
+++ b/pages/network/incentives-overview.mdx
@@ -18,7 +18,7 @@ Tangle’s incentives come from two sources:
 
 Claim paths: staker fees + staker inflation via `ServiceFeeDistributor`, TNT staking incentives via `RewardVaults`, and operator/customer/developer TNT via `InflationPool`.
 
-Code references: [Payments.sol](https://github.com/tangle-network/tnt-core/blob/v2/src/v2/core/Payments.sol), [ServiceFeeDistributor.sol](https://github.com/tangle-network/tnt-core/blob/v2/src/v2/rewards/ServiceFeeDistributor.sol), [InflationPool.sol](https://github.com/tangle-network/tnt-core/blob/v2/src/v2/rewards/InflationPool.sol), [RewardVaults.sol](https://github.com/tangle-network/tnt-core/blob/v2/src/v2/rewards/RewardVaults.sol), [TangleMetrics.sol](https://github.com/tangle-network/tnt-core/blob/v2/src/v2/rewards/TangleMetrics.sol)
+Code references: [Payments.sol](https://github.com/tangle-network/tnt-core/blob/main/src/core/Payments.sol), [ServiceFeeDistributor.sol](https://github.com/tangle-network/tnt-core/blob/main/src/rewards/ServiceFeeDistributor.sol), [InflationPool.sol](https://github.com/tangle-network/tnt-core/blob/main/src/rewards/InflationPool.sol), [RewardVaults.sol](https://github.com/tangle-network/tnt-core/blob/main/src/rewards/RewardVaults.sol), [TangleMetrics.sol](https://github.com/tangle-network/tnt-core/blob/main/src/rewards/TangleMetrics.sol)
 
 ## Service Fees
 
@@ -60,8 +60,8 @@ The protocol can optionally record activity into a metrics contract (`TangleMetr
 
 ## Source Contracts (GitHub)
 
-- [`Payments.sol`](https://github.com/tangle-network/tnt-core/blob/v2/src/v2/core/Payments.sol)
-- [`ServiceFeeDistributor.sol`](https://github.com/tangle-network/tnt-core/blob/v2/src/v2/rewards/ServiceFeeDistributor.sol)
-- [`InflationPool.sol`](https://github.com/tangle-network/tnt-core/blob/v2/src/v2/rewards/InflationPool.sol)
-- [`RewardVaults.sol`](https://github.com/tangle-network/tnt-core/blob/v2/src/v2/rewards/RewardVaults.sol)
-- [`TangleMetrics.sol`](https://github.com/tangle-network/tnt-core/blob/v2/src/v2/rewards/TangleMetrics.sol)
+- [`Payments.sol`](https://github.com/tangle-network/tnt-core/blob/main/src/core/Payments.sol)
+- [`ServiceFeeDistributor.sol`](https://github.com/tangle-network/tnt-core/blob/main/src/rewards/ServiceFeeDistributor.sol)
+- [`InflationPool.sol`](https://github.com/tangle-network/tnt-core/blob/main/src/rewards/InflationPool.sol)
+- [`RewardVaults.sol`](https://github.com/tangle-network/tnt-core/blob/main/src/rewards/RewardVaults.sol)
+- [`TangleMetrics.sol`](https://github.com/tangle-network/tnt-core/blob/main/src/rewards/TangleMetrics.sol)

--- a/pages/network/incentives-stakers.mdx
+++ b/pages/network/incentives-stakers.mdx
@@ -47,18 +47,20 @@ Review delegator risks before choosing exposure and lock settings.
 
 ## Source Contracts (GitHub)
 
-- [`MultiAssetDelegation.sol`](https://github.com/tangle-network/tnt-core/blob/v2/src/v2/restaking/MultiAssetDelegation.sol)
-- [`RewardVaults.sol`](https://github.com/tangle-network/tnt-core/blob/v2/src/v2/rewards/RewardVaults.sol)
-- [`ServiceFeeDistributor.sol`](https://github.com/tangle-network/tnt-core/blob/v2/src/v2/rewards/ServiceFeeDistributor.sol)
-- [`InflationPool.sol`](https://github.com/tangle-network/tnt-core/blob/v2/src/v2/rewards/InflationPool.sol)
+- [`MultiAssetDelegation.sol`](https://github.com/tangle-network/tnt-core/blob/main/src/staking/MultiAssetDelegation.sol)
+- [`RewardVaults.sol`](https://github.com/tangle-network/tnt-core/blob/main/src/rewards/RewardVaults.sol)
+- [`ServiceFeeDistributor.sol`](https://github.com/tangle-network/tnt-core/blob/main/src/rewards/ServiceFeeDistributor.sol)
+- [`InflationPool.sol`](https://github.com/tangle-network/tnt-core/blob/main/src/rewards/InflationPool.sol)
 
 ## User Stories
 
 **Maya the staker**
+
 - She delegates 1,000 wstETH to a trusted operator in `Fixed` mode for two blueprints she understands.
 - She earns USDC fees from services on those blueprints and optional TNT incentives from the staking vault.
 - When the operator stops serving a blueprint, she removes it from her fixed list to reduce exposure.
 
 **Lee the integrator**
+
 - He builds a dashboard that shows stakers their estimated service-fee rewards.
 - He reads scores and pending rewards from `ServiceFeeDistributor`, and vault info from `RewardVaults`.

--- a/pages/network/launch.mdx
+++ b/pages/network/launch.mdx
@@ -14,7 +14,7 @@ Tangle is launching as a protocol stack on EVM: a coordination layer for agents 
 - **Migration tooling is live** for Substrate → EVM claims and direct EVM allocations.
 - **Incentives and credits are optional** modules that can be enabled by governance.
 
-Protocol contracts (GitHub): https://github.com/tangle-network/tnt-core/tree/v2/src/v2
+Protocol contracts (GitHub): https://github.com/tangle-network/tnt-core/tree/main/src
 
 ## Token Distribution and Lockups
 

--- a/pages/network/metrics-and-scoring.mdx
+++ b/pages/network/metrics-and-scoring.mdx
@@ -50,7 +50,7 @@ Merit-based rewards only exist if `InflationPool` is funded with TNT. If it has 
 
 ## Source Contracts (GitHub)
 
-- [`TangleMetrics.sol`](https://github.com/tangle-network/tnt-core/blob/v2/src/v2/rewards/TangleMetrics.sol)
-- [`InflationPool.sol`](https://github.com/tangle-network/tnt-core/blob/v2/src/v2/rewards/InflationPool.sol)
-- [`ServiceFeeDistributor.sol`](https://github.com/tangle-network/tnt-core/blob/v2/src/v2/rewards/ServiceFeeDistributor.sol)
-- [`OperatorStatusRegistry.sol`](https://github.com/tangle-network/tnt-core/blob/v2/src/v2/restaking/OperatorStatusRegistry.sol)
+- [`TangleMetrics.sol`](https://github.com/tangle-network/tnt-core/blob/main/src/rewards/TangleMetrics.sol)
+- [`InflationPool.sol`](https://github.com/tangle-network/tnt-core/blob/main/src/rewards/InflationPool.sol)
+- [`ServiceFeeDistributor.sol`](https://github.com/tangle-network/tnt-core/blob/main/src/rewards/ServiceFeeDistributor.sol)
+- [`OperatorStatusRegistry.sol`](https://github.com/tangle-network/tnt-core/blob/main/src/staking/OperatorStatusRegistry.sol)

--- a/pages/network/network-parameters.mdx
+++ b/pages/network/network-parameters.mdx
@@ -4,36 +4,36 @@ This page summarizes protocol-level defaults for the Tangle v2 (EVM) deployment.
 
 ## TNT Core Values
 
-| Parameter | Value |
-| --------- | ----- |
-| Name | Tangle Network Token |
-| Symbol | TNT |
-| Decimals | 18 |
+| Parameter             | Value                             |
+| --------------------- | --------------------------------- |
+| Name                  | Tangle Network Token              |
+| Symbol                | TNT                               |
+| Decimals              | 18                                |
 | Max supply (hard cap) | 109,255,636.91921292788561091 TNT |
 
-Source: https://github.com/tangle-network/tnt-core/blob/v2/src/v2/governance/TangleToken.sol
+Source: https://github.com/tangle-network/tnt-core/blob/main/src/governance/TangleToken.sol
 
 ## TNT Contract Addresses
 
-| Environment | Token Contract | Explorer |
-| ----------- | -------------- | -------- |
-| Mainnet | `TBD` | `TBD` |
-| Testnet | `0xa9ffe787eea7f385dac8481cd8bdc3d9194aeb5a` | https://testnet-explorer.tangle.tools/address/0xa9ffe787eea7f385dac8481cd8bdc3d9194aeb5a |
-| Local | `TBD` | `TBD` |
+| Environment | Token Contract                               | Explorer                                                                                 |
+| ----------- | -------------------------------------------- | ---------------------------------------------------------------------------------------- |
+| Mainnet     | `TBD`                                        | `TBD`                                                                                    |
+| Testnet     | `0xa9ffe787eea7f385dac8481cd8bdc3d9194aeb5a` | https://testnet-explorer.tangle.tools/address/0xa9ffe787eea7f385dac8481cd8bdc3d9194aeb5a |
+| Local       | `TBD`                                        | `TBD`                                                                                    |
 
 Testnet source: https://github.com/tangle-network/tnt-core/blob/v2/deployments/base-sepolia/latest.json
 
 ## Core Contract Addresses
 
-| Contract | Mainnet | Testnet | Local |
-| -------- | ------- | ------- | ----- |
-| `Tangle` | `TBD` | `0x1be58d12620ecc8ba9d780feec2596510d75a933` | `TBD` |
-| `MultiAssetDelegation` | `TBD` | `0x787dd1de4099ff8c68bfac11b82e4aed52c7f1e1` | `TBD` |
-| `OperatorStatusRegistry` | `TBD` | `0x20258c5e4cba66d4819a06045ff00d15775e64fb` | `TBD` |
-| `TangleMetrics` | `TBD` | `0x2057f94d04e4d667c4d5e60d23d2963358c00970` | `TBD` |
-| `RewardVaults` | `TBD` | `0x2963a51fec3e2cf51b19b848942d91296448a353` | `TBD` |
-| `InflationPool` | `TBD` | `0xe620f87540724a0cebdee9796dd8580e02dd4911` | `TBD` |
-| `Credits` | `TBD` | `0x758226e04478541fcdac605e1f235e2956259a10` | `TBD` |
+| Contract                 | Mainnet | Testnet                                      | Local |
+| ------------------------ | ------- | -------------------------------------------- | ----- |
+| `Tangle`                 | `TBD`   | `0x1be58d12620ecc8ba9d780feec2596510d75a933` | `TBD` |
+| `MultiAssetDelegation`   | `TBD`   | `0x787dd1de4099ff8c68bfac11b82e4aed52c7f1e1` | `TBD` |
+| `OperatorStatusRegistry` | `TBD`   | `0x20258c5e4cba66d4819a06045ff00d15775e64fb` | `TBD` |
+| `TangleMetrics`          | `TBD`   | `0x2057f94d04e4d667c4d5e60d23d2963358c00970` | `TBD` |
+| `RewardVaults`           | `TBD`   | `0x2963a51fec3e2cf51b19b848942d91296448a353` | `TBD` |
+| `InflationPool`          | `TBD`   | `0xe620f87540724a0cebdee9796dd8580e02dd4911` | `TBD` |
+| `Credits`                | `TBD`   | `0x758226e04478541fcdac605e1f235e2956259a10` | `TBD` |
 
 ## Protocol Defaults (v2)
 
@@ -41,33 +41,34 @@ Defaults are defined in `TangleStorage` and `ProtocolConfig` and can be overridd
 
 ### Fee and Security Defaults
 
-| Parameter | Value |
-| --------- | ----- |
+| Parameter                   | Value                                                      |
+| --------------------------- | ---------------------------------------------------------- |
 | Service fee split (default) | 20% developer / 20% protocol / 40% operators / 20% stakers |
-| Default TNT min exposure | 10% (1000 bps) |
-| TNT payment discount | 0 bps |
-| Aggregation threshold | 67% (6700 bps) |
+| Default TNT min exposure    | 10% (1000 bps)                                             |
+| TNT payment discount        | 0 bps                                                      |
+| Aggregation threshold       | 67% (6700 bps)                                             |
 
 ### Timing Defaults
 
-| Parameter | Value |
-| --------- | ----- |
-| Round duration | 6 hours |
-| Rounds per epoch | 28 (7 days) |
-| Delegator unstake delay | 28 rounds (7 days) |
-| Operator exit delay | 56 rounds (14 days) |
-| Dispute window | 14 rounds (3.5 days) |
-| Reward grace period | 4 rounds (24 hours) |
-| Min service commitment | 1 day |
-| Exit queue duration | 7 days |
-| Min service TTL | 1 hour |
-| Max service TTL | 365 days |
-| Request expiry grace | 1 hour |
-| Max quote age | 1 hour |
+| Parameter               | Value                |
+| ----------------------- | -------------------- |
+| Round duration          | 6 hours              |
+| Rounds per epoch        | 28 (7 days)          |
+| Delegator unstake delay | 28 rounds (7 days)   |
+| Operator exit delay     | 56 rounds (14 days)  |
+| Dispute window          | 14 rounds (3.5 days) |
+| Reward grace period     | 4 rounds (24 hours)  |
+| Min service commitment  | 1 day                |
+| Exit queue duration     | 7 days               |
+| Min service TTL         | 1 hour               |
+| Max service TTL         | 365 days             |
+| Request expiry grace    | 1 hour               |
+| Max quote age           | 1 hour               |
 
 Sources:
-- https://github.com/tangle-network/tnt-core/blob/v2/src/v2/TangleStorage.sol
-- https://github.com/tangle-network/tnt-core/blob/v2/src/v2/config/ProtocolConfig.sol
+
+- https://github.com/tangle-network/tnt-core/blob/main/src/TangleStorage.sol
+- https://github.com/tangle-network/tnt-core/blob/main/src/config/ProtocolConfig.sol
 
 ## Host Chain Parameters
 

--- a/pages/network/overview.mdx
+++ b/pages/network/overview.mdx
@@ -7,15 +7,19 @@ import ExpandableImage from "../../components/ExpandableImage";
 Tangle is the shared operating layer for autonomous work. The protocol coordinates operator-run services and routes payments. Developers publish Blueprints, users instantiate them on demand, and operators run them for a fee.
 
 ## Today vs Future
+
 Today the protocol ships with managed onboarding and a curated operator set. Over time it evolves into an open marketplace where operators host runtime services and earn based on reliability and usage.
 
 ## Build Composable Services
+
 Blueprints are composable services that can be instantiated by users. They are built using the [Blueprint SDK](https://github.com/tangle-network/blueprint/tree/v2) and can integrate with external security providers when needed.
 
 ## Earn as a Service Operator
+
 Operators can earn rewards by operating Blueprint instances requested by users. Operators register for Blueprints and maintain control over the services they run, selecting the resources they want to expose for securing the Blueprint.
 
 ## Maximize Resource Utilization
+
 Tangle enables shared security across Blueprints, allowing operators to secure multiple Blueprints with a single pool of resources and participants to earn rewards proportional to the value secured.
 
 ## Who This Is For

--- a/pages/network/points-mechanics.mdx
+++ b/pages/network/points-mechanics.mdx
@@ -30,11 +30,11 @@ Contract source (GitHub): https://github.com/tangle-network/tnt-core/blob/v2/pac
 
 We will publish the contract addresses as each environment is deployed.
 
-| Environment | Credits Contract | Explorer |
-| ----------- | ---------------- | -------- |
-| Mainnet     | `TBD`            | `TBD`    |
+| Environment | Credits Contract                             | Explorer                                                                                 |
+| ----------- | -------------------------------------------- | ---------------------------------------------------------------------------------------- |
+| Mainnet     | `TBD`                                        | `TBD`                                                                                    |
 | Testnet     | `0x758226e04478541fcdac605e1f235e2956259a10` | https://testnet-explorer.tangle.tools/address/0x758226e04478541fcdac605e1f235e2956259a10 |
-| Local       | `TBD`            | `TBD`    |
+| Local       | `TBD`                                        | `TBD`                                                                                    |
 
 Testnet source: https://github.com/tangle-network/tnt-core/blob/v2/deployments/base-sepolia/latest.json
 

--- a/pages/network/tokenomics/allocation.mdx
+++ b/pages/network/tokenomics/allocation.mdx
@@ -19,14 +19,14 @@ distribution contracts and migration snapshot files; the table below is a readab
 
 ## Allocation Summary
 
-| Category | Purpose | Amount (TNT) | Share | Vesting |
-| -------- | ------- | ------------ | ----- | ------- |
-| Substrate migration claims | SS58 snapshot claims via Merkle tree | 51,244,581.8122 | 46.90% | 2% unlocked + 12m cliff + 24m linear |
-| EVM allocations | Direct EVM recipient list | 1,125,776.5192 | 1.03% | 2% unlocked + 12m cliff + 24m linear |
-| Treasury carveout | Non-claimable module balances | 36,844,468.7611 | 33.72% | Liquid at deployment |
-| Foundation carveout | Foundation allocation | 15,040,809.8267 | 13.77% | Liquid at deployment |
-| Liquidity ops carveout | Liquidity operations budget | 5,000,000 | 4.58% | Liquid at deployment |
-| **Total (MAX_SUPPLY)** | Hard cap from `TangleToken` | 109,255,636.9192 | 100% | — |
+| Category                   | Purpose                              | Amount (TNT)     | Share  | Vesting                              |
+| -------------------------- | ------------------------------------ | ---------------- | ------ | ------------------------------------ |
+| Substrate migration claims | SS58 snapshot claims via Merkle tree | 51,244,581.8122  | 46.90% | 2% unlocked + 12m cliff + 24m linear |
+| EVM allocations            | Direct EVM recipient list            | 1,125,776.5192   | 1.03%  | 2% unlocked + 12m cliff + 24m linear |
+| Treasury carveout          | Non-claimable module balances        | 36,844,468.7611  | 33.72% | Liquid at deployment                 |
+| Foundation carveout        | Foundation allocation                | 15,040,809.8267  | 13.77% | Liquid at deployment                 |
+| Liquidity ops carveout     | Liquidity operations budget          | 5,000,000        | 4.58%  | Liquid at deployment                 |
+| **Total (MAX_SUPPLY)**     | Hard cap from `TangleToken`          | 109,255,636.9192 | 100%   | —                                    |
 
 ## Vesting and Lockups
 
@@ -40,7 +40,7 @@ For legacy allocations and migration details, see [TNT Migration and Claims](/ne
 
 ## Source of Truth (GitHub)
 
-- Token cap: https://github.com/tangle-network/tnt-core/blob/v2/src/v2/governance/TangleToken.sol
+- Token cap: https://github.com/tangle-network/tnt-core/blob/main/src/governance/TangleToken.sol
 - Substrate Merkle snapshot: https://github.com/tangle-network/tnt-core/blob/v2/packages/migration-claim/merkle-tree.json
 - EVM recipient list: https://github.com/tangle-network/tnt-core/blob/v2/packages/migration-claim/evm-claims.json
 - Treasury carveout: https://github.com/tangle-network/tnt-core/blob/v2/packages/migration-claim/treasury-carveout.json
@@ -51,8 +51,8 @@ For legacy allocations and migration details, see [TNT Migration and Claims](/ne
 
 | Environment | Distribution Contract | Explorer |
 | ----------- | --------------------- | -------- |
-| Mainnet | `TBD` | `TBD` |
-| Testnet | `TBD` | `TBD` |
-| Local | `TBD` | `TBD` |
+| Mainnet     | `TBD`                 | `TBD`    |
+| Testnet     | `TBD`                 | `TBD`    |
+| Local       | `TBD`                 | `TBD`    |
 
 The summary will be kept in sync with these contracts.

--- a/pages/network/tokenomics/inflation.mdx
+++ b/pages/network/tokenomics/inflation.mdx
@@ -14,8 +14,9 @@ If governance allocates TNT to incentives, funds are deposited into `InflationPo
 See [Incentives](/network/incentives-overview) and [Metrics and Scoring](/network/metrics-and-scoring) for the full model.
 
 Source contracts:
-- https://github.com/tangle-network/tnt-core/blob/v2/src/v2/rewards/InflationPool.sol
-- https://github.com/tangle-network/tnt-core/blob/v2/src/v2/rewards/RewardVaults.sol
+
+- https://github.com/tangle-network/tnt-core/blob/main/src/rewards/InflationPool.sol
+- https://github.com/tangle-network/tnt-core/blob/main/src/rewards/RewardVaults.sol
 
 ## Service Fees Are Separate
 

--- a/pages/operators/manager/introduction.mdx
+++ b/pages/operators/manager/introduction.mdx
@@ -2,7 +2,6 @@
 
 SDK source (GitHub): https://github.com/tangle-network/blueprint/tree/v2/crates/manager
 
-
 The Blueprint Manager is the operator-side runtime that turns on-chain services into running off-chain infrastructure.
 
 At a high level, the Blueprint Manager:

--- a/pages/operators/manager/requirements.mdx
+++ b/pages/operators/manager/requirements.mdx
@@ -2,7 +2,6 @@
 
 SDK source (GitHub): https://github.com/tangle-network/blueprint/tree/v2/crates/manager
 
-
 Blueprints can be executed in multiple ways (see [Sources](/developers/deployment/sources/introduction)), with each requiring
 certain dependencies, and possibly hardware.
 

--- a/pages/operators/manager/security.mdx
+++ b/pages/operators/manager/security.mdx
@@ -2,7 +2,6 @@
 
 SDK source (GitHub): https://github.com/tangle-network/blueprint/tree/v2/crates/manager
 
-
 Running the Blueprint Manager in production should prioritize isolation and key safety. The recommendations below assume Tangle's EVM protocol.
 
 ## Recommended: VM sandbox for native blueprints (Linux)

--- a/pages/operators/manager/setup.mdx
+++ b/pages/operators/manager/setup.mdx
@@ -2,7 +2,6 @@
 
 SDK source (GitHub): https://github.com/tangle-network/blueprint/tree/v2/crates/manager
 
-
 This page covers the operator flow for configuring and running the Blueprint Manager against Tangle's EVM protocol.
 
 ## 1) Create a settings file

--- a/pages/operators/manager/sizing.mdx
+++ b/pages/operators/manager/sizing.mdx
@@ -2,16 +2,15 @@
 
 SDK source (GitHub): https://github.com/tangle-network/blueprint/tree/v2/crates/manager
 
-
 Blueprints vary widely in resource needs. Use the guidance below as a starting point and adjust based on the specific blueprint workloads you operate.
 
 ## Suggested tiers
 
-| Tier | Use case | vCPU | RAM | Storage | Notes |
-| --- | --- | --- | --- | --- | --- |
-| Dev / Test | Local validation, dry runs | 2-4 | 8-16 GB | 50+ GB SSD | Single service, minimal load |
-| Standard | Single blueprint, steady traffic | 8 | 32 GB | 200+ GB SSD | Good baseline for production |
-| High Throughput | Multiple services or heavy workloads | 16+ | 64-128 GB | 500+ GB NVMe | Reserve headroom for spikes |
+| Tier            | Use case                             | vCPU | RAM       | Storage      | Notes                        |
+| --------------- | ------------------------------------ | ---- | --------- | ------------ | ---------------------------- |
+| Dev / Test      | Local validation, dry runs           | 2-4  | 8-16 GB   | 50+ GB SSD   | Single service, minimal load |
+| Standard        | Single blueprint, steady traffic     | 8    | 32 GB     | 200+ GB SSD  | Good baseline for production |
+| High Throughput | Multiple services or heavy workloads | 16+  | 64-128 GB | 500+ GB NVMe | Reserve headroom for spikes  |
 
 ## Storage planning
 

--- a/pages/operators/pricing/overview.mdx
+++ b/pages/operators/pricing/overview.mdx
@@ -6,8 +6,7 @@ title: Blueprint Pricing
 
 SDK source (GitHub): https://github.com/tangle-network/blueprint/tree/v2/crates/pricing-engine
 
-Operator preferences interface (GitHub): https://github.com/tangle-network/tnt-core/blob/v2/src/v2/interfaces/ITangleOperators.sol
-
+Operator preferences interface (GitHub): https://github.com/tangle-network/tnt-core/blob/main/src/interfaces/ITangleOperators.sol
 
 As a blueprint operator, you'll need to set up pricing for your services to receive fair compensation for the resources you provide. This guide explains how pricing works in the Tangle Network and how to configure it properly.
 

--- a/pages/operators/quality-of-service.mdx
+++ b/pages/operators/quality-of-service.mdx
@@ -10,11 +10,11 @@ QoS is the observability layer for running Blueprints. As an operator, you decid
 
 QoS uses Prometheus-compatible metrics by default, with optional Grafana and Loki.
 
-| Component | Default Endpoint | Notes |
-| --- | --- | --- |
-| Prometheus metrics | `http://<host>:9090/metrics` | Includes `/health` plus Prometheus v1 API routes like `/api/v1/query`. |
-| Grafana UI | `http://<host>:3000` | Only when configured or managed by QoS. |
-| Loki push API | `http://<host>:3100/loki/api/v1/push` | Only when configured or managed by QoS. |
+| Component          | Default Endpoint                      | Notes                                                                  |
+| ------------------ | ------------------------------------- | ---------------------------------------------------------------------- |
+| Prometheus metrics | `http://<host>:9090/metrics`          | Includes `/health` plus Prometheus v1 API routes like `/api/v1/query`. |
+| Grafana UI         | `http://<host>:3000`                  | Only when configured or managed by QoS.                                |
+| Loki push API      | `http://<host>:3100/loki/api/v1/push` | Only when configured or managed by QoS.                                |
 
 ## Managed Stack vs External Stack
 

--- a/pages/staking/incentives/claiming.mdx
+++ b/pages/staking/incentives/claiming.mdx
@@ -21,10 +21,12 @@ This page answers three common questions:
 ## Delegator (Staker)
 
 **Where rewards accrue**
+
 - **Service fees + staker inflation:** `ServiceFeeDistributor` (per payment token).
 - **TNT incentives:** `RewardVaults` (per staking asset).
 
 **How to visualize**
+
 - `ServiceFeeDistributor.pendingRewards(delegator, token)`
 - `ServiceFeeDistributor.delegatorOperators(delegator)` and `delegatorAssets(delegator, operator)`
 - `RewardVaults.pendingDelegatorRewards(asset, delegator, operator)`
@@ -32,55 +34,67 @@ This page answers three common questions:
 - `RewardVaults.getDelegatorPositions(asset, delegator)`
 
 **How to claim**
+
 - **Per token:** `ServiceFeeDistributor.claimAll(token)`
 - **Multiple tokens in one tx:** `ServiceFeeDistributor.claimAllBatch(tokens)`
 - **TNT incentives:** `RewardVaults.claimDelegatorRewardsBatch(asset, operators)`
 
 **Tx count expectation**
+
 - 1 tx per token in `ServiceFeeDistributor`, plus 1 tx per asset in `RewardVaults` (or use multicall).
 
 ## Operator
 
 **Where rewards accrue**
+
 - **Service fee operator share:** `Tangle` pending rewards per payment token.
 - **TNT operator incentives:** `InflationPool` pending operator rewards.
 - **Optional TNT commission (from delegators):** `RewardVaults` pending commission per asset.
 
 **How to visualize**
+
 - `Tangle.rewardTokens(operator)` + `Tangle.pendingRewards(operator, token)`
 - `InflationPool.pendingOperatorRewards(operator)`
 - `RewardVaults.pendingOperatorCommission(asset, operator)`
 
 **How to claim**
+
 - **All tokens:** `Tangle.claimRewardsAll()`
 - **Specific tokens:** `Tangle.claimRewardsBatch(tokens)`
 - **Inflation incentives:** `InflationPool.claimOperatorRewards()`
 - **Vault commission:** `RewardVaults.claimOperatorCommission(asset)`
 
 **Tx count expectation**
+
 - 1 tx for all operator service-fee tokens + 1 tx for InflationPool + 1 tx per reward-vault asset.
 
 ## Customer
 
 **Where rewards accrue**
+
 - **Optional TNT incentives:** `InflationPool` pending customer rewards (only if weights allocate customer incentives).
 
 **How to visualize**
+
 - `InflationPool.pendingCustomerRewards(customer)`
 
 **How to claim**
+
 - `InflationPool.claimCustomerRewards()` (single tx)
 
 ## Developer
 
 **Where rewards accrue**
+
 - **Service fees:** paid directly to the developer address at payment time (no claim).
 - **Optional TNT incentives:** `InflationPool` pending developer rewards.
 
 **How to visualize**
+
 - `InflationPool.pendingDeveloperRewards(developer)`
 
 **How to claim**
+
 - `InflationPool.claimDeveloperRewards()` (single tx)
 
 ## When To Use Multicall

--- a/pages/staking/incentives/how_rewards_work.mdx
+++ b/pages/staking/incentives/how_rewards_work.mdx
@@ -15,7 +15,7 @@ Staking incentives on Tangle come from two sources:
 If you delegate to an operator that runs useful services, you earn:
 
 - **A share of the fees** those services pay (in the same token the customer used).
-- **Optional TNT incentives** when the protocol has funded an incentives budget — *“I also earn TNT from RewardVaults plus optional staker inflation.”*
+- **Optional TNT incentives** when the protocol has funded an incentives budget — _“I also earn TNT from RewardVaults plus optional staker inflation.”_
 
 You choose your exposure scope (All vs Fixed), and your share is calculated from your delegated amount and lock multiplier.
 
@@ -42,6 +42,7 @@ You choose your exposure scope (All vs Fixed), and your share is calculated from
 ## How To Get Rewarded (Practical Steps)
 
 **As a staker**
+
 - Deposit and delegate in `MultiAssetDelegation`.
 - Choose `All` or `Fixed` blueprint selection.
 - Optional: add a lock multiplier for a higher reward score.
@@ -50,12 +51,14 @@ You choose your exposure scope (All vs Fixed), and your share is calculated from
   - Service-fee + staker-inflation rewards from `ServiceFeeDistributor`.
 
 **As an operator**
+
 - Self-stake `minOperatorStake` to register.
 - Join services and set exposure and commitments responsibly.
 - Claim operator service fees from the core protocol.
 - Claim TNT commission from `RewardVaults` if you opt into commission.
 
 **As a blueprint developer**
+
 - Publish a blueprint and manage services.
 - Earn the developer split from each service payment.
 

--- a/pages/staking/incentives/vaults.mdx
+++ b/pages/staking/incentives/vaults.mdx
@@ -14,7 +14,7 @@ In Tangle documentation, “vault” can refer to different on-chain components.
 - Vaults are configured by governance (deposit cap + active status).
 - Rewards are funded from `InflationPool` (pre-funded, no minting).
 - Rewards are split across delegators by score (principal × lock multiplier), and operators can take a commission.
- - Deposit caps are hard limits: deposits above the cap are rejected until capacity is freed.
+- Deposit caps are hard limits: deposits above the cap are rejected until capacity is freed.
 
 Why this exists:
 

--- a/pages/staking/liquid-staking/introduction.mdx
+++ b/pages/staking/liquid-staking/introduction.mdx
@@ -33,8 +33,8 @@ Liquid delegation vaults manage delegation and redemption. Incentives and servic
 
 Reward claim surfaces live in the protocol:
 
-- **Service fees** are claimed through [`ServiceFeeDistributor.sol`](https://github.com/tangle-network/tnt-core/blob/v2/src/v2/rewards/ServiceFeeDistributor.sol).
-- **TNT incentives** are claimed through [`RewardVaults.sol`](https://github.com/tangle-network/tnt-core/blob/v2/src/v2/rewards/RewardVaults.sol).
+- **Service fees** are claimed through [`ServiceFeeDistributor.sol`](https://github.com/tangle-network/tnt-core/blob/main/src/rewards/ServiceFeeDistributor.sol).
+- **TNT incentives** are claimed through [`RewardVaults.sol`](https://github.com/tangle-network/tnt-core/blob/main/src/rewards/RewardVaults.sol).
 
 The vault does not automatically distribute those rewards to share holders; integrators need to wire a distribution path if they want reward pass-through.
 
@@ -42,14 +42,14 @@ See [Claiming Cheatsheet](/staking/incentives/claiming) for function-level claim
 
 ## Core Contracts (GitHub)
 
-- [`LiquidDelegationVault.sol`](https://github.com/tangle-network/tnt-core/blob/v2/src/v2/restaking/LiquidDelegationVault.sol)
-- [`LiquidDelegationFactory.sol`](https://github.com/tangle-network/tnt-core/blob/v2/src/v2/restaking/LiquidDelegationFactory.sol)
-- [`MultiAssetDelegation.sol`](https://github.com/tangle-network/tnt-core/blob/v2/src/v2/restaking/MultiAssetDelegation.sol)
+- [`LiquidDelegationVault.sol`](https://github.com/tangle-network/tnt-core/blob/main/src/staking/LiquidDelegationVault.sol)
+- [`LiquidDelegationFactory.sol`](https://github.com/tangle-network/tnt-core/blob/main/src/staking/LiquidDelegationFactory.sol)
+- [`MultiAssetDelegation.sol`](https://github.com/tangle-network/tnt-core/blob/main/src/staking/MultiAssetDelegation.sol)
 
 ## Related Interfaces (GitHub)
 
-- [`IERC7540.sol`](https://github.com/tangle-network/tnt-core/blob/v2/src/v2/interfaces/IERC7540.sol)
-- [`IMultiAssetDelegation.sol`](https://github.com/tangle-network/tnt-core/blob/v2/src/v2/interfaces/IMultiAssetDelegation.sol)
+- [`IERC7540.sol`](https://github.com/tangle-network/tnt-core/blob/main/src/interfaces/IERC7540.sol)
+- [`IMultiAssetDelegation.sol`](https://github.com/tangle-network/tnt-core/blob/main/src/interfaces/IMultiAssetDelegation.sol)
 
 ## Next Steps
 

--- a/pages/staking/liquid-staking/staking-flow.mdx
+++ b/pages/staking/liquid-staking/staking-flow.mdx
@@ -26,11 +26,11 @@ The delay is the maximum of `delegationBondLessDelay` and `leaveDelegatorsDelay`
 
 Delays are expressed in **rounds**. To convert to time, multiply by `roundDuration`.
 
-| Delay | Source | What It Controls |
-| ----- | ------ | ---------------- |
-| `delegationBondLessDelay` | `MultiAssetDelegation` | Minimum rounds before a redeem request is claimable. |
-| `leaveDelegatorsDelay` | `MultiAssetDelegation` | Additional delay before exits finalize (vault uses the max of both). |
-| `roundDuration` | `MultiAssetDelegation` | Length of a round; used to translate delays into wall-clock time. |
+| Delay                     | Source                 | What It Controls                                                     |
+| ------------------------- | ---------------------- | -------------------------------------------------------------------- |
+| `delegationBondLessDelay` | `MultiAssetDelegation` | Minimum rounds before a redeem request is claimable.                 |
+| `leaveDelegatorsDelay`    | `MultiAssetDelegation` | Additional delay before exits finalize (vault uses the max of both). |
+| `roundDuration`           | `MultiAssetDelegation` | Length of a round; used to translate delays into wall-clock time.    |
 
 See [Protocol Parameters](/network/network-parameters) for current defaults.
 

--- a/pages/vibe/profile-schema.mdx
+++ b/pages/vibe/profile-schema.mdx
@@ -57,6 +57,7 @@ The `tools` map enables or disables individual tools by name. This is the primar
 The `mcp` field defines allowlisted tool servers. Each entry is either:
 
 - **Local**
+
   - `type`: `local`
   - `command`: array of command arguments
   - `environment`: optional env map

--- a/pages/vision/architecture.mdx
+++ b/pages/vision/architecture.mdx
@@ -17,11 +17,11 @@ Tangle ties together three layers most platforms separate: the workbench where w
 
 ## What Runs Where
 
-| Layer | Runs here | Examples |
-| --- | --- | --- |
-| Workbench | Human and agent collaboration | Workflows, profiles, simulations, reviews |
-| Sandbox runtime | Executed tasks and tools | Agent sessions, tool calls, file edits |
-| Protocol | Coordination and settlement | Service registry, operator payments, staking, incentives |
+| Layer           | Runs here                     | Examples                                                 |
+| --------------- | ----------------------------- | -------------------------------------------------------- |
+| Workbench       | Human and agent collaboration | Workflows, profiles, simulations, reviews                |
+| Sandbox runtime | Executed tasks and tools      | Agent sessions, tool calls, file edits                   |
+| Protocol        | Coordination and settlement   | Service registry, operator payments, staking, incentives |
 
 ## System Architecture
 


### PR DESCRIPTION
## Summary
Fixes CI failures on v2 branch:

### Link Fixes
- Changed branch references from `v2` to `main` in tnt-core GitHub URLs
- Changed `src/v2/interfaces/` to `src/interfaces/`
- Changed `src/restaking/` to `src/staking/`
- Changed `IRestaking.sol` to `IStaking.sol`

### Formatting
- Fixed all 112 files with prettier formatting issues

### Lychee Config
- Updated `.lycheeignore` for testnet explorer 401s (links are valid but return unauthorized to bots)

### Known Issues (not fixed)
Some repo links return 404 - these repos may not exist yet:
- `hyperbridge-relayer-blueprint`
- `hyperlane-ism-blueprint-template`