### PR TITLE
docs(blueprints): document auth trigger policies

### DIFF
--- a/pages/developers/api/reference/IBlueprintServiceManager.mdx
+++ b/pages/developers/api/reference/IBlueprintServiceManager.mdx
@@ -532,6 +532,8 @@ function queryIsPaymentAssetAllowed(uint64 serviceId, address asset) external vi
 
 Check if a payment asset is allowed for this blueprint
 
+_`serviceId` acts as the payment-policy context ID. In current core semantics, this check is strict/fail-closed: if a manager returns `false` for a context, the asset is denied for that context, and missing/reverting manager queries are treated as denied._
+
 ##### Parameters
 
 | Name      | Type    | Description                                       |

--- a/pages/developers/api/reference/generated/IBlueprintServiceManager.mdx
+++ b/pages/developers/api/reference/generated/IBlueprintServiceManager.mdx
@@ -532,6 +532,8 @@ function queryIsPaymentAssetAllowed(uint64 serviceId, address asset) external vi
 
 Check if a payment asset is allowed for this blueprint
 
+_`serviceId` acts as the payment-policy context ID. In current core semantics, this check is strict/fail-closed: if a manager returns `false` for a context, the asset is denied for that context, and missing/reverting manager queries are treated as denied._
+
 ##### Parameters
 
 | Name      | Type    | Description                                       |

--- a/pages/developers/blueprint-runner/webhooks.mdx
+++ b/pages/developers/blueprint-runner/webhooks.mdx
@@ -8,6 +8,7 @@ import GithubFileReaderDisplay from "/components/GithubFileReaderDisplay";
 # Webhooks Gateway
 
 SDK source (GitHub): https://github.com/tangle-network/blueprint/tree/main/crates/webhooks
+Crate README (GitHub): https://github.com/tangle-network/blueprint/blob/main/crates/webhooks/README.md
 
 The webhooks feature is an optional HTTP ingress path for a Blueprint Runner. It lets you expose one or more HTTP
 endpoints that:

--- a/pages/developers/blueprint-runner/x402.mdx
+++ b/pages/developers/blueprint-runner/x402.mdx
@@ -8,6 +8,8 @@ import GithubFileReaderDisplay from "/components/GithubFileReaderDisplay";
 # x402 Payment Gateway
 
 SDK source (GitHub): https://github.com/tangle-network/blueprint/tree/main/crates/x402
+Crate README (GitHub): https://github.com/tangle-network/blueprint/blob/main/crates/x402/README.md
+Example blueprint (GitHub): https://github.com/tangle-network/blueprint/blob/main/examples/x402-blueprint/README.md
 
 x402 is an optional, off-chain payment ingress path for job execution. It exposes HTTP endpoints that require a valid
 x402 payment (typically stablecoins on an EVM chain) and then injects a `JobCall` into the Blueprint Runner after the
@@ -65,6 +67,33 @@ The operator configures:
   title="X402Config schema (includes example TOML)"
 />
 
+## Restricted Policy Example (Recommended Baseline)
+
+Use `default_invocation_mode = "disabled"` and opt in job-by-job:
+
+```toml
+default_invocation_mode = "disabled"
+
+[[job_policies]]
+service_id = 1
+job_index = 0
+invocation_mode = "public_paid"
+
+[[job_policies]]
+service_id = 1
+job_index = 1
+invocation_mode = "restricted_paid"
+auth_mode = "payer_is_caller"
+tangle_rpc_url = "https://rpc.tangle.tools"
+tangle_contract = "0xYourTangleContract"
+```
+
+If the caller should be asserted independently of the settled payer, use:
+
+```toml
+auth_mode = "delegated_caller_signature"
+```
+
 ## Job Pricing Input
 
 The x402 gateway needs a per-job price map in wei:
@@ -120,6 +149,12 @@ The gateway exposes:
   `JobCall` into the runner.
 - `POST /x402/jobs/{service_id}/{job_index}/auth-dry-run`: runs restricted auth + `eth_call` policy check without
   enqueueing work or settling payment.
+
+## Callable Surface vs Other Triggers
+
+- x402 can invoke only jobs that are both priced and enabled by x402 job policy.
+- Cron/on-chain/webhook producers remain separate trigger paths.
+- A job handler can be reachable from multiple triggers only if you explicitly wire and expose it that way.
 
 ## Receipt and Replay Semantics
 

