### PR TITLE
docs(copy): clarify runtime boundaries and harness support

### DIFF
--- a/pages/developers/blueprints/pricing-and-payments.mdx
+++ b/pages/developers/blueprints/pricing-and-payments.mdx
@@ -16,7 +16,7 @@ If you are looking for the operator-side gRPC daemon that generates EIP-712 quot
 
 ## Source Of Truth
 
-The most comprehensive, protocol-accurate reference lives in `tnt-core`:
+The protocol reference lives in `tnt-core`:
 
 <GithubFileReaderDisplay
   url="https://github.com/tangle-network/tnt-core/blob/main/docs/PRICING.md"

--- a/pages/developers/blueprints/use-cases.mdx
+++ b/pages/developers/blueprints/use-cases.mdx
@@ -3,20 +3,20 @@ import GithubRepoCard, { GithubRepoList } from "../../../components/GithubRepoCa
 
 # Use Cases
 
-Tangle Network enables developers to rapidly build and deploy secure multi-party services through our Blueprint system. Blueprints are reusable templates that can be instantly deployed as live services backed by Tangle's decentralized operator network, including AI agents, inference workflows, and verifiable computation pipelines.
+Blueprints work best when a service needs outside operators, explicit payment terms, and a repeatable way to request live instances. These examples show the kinds of services teams have built or templated with Tangle.
 
 ## Bridges
 
 <GithubRepoCard
   name="layerzero-dvn-blueprint-template"
-  description="Template for creating LayerZero DVN (Decentralized Verifier Network) blueprints"
+  description="Template for LayerZero DVN services."
   url="https://github.com/tangle-network/layerzero-dvn-blueprint-template"
   displayStyle="row"
 />
 
 <GithubRepoCard
   name="hyperlane-relayer-blueprint"
-  description="Blueprint for implementing Hyperlane relayer functionality"
+  description="Hyperlane relayer service packaged as a Blueprint."
   url="https://github.com/tangle-network/hyperlane-relayer-blueprint"
   displayStyle="row"
 />
@@ -39,27 +39,27 @@ Tangle Network enables developers to rapidly build and deploy secure multi-party
 
 <GithubRepoCard
   name="coinbase-agentkit-blueprint"
-  description="Coinbase AgentKit Blueprint"
+  description="Coinbase AgentKit agent service packaged as a Blueprint."
   url="https://github.com/tangle-network/coinbase-agentkit-blueprint"
   displayStyle="row"
 />
 <GithubRepoCard
   name="rig-ai-agent-blueprint"
-  description="A template showcasing Rig AI agent integration with Tangle Blueprints, which contains an example agent for spell checking and improving code documentation of requested repos."
+  description="Rig AI agent template with a code-documentation example."
   url="https://github.com/tangle-network/rig-ai-agent-blueprint"
   displayStyle="row"
 />
 
 <GithubRepoCard
   name="gaia-ai-agent-template"
-  description="Template for creating AI agents using the Gaia framework"
+  description="Gaia agent template for Blueprint services."
   url="https://github.com/tangle-network/gaia-ai-agent-template"
   displayStyle="row"
 />
 
 <GithubRepoCard
   name="discord-summarizer-rig-blueprint"
-  description="Template for creating AI agents that summarizes discord channels daily"
+  description="Rig agent that summarizes Discord channels on a schedule."
   url="https://github.com/tangle-network/discord-summarizer-rig-blueprint/"
   displayStyle="row"
 />
@@ -68,7 +68,7 @@ Tangle Network enables developers to rapidly build and deploy secure multi-party
 
 <GithubRepoCard
   name="turnkey-blueprint-template"
-  description="A template that contains Turnkey APIs for interacting with Turnkey for use in a Tangle blueprint."
+  description="Turnkey API integration template for Blueprint services."
   url="https://github.com/tangle-network/turnkey-blueprint-template"
   displayStyle="row"
 />
@@ -77,42 +77,42 @@ Tangle Network enables developers to rapidly build and deploy secure multi-party
 
 <GithubRepoCard
   name="frost-blueprint"
-  description="Blueprint for implementing FROST (Flexible Round-Optimized Schnorr Threshold) signatures"
+  description="FROST threshold-signature service."
   url="https://github.com/tangle-network/frost-blueprint"
   displayStyle="row"
 />
 
 <GithubRepoCard
   name="dfns-cggmp21-blueprint"
