### PR TITLE
docs: align with unified approveService + expireServiceRequest

### DIFF
--- a/pages/developers/api/reference/ITangleServices.mdx
+++ b/pages/developers/api/reference/ITangleServices.mdx
@@ -50,36 +50,40 @@ Get resource requirements for a service request
 #### approveService
 
 ```solidity
-function approveService(uint64 requestId, uint8 stakingPercent) external
+function approveService(struct Types.ApprovalParams params) external
 ```
 
-Approve a service request (as operator) - simple version
+Approve a service request as one of its operators.
 
-#### approveServiceWithCommitments
+_Single entrypoint covering every approval mode. Pass empty/zero fields on `ApprovalParams` to opt out of the corresponding capability:_
+
+- `securityCommitments == []` — no per-asset commitment supplied. Only valid when the request has no security requirements OR the only requirement is the protocol-default TNT requirement (auto-filled at min-exposure).
+- `blsPubkey == [0,0,0,0]` — operator does NOT register a BLS pubkey for aggregated job-result signing. BLS is opt-in; the protocol accepts any operator.
+- `teeCommitments == []` — operator does NOT bind to a TEE attestation profile.
+
+#### getTeeCommitmentRoot
 
 ```solidity
-function approveServiceWithCommitments(uint64 requestId, struct Types.AssetSecurityCommitment[] commitments) external
+function getTeeCommitmentRoot(uint64 serviceId, address operator) external view returns (bytes32)
 ```
 
-Approve a service request with multi-asset security commitments
+Returns `keccak256(abi.encode(commitments))` over an operator's `TeeAttestationCommitment[]` for a service, or `bytes32(0)` if none was supplied. The full array was emitted at approval time in `TeeCommitmentsRecorded`; slashing and provisioning oracles supply the array as a witness and verify `keccak256(abi.encode(witness)) == getTeeCommitmentRoot(serviceId, operator)`.
 
-_Commitments must match the security requirements specified in the request_
-
-#### approveServiceWithBls
+#### teeNonceFor
 
 ```solidity
-function approveServiceWithBls(uint64 requestId, uint8 stakingPercent, uint256[4] blsPubkey) external
+function teeNonceFor(uint64 requestId) external view returns (bytes32)
 ```
 
-Approve a service request with BLS public key for aggregated signature verification
+Canonical TEE attestation nonce binding for `requestId` on this contract on this chain. Operators MUST submit this exact value as `nonceBinding` in any `TeeAttestationCommitment` for the request — it eliminates cross-request attestation replay at approval time.
 
-#### approveServiceWithCommitmentsAndBls
+#### blsPopMessage
 
 ```solidity
-function approveServiceWithCommitmentsAndBls(uint64 requestId, struct Types.AssetSecurityCommitment[] commitments, uint256[4] blsPubkey) external
+function blsPopMessage(address operator, uint256[4] blsPubkey) external view returns (bytes)
 ```
 
-Approve a service request with both security commitments and BLS public key
+Build the canonical message an operator must sign with their BLS secret key to register a public key. Bound to chainId, the verifying contract, and operator.
 
 #### rejectService
 
@@ -88,6 +92,16 @@ function rejectService(uint64 requestId) external
 ```
 
 Reject a service request (as operator)
+
+#### expireServiceRequest
+
+```solidity
+function expireServiceRequest(uint64 requestId) external
+```
+
+Permissionlessly expire a stale service request and refund the requester.
+
+_Anyone may call once `block.timestamp > req.createdAt + grace` (grace is `_requestExpiryGracePeriod` or `ProtocolConfig.REQUEST_EXPIRY_GRACE_PERIOD`). Reverts if the request was already rejected, already activated, or still within its grace window._
 
 #### createServiceFromQuotes
 

--- a/pages/developers/api/reference/generated/ITangleServices.mdx
+++ b/pages/developers/api/reference/generated/ITangleServices.mdx
@@ -50,36 +50,40 @@ Get resource requirements for a service request
 #### approveService
 
 ```solidity