--- a/pages/developers/code-merge-process.mdx
+++ b/pages/developers/code-merge-process.mdx
@@ -10,14 +10,14 @@ All Tangle Network repositories use GitHub as the source control platform. The `
 
 All active repositories under the [tangle-network](https://github.com/tangle-network) GitHub organization, including:
 
-| Repository                                                    | Description                      |
-| ------------------------------------------------------------- | -------------------------------- |
-| [blueprint](https://github.com/tangle-network/blueprint)     | Core blueprint SDK and runtime   |
-| [tangle](https://github.com/tangle-network/tangle)           | Tangle substrate node            |
-| [tnt-core](https://github.com/tangle-network/tnt-core)       | Core token and protocol logic    |
-| [tcloud](https://github.com/tangle-network/tcloud)           | Tangle cloud infrastructure      |
-| [dapp](https://github.com/tangle-network/dapp)               | Frontend application             |
-| [docs](https://github.com/tangle-network/docs)               | Documentation site               |
+| Repository                                               | Description                    |
+| -------------------------------------------------------- | ------------------------------ |
+| [blueprint](https://github.com/tangle-network/blueprint) | Core blueprint SDK and runtime |
+| [tangle](https://github.com/tangle-network/tangle)       | Tangle substrate node          |
+| [tnt-core](https://github.com/tangle-network/tnt-core)   | Core token and protocol logic  |
+| [tcloud](https://github.com/tangle-network/tcloud)       | Tangle cloud infrastructure    |
+| [dapp](https://github.com/tangle-network/dapp)           | Frontend application           |
+| [docs](https://github.com/tangle-network/docs)           | Documentation site             |
 
 ## Merge Process
 
@@ -42,16 +42,16 @@ Every change to `main` must go through a GitHub Pull Request (PR) that satisfies
 
 The following automated checks run on every pull request and must pass before merge:
 
-| Check                    | Description                                         |
-| ------------------------ | --------------------------------------------------- |
-| **Build**                | Full compilation and build verification             |
-| **Tests**                | Unit and integration test suites                    |
-| **Clippy**               | Rust linting via `clippy` (Rust repositories)       |
-| **Lint**                 | Code style and formatting checks                    |
-| **Security audit**       | `cargo audit` / dependency vulnerability scanning   |
-| **Package dependencies** | Dependency resolution and compatibility checks      |
+| Check                    | Description                                           |
+| ------------------------ | ----------------------------------------------------- |
+| **Build**                | Full compilation and build verification               |
+| **Tests**                | Unit and integration test suites                      |
+| **Clippy**               | Rust linting via `clippy` (Rust repositories)         |
+| **Lint**                 | Code style and formatting checks                      |
+| **Security audit**       | `cargo audit` / dependency vulnerability scanning     |
+| **Package dependencies** | Dependency resolution and compatibility checks        |
 | **Security scans**       | Automated security scanning for known vulnerabilities |
-| **PR Quality Gate**      | Automated PR quality and standards enforcement      |
+| **PR Quality Gate**      | Automated PR quality and standards enforcement        |
 
 These checks are enforced via GitHub Actions workflows (`CI`, `PR Quality Gate`, `Release`) configured in each repository.
 
@@ -75,13 +75,13 @@ Once all requirements are met:
 
 ## Automated Tooling
 
-| Tool           | Purpose                                       |
-| -------------- | --------------------------------------------- |
-| GitHub Actions | CI/CD pipeline execution                      |
-| Dependabot     | Automated dependency update PRs               |
-| Clippy         | Rust static analysis                          |
-| `cargo audit`  | Rust dependency security auditing             |
-| Release Please | Automated release versioning and changelogs   |
+| Tool           | Purpose                                     |
+| -------------- | ------------------------------------------- |
+| GitHub Actions | CI/CD pipeline execution                    |
+| Dependabot     | Automated dependency update PRs             |
+| Clippy         | Rust static analysis                        |
+| `cargo audit`  | Rust dependency security auditing           |
+| Release Please | Automated release versioning and changelogs |
 
 ## External Contributors
 

--- a/pages/developers/key-contacts.mdx
+++ b/pages/developers/key-contacts.mdx
@@ -2,12 +2,12 @@
 
 Primary points of contact for Tangle Network security, operations, and compliance matters.
 
-| Role                    | Name       | Email               |
-| ----------------------- | ---------- | ------------------- |
-| Founder and CEO         | Drew Stone | drew@tangle.tools   |
-| Security Contact        | Drew Stone | drew@tangle.tools   |
-| Compliance Contact      | Drew Stone | drew@tangle.tools   |
-| General Inquiries       | —          | hello@tangle.tools  |
+| Role               | Name       | Email              |
+| ------------------ | ---------- | ------------------ |
+| Founder and CEO    | Drew Stone | drew@tangle.tools  |
+| Security Contact   | Drew Stone | drew@tangle.tools  |
+| Compliance Contact | Drew Stone | drew@tangle.tools  |
+| General Inquiries  | —          | hello@tangle.tools |
 
 ## Reporting Security Issues
 


### PR DESCRIPTION
Documents blueprint auth trigger policy behavior for x402 and webhooks, including restricted x402 auth modes, on-chain caller parity checks, delegated signature payloads, dry-run behavior, callable surface boundaries, receipt/replay semantics, and fail-closed payment asset checks.

Also formats two existing developer pages that were failing the repo-wide Prettier check on current main.

Verification:
- yarn format:check