-  description="Blueprint for implementing DFNS CGGMP21 distributed key generation"
+  description="DFNS CGGMP21 distributed key-generation service."
   url="https://github.com/tangle-network/dfns-cggmp21-blueprint"
   displayStyle="row"
 />
 
 <GithubRepoCard
   name="schnorr-musig2-blueprint"
-  description="Blueprint for Musig2 Schnorr signatures over Secp256k1"
+  description="MuSig2 Schnorr signing over Secp256k1."
   url="https://github.com/tangle-network/schnorr-musig2-blueprint"
   displayStyle="row"
 />
 
 <GithubRepoCard
   name="bls-blueprint"
-  description="Blueprint for threshold BLS signatures using BLS381"
+  description="Threshold BLS signatures using BLS381."
   url="https://github.com/tangle-network/bls-blueprint"
   displayStyle="row"
 />
 
 <GithubRepoCard
   name="silent-timelock-encryption-blueprint"
-  description="Blueprint for silent setup timelock encryptions and threshold decryptions."
+  description="Silent-setup timelock encryption and threshold decryption."
   url="https://github.com/tangle-network/silent-timelock-encryption-blueprint"
   displayStyle="row"
 />
 
 <GithubRepoCard
   name="bte-blueprint"
-  description="Blueprint for batch threshold decryption, includes examples for MEV-resistent orderflow."
+  description="Batch threshold decryption, including MEV-resistant order-flow examples."
   url="https://github.com/tangle-network/bte-blueprint"
   displayStyle="row"
 />
@@ -121,7 +121,7 @@ Tangle Network enables developers to rapidly build and deploy secure multi-party
 
 <GithubRepoCard
   name="obol-dvt-blueprint"
-  description="Blueprint for implementing Obol Distributed Validator Technology"
+  description="Obol Distributed Validator Technology service."
   url="https://github.com/tangle-network/obol-dvt-blueprint"
   displayStyle="row"
 />
@@ -130,28 +130,28 @@ Tangle Network enables developers to rapidly build and deploy secure multi-party
 
 <GithubRepoCard
   name="secure-code-execution-blueprint"
-  description="A template for code execution service supporting Rust, Golang, Python, JS/TS"
+  description="Code execution service template for Rust, Go, Python, and JS/TS."
   url="https://github.com/tangle-network/secure-code-execution-blueprint"
   displayStyle="row"
 />
 
 <GithubRepoCard
   name="txrelayer-blueprint"
-  description="Blueprint for feeless transaction relayers to support any EVM."
+  description="Feeless transaction relayer service for EVM chains."
   url="https://github.com/tangle-network/txrelayer-blueprint"
   displayStyle="row"
 />
 
 <GithubRepoCard
   name="tls-notary-blueprint"
-  description="Blueprint for implementing TLS notary services"
+  description="TLS notary service."
   url="https://github.com/tangle-network/tls-notary-blueprint"
   displayStyle="row"
 />
 
 <GithubRepoCard
   name="apillon-simplet-blueprint-template"
-  description="Template for creating Apillon Simplet web services"
+  description="Apillon Simplet web-service template."
   url="https://github.com/tangle-network/apillon-simplet-blueprint-template"
   displayStyle="row"
 />
@@ -160,19 +160,19 @@ Tangle Network enables developers to rapidly build and deploy secure multi-party
 
 <GithubRepoCard
   name="avail-arbitrum-orbit-raas"
-  description="Rollup-as-a-Service implementation for Arbitrum Orbit using Avail DA"
+  description="Arbitrum Orbit Rollup-as-a-Service with Avail DA."
   url="https://github.com/tangle-network/avail-arbitrum-orbit-raas"
   displayStyle="row"
 />
 <GithubRepoCard
   name="raas-blueprints"
-  description="Collection of Rollup-as-a-Service blueprints"
+  description="Rollup-as-a-Service Blueprint collection."
   url="https://github.com/tangle-network/raas-blueprints"
   displayStyle="row"
 />
 <GithubRepoCard
   name="espresso-raas-blueprint"
-  description="Espresso Rollup-as-a-Service Blueprint"
+  description="Espresso Rollup-as-a-Service Blueprint."
   url="https://github.com/tangle-network/espresso-raas-blueprint"
   displayStyle="row"
 />