-function approveService(uint64 requestId, uint8 stakingPercent) external
+function approveService(struct Types.ApprovalParams params) external
 ```
 
-Approve a service request (as operator) - simple version
+Approve a service request as one of its operators.
 
-#### approveServiceWithCommitments
+_Single entrypoint covering every approval mode. Pass empty/zero fields on `ApprovalParams` to opt out of the corresponding capability:_
+
+- `securityCommitments == []` — no per-asset commitment supplied. Only valid when the request has no security requirements OR the only requirement is the protocol-default TNT requirement (auto-filled at min-exposure).
+- `blsPubkey == [0,0,0,0]` — operator does NOT register a BLS pubkey for aggregated job-result signing. BLS is opt-in; the protocol accepts any operator.
+- `teeCommitments == []` — operator does NOT bind to a TEE attestation profile.
+
+#### getTeeCommitmentRoot
 
 ```solidity
-function approveServiceWithCommitments(uint64 requestId, struct Types.AssetSecurityCommitment[] commitments) external
+function getTeeCommitmentRoot(uint64 serviceId, address operator) external view returns (bytes32)
 ```
 
-Approve a service request with multi-asset security commitments
+Returns `keccak256(abi.encode(commitments))` over an operator's `TeeAttestationCommitment[]` for a service, or `bytes32(0)` if none was supplied. The full array was emitted at approval time in `TeeCommitmentsRecorded`; slashing and provisioning oracles supply the array as a witness and verify `keccak256(abi.encode(witness)) == getTeeCommitmentRoot(serviceId, operator)`.
 
-_Commitments must match the security requirements specified in the request_
-
-#### approveServiceWithBls
+#### teeNonceFor
 
 ```solidity
-function approveServiceWithBls(uint64 requestId, uint8 stakingPercent, uint256[4] blsPubkey) external
+function teeNonceFor(uint64 requestId) external view returns (bytes32)
 ```
 
-Approve a service request with BLS public key for aggregated signature verification
+Canonical TEE attestation nonce binding for `requestId` on this contract on this chain. Operators MUST submit this exact value as `nonceBinding` in any `TeeAttestationCommitment` for the request — it eliminates cross-request attestation replay at approval time.
 
-#### approveServiceWithCommitmentsAndBls
+#### blsPopMessage
 
 ```solidity
-function approveServiceWithCommitmentsAndBls(uint64 requestId, struct Types.AssetSecurityCommitment[] commitments, uint256[4] blsPubkey) external
+function blsPopMessage(address operator, uint256[4] blsPubkey) external view returns (bytes)
 ```
 
-Approve a service request with both security commitments and BLS public key
+Build the canonical message an operator must sign with their BLS secret key to register a public key. Bound to chainId, the verifying contract, and operator.
 
 #### rejectService
 
@@ -88,6 +92,16 @@ function rejectService(uint64 requestId) external
 ```
 
 Reject a service request (as operator)
+
+#### expireServiceRequest
+
+```solidity
+function expireServiceRequest(uint64 requestId) external
+```
+
+Permissionlessly expire a stale service request and refund the requester.
+
+_Anyone may call once `block.timestamp > req.createdAt + grace` (grace is `_requestExpiryGracePeriod` or `ProtocolConfig.REQUEST_EXPIRY_GRACE_PERIOD`). Reverts if the request was already rejected, already activated, or still within its grace window._
 
 #### createServiceFromQuotes
 

--- a/pages/developers/auth-surface.mdx
+++ b/pages/developers/auth-surface.mdx
@@ -98,17 +98,16 @@ See [Slashing](/developers/slashing) for the full lifecycle and runbooks.
 
 ### Services
 
-| Function                                                      | Caller                                               |
-| ------------------------------------------------------------- | ---------------------------------------------------- |
-| `requestService(...)`                                         | Anyone (when not paused)                             |
-| `approveService(requestId, stakingPercent)`                   | Operator listed in the request (request not expired) |
-| `approveServiceWithCommitments(...)`                          | Operator listed in the request                       |
-| `approveServiceWithBls(requestId, stakingPercent, blsPubkey)` | Operator listed in the request                       |
-| `approveServiceWithCommitmentsAndBls(...)`                    | Operator listed in the request                       |
-| `rejectService(requestId)`                                    | Operator listed in the request                       |
-| `expireServiceRequest(requestId)`                             | Anyone, after grace period (when not activated)      |
-| `terminateService(serviceId)`                                 | Service owner                                        |
-| `forceRemoveOperator(serviceId, operator)`                    | Blueprint manager only                               |
+| Function                                   | Caller                                               |
+| ------------------------------------------ | ---------------------------------------------------- |
+| `requestService(...)`                      | Anyone (when not paused)                             |
+| `approveService(ApprovalParams)`           | Operator listed in the request (request not expired) |
+| `rejectService(requestId)`                 | Operator listed in the request                       |
+| `expireServiceRequest(requestId)`          | Anyone, after grace period (when not activated)      |
+| `terminateService(serviceId)`              | Service owner                                        |
+| `forceRemoveOperator(serviceId, operator)` | Blueprint manager only                               |
+
+`approveService` is a single entrypoint. Optional capabilities are opt-in via empty/zero fields on `ApprovalParams`: empty `securityCommitments`, zero `blsPubkey`, or empty `teeCommitments` each means "skip this capability." See [the slashing doc](/developers/slashing) for the per-asset commitment contract.
 
 ### Payments
 

--- a/pages/developers/slashing.mdx
+++ b/pages/developers/slashing.mdx
@@ -168,7 +168,7 @@ The deadline (`disputeResolutionDeadline`) matters because without auto-resoluti
 
 ## Per-Asset Commitment Slashing
 
-When an operator joins a service via `approveServiceWithCommitments`, they declare per-asset exposure (`AssetSecurityCommitment[]`). On slash:
+When an operator joins a service via `approveService(ApprovalParams)` with a non-empty `securityCommitments`, they declare per-asset exposure (`AssetSecurityCommitment[]`). On slash:
 
 - `_executeSlashOnStaking` reads `_serviceSecurityCommitments[serviceId][operator]`.
 - If commitments exist, it routes to `slashForService(operator, blueprintId, serviceId, commitments, slashBps, evidence)` which only burns the committed assets proportionally to `commitment.exposureBps`.