--- a/pages/infrastructure/introduction.mdx
+++ b/pages/infrastructure/introduction.mdx
@@ -1,7 +1,11 @@
 # Sandbox Runtime
 
 The sandbox runtime is the execution layer for autonomous work. It provisions isolated environments, manages session execution, and streams events so workflows can run safely at scale.
-Today, workloads are triggered through the workbench and managed platform services. External runtime APIs are not yet public.
+
+There are two paths:
+
+- **Hosted sandbox infrastructure**: apps use the Sandbox SDK/API against Tangle-managed orchestration when they have an API key and product access.
+- **Protocol-backed sandbox services**: operators run sandbox blueprints as service instances, and apps verify chain/indexer state plus live operator health before routing users in.
 
 ## What It Provides
 
@@ -23,4 +27,4 @@ Today, workloads are triggered through the workbench and managed platform servic
 - **Platform engineers**: Review [architecture](/infrastructure/architecture) and [orchestration](/infrastructure/orchestration).
 - **Security teams**: Start with [sandboxing and safety](/infrastructure/sandboxing).
 
-The runtime is available via partnership or early access.
+Hosted runtime access is gated by product/API-key access. Protocol-backed runtime access depends on a registered blueprint service instance and reachable operator endpoint.

--- a/pages/network/overview.mdx
+++ b/pages/network/overview.mdx
@@ -4,23 +4,23 @@ import ExpandableImage from "../../components/ExpandableImage";
 
 # Protocol Foundation
 
-Tangle is the shared operating layer for autonomous work. The protocol coordinates operator-run services and routes payments. Developers publish Blueprints, users instantiate them on demand, and operators run them for a fee.
+Tangle coordinates services that outside operators can run for users. Developers publish Blueprints, users request service instances, operators accept work, and protocol contracts track stake, lifecycle state, and payment terms.
 
 ## Today vs Future
 
-Today the protocol ships with managed onboarding and a curated operator set. Over time it evolves into an open marketplace where operators host runtime services and earn based on reliability and usage.
+Today the network uses managed onboarding and a curated operator set. The protocol path is still the same one a larger market needs: register operators, request service instances, record commitments, and settle fees.
 
 ## Build Composable Services
 