--- a/scripts/check-tnt-core-sync.mjs
+++ b/scripts/check-tnt-core-sync.mjs
@@ -15,7 +15,9 @@ function resolveTntCoreDir() {
   ].filter(Boolean);
 
   for (const candidate of candidates) {
-    if (fs.existsSync(path.join(candidate, "src/interfaces/ITangleServices.sol"))) {
+    if (
+      fs.existsSync(path.join(candidate, "src/interfaces/ITangleServices.sol"))
+    ) {
       return candidate;
     }
   }
@@ -34,7 +36,10 @@ const helperPath = path.join(
 const sourcePath = path.join(tntCoreDir, "src/interfaces/ITangleServices.sol");
 const docsPaths = [
   path.join(repoRoot, "pages/developers/api/reference/ITangleServices.mdx"),
-  path.join(repoRoot, "pages/developers/api/reference/generated/ITangleServices.mdx"),
+  path.join(
+    repoRoot,
+    "pages/developers/api/reference/generated/ITangleServices.mdx",
+  ),
 ];
 
 function readFile(targetPath) {
@@ -57,8 +62,10 @@ const source = readFile(sourcePath).replace(/\s+/g, " ");
 const requiredSourceSnippets = [
   "Types.ConfidentialityPolicy confidentiality",
   "function getServiceRequestResourceRequirements(",
-  "function approveServiceWithBls(",
-  "function approveServiceWithCommitmentsAndBls(",
+  "function approveService(Types.ApprovalParams calldata params)",
+  "function expireServiceRequest(uint64 requestId)",
+  "function getTeeCommitmentRoot(uint64 serviceId, address operator)",
+  "function teeNonceFor(uint64 requestId)",
   "function terminateServiceForNonPayment(",
   "event ServiceTerminatedForNonPayment(",
 ];
@@ -83,8 +90,10 @@ const requiredDocsSnippets = [
   "function requestServiceWithExposure(uint64 blueprintId, address[] operators, uint16[] exposureBps, bytes config, address[] permittedCallers, uint64 ttl, address paymentToken, uint256 paymentAmount, enum Types.ConfidentialityPolicy confidentiality) external payable returns (uint64 requestId)",
   "function requestServiceWithSecurity(uint64 blueprintId, address[] operators, struct Types.AssetSecurityRequirement[] securityRequirements, bytes config, address[] permittedCallers, uint64 ttl, address paymentToken, uint256 paymentAmount, enum Types.ConfidentialityPolicy confidentiality) external payable returns (uint64 requestId)",
   "function getServiceRequestResourceRequirements(uint64 requestId) external view returns (struct Types.ResourceCommitment[])",
-  "function approveServiceWithBls(uint64 requestId, uint8 stakingPercent, uint256[4] blsPubkey) external",
-  "function approveServiceWithCommitmentsAndBls(uint64 requestId, struct Types.AssetSecurityCommitment[] commitments, uint256[4] blsPubkey) external",
+  "function approveService(struct Types.ApprovalParams params) external",
+  "function expireServiceRequest(uint64 requestId) external",
+  "function getTeeCommitmentRoot(uint64 serviceId, address operator) external view returns (bytes32)",
+  "function teeNonceFor(uint64 requestId) external view returns (bytes32)",
   "function terminateServiceForNonPayment(uint64 serviceId) external",
   "event ServiceRequested(uint64 requestId, uint64 blueprintId, address requester, enum Types.ConfidentialityPolicy confidentiality)",
   "event ServiceRequestedWithSecurity(uint64 requestId, uint64 blueprintId, address requester, enum Types.ConfidentialityPolicy confidentiality)",


### PR DESCRIPTION
## Summary

Brings the protocol reference docs back in sync with what tnt-core actually exposes today.

- **ITangleServices reference** (manual + generated mirror): the four removed \`approveServiceWith*\` variants are out, replaced by the single \`approveService(ApprovalParams)\` entrypoint plus \`expireServiceRequest\`, \`getTeeCommitmentRoot\`, \`teeNonceFor\`, and \`blsPopMessage\` (which were already on the contract but not documented in the reference page).
- **Auth surface table**: four approval rows collapsed to one with a note on the opt-in fields (empty \`securityCommitments\`, zero \`blsPubkey\`, empty \`teeCommitments\`).
- **Slashing doc**: per-asset commitment narrative now points at the unified entrypoint.
- **\`scripts/check-tnt-core-sync.mjs\`**: was actively failing because it asserted on the removed signatures. Updated to gate on the new surface — re-running against the current tnt-core checkout passes.

## Why now

\`yarn check:tnt-core-sync\` was broken (asserts \`function approveServiceWithBls(\` is present in tnt-core source; that signature no longer exists). CI doesn't currently invoke this script but it's intended as a contributor tripwire — a broken tripwire is worse than no tripwire.

## Test plan

- [x] \`TNT_CORE_DIR=/path/to/tnt-core node scripts/check-tnt-core-sync.mjs\` → "tnt-core sync checks passed"
- [x] \`yarn prettier --write\` clean on all touched files
- [x] No remaining \`approveServiceWith\` or \`approveService(requestId, stakingPercent)\` references under \`pages/\`