-Blueprints are composable services that can be instantiated by users. They are built using the [Blueprint SDK](https://github.com/tangle-network/blueprint/tree/main) and can integrate with external security providers when needed.
+Blueprints package jobs, metadata, binaries, pricing, and optional service-manager logic. Developers build them with the [Blueprint SDK](https://github.com/tangle-network/blueprint/tree/main), then users instantiate live service instances from registered operators.
 
 ## Earn as a Service Operator
 
-Operators can earn rewards by operating Blueprint instances requested by users. Operators register for Blueprints and maintain control over the services they run, selecting the resources they want to expose for securing the Blueprint.
+Operators earn service fees by running requested instances. They choose which Blueprints to register for, which endpoints to expose, and which resources or isolation modes they are willing to commit.
 
 ## Maximize Resource Utilization
 
-Tangle enables shared security across Blueprints, allowing operators to secure multiple Blueprints with a single pool of resources and participants to earn rewards proportional to the value secured.
+Operators can reuse one stake and operations stack across multiple Blueprints. That gives users a consistent way to select operators while each Blueprint keeps its own jobs, pricing, and runtime requirements.
 
 ## Who This Is For
 
@@ -32,11 +32,11 @@ Tangle enables shared security across Blueprints, allowing operators to secure m
 
 <ExpandableImage src="/images/ServiceInstanceFlow.png" alt="Service Instance Flow" allowZoom={true} />
 
-Tangle Network employs a modular architecture to enable the creation and deployment of reusable services called Blueprints:
+Tangle uses a modular service model:
 
 #### Blueprints
 
-A Blueprint is a specification that defines a service. Blueprints themselves are not live service instances. Developers create Blueprints by specifying a service binary (artifact), the jobs involved, a set of smart contracts for registration and requesting instances, and additional metadata. Users instantiate services by configuring the operator set and paying the necessary fees. [Read more about Blueprints](/developers/blueprints/introduction)
+A Blueprint is a service template, not a live service. It defines the runnable artifact, jobs, metadata, pricing hooks, and registration/request logic. Users create service instances by selecting operators and accepting the payment terms. [Read more about Blueprints](/developers/blueprints/introduction)
 
 #### Economic Security on Blueprints
 
@@ -44,32 +44,30 @@ Economic security backs operators who run services based on Blueprints. Operator
 
 #### Requesting Service Instances
 
-Users deploy live service instances using a Blueprint's request functionality. The requester specifies criteria like the number of operators or other operator attributes. A specific subset of qualified operators is then selected to run that service instance.
-
-We aim to support fine-grained controls over requesting instances, such as specifying the number of operators, the operator set, and other operator attributes. This allows users to customize their service instances based on their requirements.
+Users create live service instances through a Blueprint request. The request names the operator set, payment terms, and service parameters the Blueprint supports.
 
 #### Incentives
 
 Operators earn **service fees** for running Blueprint instances and may earn optional **TNT incentives** if governance funds them. Developers earn a share of service fees and can also receive optional TNT incentives based on activity metrics.
 
-This separation into Blueprints and instances allows services to be defined once but instantiated multiple times by different users with varying operator requirements. Blueprint developers benefit from their work being utilized widely across ecosystems and applications.
+This separation lets one Blueprint support many service instances with different operators, prices, endpoints, and runtime requirements.
 
 ## Use Cases
 
-Tangle is a protocol for reusable cryptographic and AI services. It supports complex workloads that need verifiable execution and reliable operator incentives. Key service areas include:
+Tangle is a protocol for reusable cryptographic, AI, and runtime services. The protocol handles operator commitments and payments; each Blueprint defines the actual workload. Common service areas include:
 
-- **Privacy Infrastructure**: Tangle provides a foundation for enabling privacy-preserving solutions through technologies like multi-party computation (MPC) and zero-knowledge proofs.
+- **Privacy infrastructure**: MPC and zero-knowledge services where operators run key generation, signing, proving, or verification jobs.
 
-- **Oracles**: Build decentralized oracle services that can securely feed off-chain data to blockchains using Tangle's threshold signatures and MPC primitives.
+- **Oracles**: data services that use threshold signatures, MPC, or attestation before posting off-chain information onchain.
 
-- **AI/ML**: Offer secure and scalable AI inference, fine-tuning, and evaluation services through operator-hosted runtimes.
+- **AI/ML**: inference, fine-tuning, evaluation, and sandboxed agent work through operator-hosted runtimes.
 
-- **Custody Solutions**: Leverage Tangle's cryptographic services to create distributed custody solutions with robust security guarantees.
+- **Custody**: distributed signing and policy checks using threshold cryptography.
 
-- **Bridges**: Develop cross-chain bridges and asset movement solutions using Tangle's MPC co-processors and private bridging capabilities.
+- **Bridges**: cross-chain message, verification, and asset-movement services backed by operator commitments.
 
-- **Zero-Knowledge Services**: Implement applications leveraging zero-knowledge proofs, such as zero-knowledge machine learning (ZKML) projects, using Tangle's proof generation services.
+- **Zero-knowledge services**: proof generation, proof aggregation, and verification jobs.
 
-- **Novel Cryptographic Applications**: Tangle's modular architecture and rich cryptographic library enable developers to build innovative applications requiring advanced cryptographic primitives.
+- **Custom cryptographic services**: any service that can be expressed as jobs, operator requirements, and settlement rules.
 
-The core vision of Tangle is to provide infrastructure for developers to create and monetize a wide array of services with reliable execution and clear incentives. Developers are rewarded for valuable Blueprints, and operators are rewarded for dependable service delivery.
+The point is simple: developers package services once, users instantiate them when needed, and operators get paid for work they can prove they accepted and served.

--- a/pages/vibe/_meta.ts
+++ b/pages/vibe/_meta.ts
@@ -9,7 +9,7 @@ const meta: Meta = {
     type: "separator",
     title: "Profile Schema",
   },
-  "profile-schema": "OpenCode Profile Schema",
+  "profile-schema": "Profile Schema",
   integrations: "Integrations",
 };
 

--- a/pages/vibe/introduction.mdx
+++ b/pages/vibe/introduction.mdx
@@ -23,7 +23,7 @@ The workbench sends execution to the sandbox runtime and can route payments thro
 
 ## Profiles Power The Runtime
 
-Workbench profiles are the control surface for the OpenCode sidecar. They define model routing, per-agent prompts, and tool permissions so every run behaves predictably without hard-coded rules.
+Workbench profiles configure the selected agent harness, model routing, per-agent prompts, and tool permissions. OpenCode is one supported harness, not the product boundary.
 
 ## Start Here (By Role)
 

--- a/pages/vibe/profile-schema.mdx
+++ b/pages/vibe/profile-schema.mdx
@@ -1,17 +1,21 @@
 # Profile Schema
 
-This page documents the profile schema used to configure sidecar agents. Today, the schema maps to OpenCode. Over time, additional backends will share the same profile surface where possible.
+This page documents the profile schema used to configure sidecar agents. The schema is shared across harnesses; each harness maps the fields it supports to its own config files, environment, and runtime flags.
 
 ## Current Support
 
-- **OpenCode**: Full profile support (models, permissions, tools, tool servers, plugins).
-- **Future backends**: We will document compatibility notes as new runtimes are added.
+- **Router-backed harnesses**: OpenCode, OpenClaw, NanoClaw, Hermes, AMP, and Factory Droids can accept broad model/provider routing when product policy allows it.
+- **Vendor-native harnesses**: Claude Code, Codex, and Kimi Code map best to their native provider families.
+- **CLI base**: no agent harness; shell and workflow tools only.
+
+Products can expose a subset of this list. Read runtime capabilities from the sandbox or blueprint instance instead of assuming every harness is enabled.
 
 ## Top-Level Fields
 
 - **name**: Human-friendly identifier.
 - **description**: Optional detail about what the profile is for.
 - **extends**: Name of a base profile to inherit from.
+- **harness**: Optional agent backend to request when the product allows harness selection.
 - **model**: Primary model to use, in `provider/model-id` format.
 - **small_model**: Optional secondary model for lighter tasks.
 - **agent**: Map of per-agent overrides (plan, build, explore, or custom).

--- a/pages/vibe/profiles.mdx
+++ b/pages/vibe/profiles.mdx
@@ -1,9 +1,10 @@
 # Profiles and Policies
 
-Profiles define how an agent behaves end to end. They package model choice, tool access, permissions, and guardrails into a reusable sidecar agent profile that the runtime enforces. This is how the workbench configures the OpenCode execution layer without hard-coding behavior into every task.
+Profiles define how an agent behaves end to end. They package model choice, tool access, permissions, guardrails, and harness selection into a reusable sidecar profile that the runtime enforces. This is how the workbench configures agent execution without hard-coding behavior into every task.
 
 ## What A Profile Controls
 
+- **Harness selection**: OpenCode, Claude Code, Codex, AMP, Factory Droids, Kimi Code, OpenClaw, NanoClaw, Hermes, or CLI base when the product exposes them.
 - **Model selection**: primary and small model routing per profile.
 - **Per-agent tuning**: distinct configs for plan/build/explore (prompt, temperature, max steps).
 - **Tool access**: enable or disable individual tools.
@@ -65,4 +66,4 @@ Under the hood, profiles can extend a base profile. The runtime merges overrides
 }
 ```
 
-For a field-by-field reference, see [Profile Schema](/vibe/profile-schema). The schema currently targets OpenCode, with additional backends planned.
+For a field-by-field reference, see [Profile Schema](/vibe/profile-schema). The schema is harness-aware; each backend maps the shared profile fields to its own config surface.


### PR DESCRIPTION
## Summary
- add a copy pass that separates hosted sandbox infrastructure from protocol-backed sandbox services
- update Workbench profile docs so OpenCode is one supported harness instead of the product boundary
- rewrite older Blueprint use-case and Protocol overview copy to name mechanisms and remove generic marketing language

## Verification
- `yarn format:check`
- `yarn check:tnt-core-sync`
- `yarn build`
- `node /home/drew/code/dotfiles/claude/skills/docs-slop-audit/scripts/scan-docs-slop.mjs --json pages/blueprints pages/developers/blueprints pages/infrastructure pages/network` -> 42 files scanned, 27 findings after the pass, down from 35 before; remaining high items are mostly intentional protocol/hosted-infra and OpenCode manual-review guardrails
- `git merge-tree --write-tree origin/main HEAD` -> clean tree `1e74b514ac7dc96a16ccc650704d0559c933c1d8`