### PR TITLE
docs(blueprints): remove product indexer claims

### DIFF
--- a/pages/blueprints/ai-agent-sandbox/_meta.ts
+++ b/pages/blueprints/ai-agent-sandbox/_meta.ts
@@ -4,7 +4,7 @@ const meta: Meta = {
   index: "Overview",
   "operator-requirements": "Operator Requirements",
   "runtime-and-harnesses": "Runtime and Harnesses",
-  "dapp-and-indexer": "Dapp and Indexer",
+  "dapp-and-indexer": "Dapp Integration",
 };
 
 export default meta;

--- a/pages/blueprints/ai-agent-sandbox/dapp-and-indexer.mdx
+++ b/pages/blueprints/ai-agent-sandbox/dapp-and-indexer.mdx
@@ -1,13 +1,15 @@
 ---
-title: AI Agent Sandbox Dapp and Indexer
-description: Dapp metadata, iframe policy, indexed state, and live health boundaries for AI Agent Sandbox.
+title: AI Agent Sandbox Dapp Integration
+description: Dapp metadata, iframe policy, protocol state, and live health boundaries for AI Agent Sandbox.
 ---
 
-# AI Agent Sandbox Dapp and Indexer
+# AI Agent Sandbox Dapp Integration
 
 Tangle Cloud should launch the hosted sandbox app from metadata, then keep the raw protocol page one click away.
 
 The hosted app owns the sandbox UX. The protocol page owns raw state inspection.
+
+The AI Agent Sandbox repo does not ship a dedicated indexer today. Treat protocol state as data the dapp can read from contracts or a shared protocol indexing layer when one is available. Do not make an indexer part of the blueprint operator path.
 
 ## Metadata the dapp should use
 
@@ -21,7 +23,7 @@ The hosted app owns the sandbox UX. The protocol page owns raw state inspection.
 
 The metadata also declares cloud, dedicated instance, and TEE instance modes. Use those records to route service creation to the right blueprint ID for the selected network.
 
-## Indexed state
+## Protocol state
 
 | State                                   | Why the dapp needs it                                       |
 | --------------------------------------- | ----------------------------------------------------------- |
@@ -33,11 +35,11 @@ The metadata also declares cloud, dedicated instance, and TEE instance modes. Us
 | Jobs                                    | Show lifecycle and workflow commands.                       |
 | Heartbeats                              | Separate "not ready yet" from "operator stopped reporting." |
 
-The indexer should preserve enough history to distinguish pending provisioning from operator failure. The hosted app should not have to guess.
+The dapp should preserve enough protocol history to distinguish pending provisioning from operator failure. That history can come from direct chain reads, a shared protocol indexer, or another canonical protocol-state service. It is not a separate component shipped by this blueprint.
 
 ## Live checks
 
-Indexed state is not enough to open a terminal or inject a secret. Before showing a sandbox as usable, the app should check:
+Protocol state is not enough to open a terminal or inject a secret. Before showing a sandbox as usable, the app should check:
 
 1. operator API reachability
 2. session auth challenge/session flow
@@ -51,12 +53,12 @@ For TEE mode, the app should also expose attestation status and avoid presenting
 
 The sandbox app is iframe-first. The parent dapp should:
 
-| Rule                                                            | Reason                                                                      |
-| --------------------------------------------------------------- | --------------------------------------------------------------------------- |
-| Restrict iframe hosts to trusted suffixes and manifest entries. | Prevent arbitrary operator metadata from embedding a hostile app.           |
-| Pass parent origin and chain context explicitly.                | Lets the child app request wallet operations through the parent.            |
-| Keep wallet approval in the parent.                             | Users should see the same wallet confirmation model across Tangle Cloud.    |
-| Keep a link to raw protocol state.                              | Operators and support need chain/indexer state when the hosted app is down. |
+| Rule                                                            | Reason                                                                                   |
+| --------------------------------------------------------------- | ---------------------------------------------------------------------------------------- |
+| Restrict iframe hosts to trusted suffixes and manifest entries. | Prevent arbitrary operator metadata from embedding a hostile app.                        |
+| Pass parent origin and chain context explicitly.                | Lets the child app request wallet operations through the parent.                         |
+| Keep wallet approval in the parent.                             | Users should see the same wallet confirmation model across Tangle Cloud.                 |
+| Keep a link to raw protocol state.                              | Operators and support need chain and service-instance state when the hosted app is down. |
 
 ## Bad copy to avoid
 

--- a/pages/blueprints/ai-agent-sandbox/index.mdx
+++ b/pages/blueprints/ai-agent-sandbox/index.mdx
@@ -60,11 +60,11 @@ Every data endpoint requires a signed wallet session. Production operators must 
 
 ## What to read next
 
-| Page                                                                        | Use it for                                                          |
-| --------------------------------------------------------------------------- | ------------------------------------------------------------------- |
-| [Operator Requirements](/blueprints/ai-agent-sandbox/operator-requirements) | Host setup, ports, Docker, Firecracker, TEE, state, and secrets.    |
-| [Runtime and Harnesses](/blueprints/ai-agent-sandbox/runtime-and-harnesses) | Runtime backends, capability discovery, harnesses, and AI keys.     |
-| [Dapp and Indexer](/blueprints/ai-agent-sandbox/dapp-and-indexer)           | Metadata, iframe policy, indexed state, and live health boundaries. |
+| Page                                                                        | Use it for                                                           |
+| --------------------------------------------------------------------------- | -------------------------------------------------------------------- |
+| [Operator Requirements](/blueprints/ai-agent-sandbox/operator-requirements) | Host setup, ports, Docker, Firecracker, TEE, state, and secrets.     |
+| [Runtime and Harnesses](/blueprints/ai-agent-sandbox/runtime-and-harnesses) | Runtime backends, capability discovery, harnesses, and AI keys.      |
+| [Dapp Integration](/blueprints/ai-agent-sandbox/dapp-and-indexer)           | Metadata, iframe policy, protocol state, and live health boundaries. |
 
 ## Sources used
 

--- a/pages/blueprints/ai-agent-sandbox/runtime-and-harnesses.mdx
+++ b/pages/blueprints/ai-agent-sandbox/runtime-and-harnesses.mdx
@@ -91,4 +91,4 @@ Use these probes before routing users into a sandbox:
 | `/api/capabilities`     | The runtime and harness features the operator says are available.               |
 | Product operation probe | A real exec, prompt, terminal, port, or workflow call through the operator API. |
 
-The indexer can tell the app that a service exists. It cannot tell the app that a sidecar is usable right now.
+Protocol state can tell the app that a service exists. It cannot tell the app that a sidecar is usable right now.

--- a/pages/blueprints/ai-trading/_meta.ts
+++ b/pages/blueprints/ai-trading/_meta.ts
@@ -4,7 +4,7 @@ const meta: Meta = {
   index: "Overview",
   "operator-requirements": "Operator Requirements",
   "runtime-and-risk": "Runtime and Risk",
-  "dapp-and-indexer": "Dapp and Indexer",
+  "dapp-and-indexer": "Dapp Integration",
 };
 
 export default meta;

--- a/pages/blueprints/ai-trading/dapp-and-indexer.mdx
+++ b/pages/blueprints/ai-trading/dapp-and-indexer.mdx
@@ -1,11 +1,13 @@
 ---
-title: AI Trading Dapp and Indexer
-description: Arena routing, operator discovery, and indexed state for AI Trading.
+title: AI Trading Dapp Integration
+description: Arena routing, operator discovery, protocol state, and live operator reads for AI Trading.
 ---
 
-# AI Trading Dapp and Indexer
+# AI Trading Dapp Integration
 
 The Arena is the product app for AI Trading. Tangle Cloud should launch it from trusted metadata and preserve the protocol fallback route for raw service state.
+
+The AI Trading repo does not ship a dedicated indexer today. Its own improvement notes list vault event indexing as future work. Treat protocol state as data the Arena can read from contracts or a shared protocol indexing layer when one exists, not as a blueprint operator requirement.
 
 ## Metadata the dapp should use
 
@@ -19,7 +21,7 @@ The Arena is the product app for AI Trading. Tangle Cloud should launch it from 
 
 The metadata also declares cloud, instance, and TEE modes. The Arena should use those mode records instead of hard-coding a single blueprint ID.
 
-## Indexed state
+## Protocol state
 
 | State                               | Why the dapp needs it                                             |
 | ----------------------------------- | ----------------------------------------------------------------- |
@@ -30,7 +32,7 @@ The metadata also declares cloud, instance, and TEE modes. The Arena should use 
 | Pricing pointers                    | Show quote or subscription information when available.            |
 | Heartbeats                          | Distinguish dead operators from missing data.                     |
 
-The indexer should make operator discovery reliable. It should not be treated as proof that a bot is healthy or that a trade was safe.
+Protocol state should make operator discovery reliable. It should not be treated as proof that a bot is healthy or that a trade was safe.
 
 ## Live operator reads
 
@@ -46,7 +48,7 @@ The Arena still needs operator APIs for:
 - terminal or sidecar logs
 - health
 
-If an operator endpoint is unreachable, say that. Do not replace it with stale indexed state unless the UI labels it as stale.
+If an operator endpoint is unreachable, say that. Do not replace it with stale protocol state unless the UI labels it as stale.
 
 ## User-facing states
 

--- a/pages/blueprints/ai-trading/index.mdx
+++ b/pages/blueprints/ai-trading/index.mdx
@@ -56,11 +56,11 @@ On-chain guards live in contracts such as `PolicyEngine`, `TradeValidator`, vaul
 
 ## What to read next
 
-| Page                                                                  | Use it for                                                                       |
-| --------------------------------------------------------------------- | -------------------------------------------------------------------------------- |
-| [Operator Requirements](/blueprints/ai-trading/operator-requirements) | VPS sizing, install flow, service IDs, ports, env, admission, and upgrade rules. |
-| [Runtime and Risk](/blueprints/ai-trading/runtime-and-risk)           | Paper mode, agent keys, runtime backend, risk gates, and validation trust.       |
-| [Dapp and Indexer](/blueprints/ai-trading/dapp-and-indexer)           | Arena iframe metadata, operator discovery, and indexed service state.            |
+| Page                                                                  | Use it for                                                                          |
+| --------------------------------------------------------------------- | ----------------------------------------------------------------------------------- |
+| [Operator Requirements](/blueprints/ai-trading/operator-requirements) | VPS sizing, install flow, service IDs, ports, env, admission, and upgrade rules.    |
+| [Runtime and Risk](/blueprints/ai-trading/runtime-and-risk)           | Paper mode, agent keys, runtime backend, risk gates, and validation trust.          |
+| [Dapp Integration](/blueprints/ai-trading/dapp-and-indexer)           | Arena iframe metadata, operator discovery, protocol state, and live operator reads. |
 
 ## Sources used
 

--- a/pages/blueprints/dapp-integration.mdx
+++ b/pages/blueprints/dapp-integration.mdx
@@ -1,6 +1,6 @@
 ---
 title: Dapp Integration
-description: How Tangle Cloud should route blueprint apps, use indexed state, and prove local staking flows.
+description: How the dapp should route blueprint apps, show service state, and prove local staking flows.
 ---
 
 # Dapp Integration
@@ -37,14 +37,14 @@ Do not build around one agent harness, one venue, or one operator URL. Route fro
 
 | State                         | Source                                                                                                     |
 | ----------------------------- | ---------------------------------------------------------------------------------------------------------- |
-| Blueprint exists              | Indexer over blueprint creation and metadata updates.                                                      |
+| Blueprint exists              | Contract reads or shared protocol indexing over blueprint creation and metadata updates.                   |
 | Operator can serve it         | Operator registration and endpoint metadata.                                                               |
 | Service instance exists       | Service request, approval, and activation events.                                                          |
-| Job was submitted             | Indexed job events.                                                                                        |
+| Job was submitted             | Protocol job events.                                                                                       |
 | Product is healthy            | Operator API, app-level probe, or blueprint-specific proof path.                                           |
 | Product result is trustworthy | Contract state, attestation, settlement receipt, SP1 proof, signed report, or product-specific validation. |
 
-The indexer is discovery infrastructure. It tells the dapp what the protocol saw. It does not replace runtime health checks.
+Shared protocol indexing is discovery infrastructure when it exists. It tells the dapp what the protocol saw. It is not shipped by these product blueprint repos, and it does not replace runtime health checks.
 
 ## Failure states worth showing
 
@@ -89,14 +89,14 @@ The direct local staking gate must exercise real contract calls for:
 6. schedule withdraw
 7. execute withdraw
 
-The browser gate should prove the same actions through the UI. If local GraphQL/indexer noise blocks the browser run, say that plainly and keep the direct contract gate as the hard proof. Do not claim the browser gate passed unless it did.
+The browser gate should prove the same actions through the UI. If local GraphQL or protocol-state noise blocks the browser run, say that plainly and keep the direct contract gate as the hard proof. Do not claim the browser gate passed unless it did.
 
 ## Implementation rules
 
-| Rule                                                          | Reason                                                                          |
-| ------------------------------------------------------------- | ------------------------------------------------------------------------------- |
-| Prefer metadata and iframe policy over bespoke React modules. | New first-party apps should not require a dapp redeploy for every route change. |
-| Keep the generic protocol route.                              | Operators and auditors need raw chain/indexer state.                            |
-| Use operator APIs for live product state.                     | The indexer cannot tell whether a bot, sandbox, or venue is healthy right now.  |
-| Keep jobs for commands, not reads.                            | Job history should mean work was requested.                                     |
-| Show unavailable, pending, failed, and healthy separately.    | Each state has a different fix.                                                 |
+| Rule                                                          | Reason                                                                            |
+| ------------------------------------------------------------- | --------------------------------------------------------------------------------- |
+| Prefer metadata and iframe policy over bespoke React modules. | New first-party apps should not require a dapp redeploy for every route change.   |
+| Keep the generic protocol route.                              | Operators and auditors need raw chain and service-instance state.                 |
+| Use operator APIs for live product state.                     | Protocol state cannot tell whether a bot, sandbox, or venue is healthy right now. |
+| Keep jobs for commands, not reads.                            | Job history should mean work was requested.                                       |
+| Show unavailable, pending, failed, and healthy separately.    | Each state has a different fix.                                                   |

--- a/pages/blueprints/index.mdx
+++ b/pages/blueprints/index.mdx
@@ -13,16 +13,16 @@ The live unit is a service instance. A user requests it, picks registered operat
 
 If you only remember one model, use this:
 
-| Layer                 | Plain meaning                                                                                  |
-| --------------------- | ---------------------------------------------------------------------------------------------- |
-| Blueprint             | The recipe: jobs, metadata, binaries, contracts, and app policy.                               |
-| Operator registration | An operator says, on-chain, "I can run this recipe."                                           |
-| Service request       | A user chooses parameters and the operators that should serve them.                            |
-| Service instance      | The running service created from that request.                                                 |
-| Job                   | A command against one service instance. Jobs change state or ask operators to do work.         |
-| Query                 | A read from contracts, the indexer, or an operator API. Queries should not be modeled as jobs. |
+| Layer                 | Plain meaning                                                                                                               |
+| --------------------- | --------------------------------------------------------------------------------------------------------------------------- |
+| Blueprint             | The recipe: jobs, metadata, binaries, contracts, and app policy.                                                            |
+| Operator registration | An operator says, on-chain, "I can run this recipe."                                                                        |
+| Service request       | A user chooses parameters and the operators that should serve them.                                                         |
+| Service instance      | The running service created from that request.                                                                              |
+| Job                   | A command against one service instance. Jobs change state or ask operators to do work.                                      |
+| Query                 | A read from contracts, a shared protocol indexer when available, or an operator API. Queries should not be modeled as jobs. |
 
-The indexer turns protocol events into app state. It can tell the dapp which blueprints exist, which operators registered, which service instances were created, which jobs landed, and which endpoints operators advertised. It does not prove that an endpoint is healthy, honest, or serving the right model. Product pages still need operator API checks, contract reads, attestations, settlement receipts, or proof systems.
+A shared protocol indexer can turn protocol events into app state. It can tell the dapp which blueprints exist, which operators registered, which service instances were created, which jobs landed, and which endpoints operators advertised. It is not part of the three product blueprint repos documented here, and it does not prove that an endpoint is healthy, honest, or serving the right model. Product pages still need operator API checks, contract reads, attestations, settlement receipts, or proof systems.
 
 ## First-party blueprint products
 

--- a/pages/blueprints/protocol-model.mdx
+++ b/pages/blueprints/protocol-model.mdx
@@ -17,23 +17,23 @@ A blueprint is the template. It defines what can be run: jobs, metadata, binarie
 4. Operators approve or join the request.
 5. The service instance becomes active.
 6. The user submits jobs to that service instance.
-7. Apps read chain state, indexed state, and operator APIs to show what happened.
+7. Apps read chain state, shared indexed protocol state when available, and operator APIs to show what happened.
 
 The service instance is the boundary for state, auth, and billing. If a page says the template itself is live, read that as a wording bug. The service instance is live.
 
 ## Names that should not drift
 
-| Term                  | Use it for                                                                            |
-| --------------------- | ------------------------------------------------------------------------------------- |
-| Blueprint             | The abstract capability definition.                                                   |
-| Operator registration | An operator's on-chain opt-in for a blueprint.                                        |
-| Service request       | The user's request to instantiate the blueprint with chosen operators and parameters. |
-| Service instance      | The live unit created from a request.                                                 |
-| Job                   | A state-changing command against a service instance.                                  |
-| Query                 | A read through `eth_call`, the indexer, or an operator API.                           |
-| Operator API          | The off-chain API an operator exposes for live product state and controls.            |
-| Hosted app            | The product UI. It may be first-party, but it is not the blueprint.                   |
-| BSM                   | Blueprint Service Manager contract logic for blueprint-specific rules.                |
+| Term                  | Use it for                                                                               |
+| --------------------- | ---------------------------------------------------------------------------------------- |
+| Blueprint             | The abstract capability definition.                                                      |
+| Operator registration | An operator's on-chain opt-in for a blueprint.                                           |
+| Service request       | The user's request to instantiate the blueprint with chosen operators and parameters.    |
+| Service instance      | The live unit created from a request.                                                    |
+| Job                   | A state-changing command against a service instance.                                     |
+| Query                 | A read through `eth_call`, a shared protocol indexer when available, or an operator API. |
+| Operator API          | The off-chain API an operator exposes for live product state and controls.               |
+| Hosted app            | The product UI. It may be first-party, but it is not the blueprint.                      |
+| BSM                   | Blueprint Service Manager contract logic for blueprint-specific rules.                   |
 
 ## Jobs are not reads
 
@@ -59,20 +59,20 @@ Use jobs for:
 
 This split matters. If reads become jobs, the app gets slow, operators pay more gas than needed, and the protocol history stops meaning "work was requested."
 
-## What the indexer can prove
+## What protocol state can prove
 
-The indexer can show what the chain observed:
+A shared protocol indexer can show what the chain observed. These product blueprint repos do not ship dedicated indexers, so treat indexing as shared dapp/protocol infrastructure, not as part of the blueprint operator runtime.
 
-| Indexed state                         | Useful for                                                                |
+| Protocol state                        | Useful for                                                                |
 | ------------------------------------- | ------------------------------------------------------------------------- |
 | Blueprint creation and source updates | Catalogs, audits, and app routing.                                        |
 | Operator registration                 | Discovery, capacity lists, and endpoint metadata.                         |
 | Service requests and approvals        | Provisioning status and operator participation.                           |
 | Service instances                     | Instance pages, ownership, selected operators, and lifecycle.             |
 | Jobs                                  | User-visible commands, support traces, and billing or settlement context. |
-| Heartbeats or status events           | Liveness history and incident timelines.                                  |
+| Heartbeats or status events           | Liveness history and incident timelines when the protocol emits them.     |
 
-The indexer cannot prove endpoint honesty, model output quality, exchange execution, or credit redemption. Those need product-specific evidence: operator API probes, contract state, attestations, settlement receipts, SP1 proofs, or signed reports.
+Protocol state cannot prove endpoint honesty, model output quality, exchange execution, or credit redemption. Those need product-specific evidence: operator API probes, contract state, attestations, settlement receipts, SP1 proofs, or signed reports.
 
 ## Reader map
 
@@ -90,6 +90,6 @@ The indexer cannot prove endpoint honesty, model output quality, exchange execut
 | --------------------------------------------- | ---------------------------------------------------------------------------- |
 | "Deploy the blueprint for a user."            | "Request a service instance from a blueprint."                               |
 | "The operator provisions the blueprint."      | "The operator provisions the service instance."                              |
-| "The dapp reads the blueprint for bot state." | "The dapp reads indexed service state and the operator API for bot state."   |
-| "Submit a job for a normal read."             | "Read from the contract, indexer, or operator API."                          |
+| "The dapp reads the blueprint for bot state." | "The dapp reads protocol service state and the operator API for bot state."  |
+| "Submit a job for a normal read."             | "Read from the contract, shared protocol indexer, or operator API."          |
 | "The hosted app is the blueprint."            | "The hosted app is the UI for service instances created from the blueprint." |

--- a/pages/blueprints/surplus-market/_meta.ts
+++ b/pages/blueprints/surplus-market/_meta.ts
@@ -4,7 +4,7 @@ const meta: Meta = {
   index: "Overview",
   "operator-requirements": "Operator Requirements",
   "settlement-and-inference": "Settlement and Inference",
-  "dapp-and-indexer": "Dapp and Indexer",
+  "dapp-and-indexer": "Dapp Integration",
 };
 
 export default meta;

--- a/pages/blueprints/surplus-market/dapp-and-indexer.mdx
+++ b/pages/blueprints/surplus-market/dapp-and-indexer.mdx
@@ -1,13 +1,15 @@
 ---
-title: Surplus Market Dapp and Indexer
-description: Dapp routing, metadata gaps, and indexer requirements for the Surplus Market blueprint.
+title: Surplus Market Dapp Integration
+description: Dapp routing, metadata gaps, protocol state, and live venue checks for the Surplus Market blueprint.
 ---
 
-# Surplus Market Dapp and Indexer
+# Surplus Market Dapp Integration
 
 Surplus is live as a hosted app at `https://surplus-market.pages.dev/`.
 
 Tangle Cloud should treat it as a first-party link-out until the repo publishes rich `blueprintUi` metadata and a `*.blueprint.tangle.tools` iframe host. Do not pretend it has the same iframe contract as Sandbox and Trading yet.
+
+The Surplus repo does not ship a dedicated indexer today. The product app can read protocol state from contracts or a shared protocol indexing layer when one exists, but the venue, order book, settlement outbox, and inference redemption state live in the product/operator path.
 
 ## Current metadata
 
@@ -26,12 +28,12 @@ It does not yet include the rich `blueprintUi` object used by Sandbox and Tradin
 | Route             | Behavior                                                       |
 | ----------------- | -------------------------------------------------------------- |
 | Product app       | Link to `https://surplus-market.pages.dev/`.                   |
-| Protocol fallback | Preserve the raw indexed blueprint and service-instance route. |
+| Protocol fallback | Preserve the raw blueprint and service-instance route.         |
 | Future iframe     | Use only after a trusted host and iframe policy are published. |
 
 The product app owns market UX. The protocol fallback owns chain and service inspection.
 
-## Indexed state
+## Protocol state
 
 | State                                 | Why the dapp needs it                                           |
 | ------------------------------------- | --------------------------------------------------------------- |
@@ -42,7 +44,7 @@ The product app owns market UX. The protocol fallback owns chain and service ins
 | Endpoint metadata                     | Route app checks and operator inspection.                       |
 | Heartbeats                            | Distinguish dead venues from quiet books.                       |
 
-## Product state that does not belong only in the indexer
+## Product state that is not protocol state
 
 The app needs live product checks for:
 
@@ -56,7 +58,7 @@ The app needs live product checks for:
 - attester quorum
 - inference backend health
 
-The indexer can show that a job happened. It cannot prove that a credit lot was redeemed or that a model request was served honestly. Use settlement receipts, spend vouchers, attester signatures, SP1 proofs, or operator API responses for those claims.
+Protocol state can show that a job happened. It cannot prove that a credit lot was redeemed or that a model request was served honestly. Use settlement receipts, spend vouchers, attester signatures, SP1 proofs, or operator API responses for those claims.
 
 ## User-facing states
 

--- a/pages/blueprints/surplus-market/index.mdx
+++ b/pages/blueprints/surplus-market/index.mdx
@@ -69,7 +69,7 @@ The placeholders preserve compact job index compatibility. Do not remove them wi
 | ------------------------------------------------------------------------------- | --------------------------------------------------------------------------------- |
 | [Operator Requirements](/blueprints/surplus-market/operator-requirements)       | Venue host, settlement keys, inference backend, CLOB, and privacy mode.           |
 | [Settlement and Inference](/blueprints/surplus-market/settlement-and-inference) | Credit lots, redemption, attester quorum, SP1 path, and inference proof boundary. |
-| [Dapp and Indexer](/blueprints/surplus-market/dapp-and-indexer)                 | Current link-out app, metadata gap, and indexed market state.                     |
+| [Dapp Integration](/blueprints/surplus-market/dapp-and-indexer)                 | Current link-out app, metadata gap, protocol state, and live venue checks.        |
 
 ## Sources used
 

--- a/pages/infrastructure/introduction.mdx
+++ b/pages/infrastructure/introduction.mdx
@@ -5,7 +5,7 @@ The sandbox runtime is the execution layer for autonomous work. It provisions is
 There are two paths:
 
 - **Hosted sandbox infrastructure**: apps use the Sandbox SDK/API against Tangle-managed orchestration when they have an API key and product access.
-- **Protocol-backed sandbox services**: operators run sandbox blueprints as service instances, and apps verify chain/indexer state plus live operator health before routing users in.
+- **Protocol-backed sandbox services**: operators run sandbox blueprints as service instances, and apps verify chain/service state plus live operator health before routing users in.
 
 ## What It Provides
 


### PR DESCRIPTION
## Summary
- rename the three product blueprint sidebar/page labels from Dapp and Indexer to Dapp Integration
- state explicitly that AI Agent Sandbox, AI Trading, and Surplus do not ship dedicated indexers today
- reframe product dapp reads as protocol state plus live operator/product checks, with shared protocol indexing only when available
- tighten the blueprint protocol model so indexer language does not imply blueprint operator requirements

## Evidence
- Repo checks found no Envio/Subgraph/Ponder/Hasura/indexer artifacts in the three product blueprint repos; AI Trading only lists vault event indexing as future work in IMPROVEMENTS.md
- Installed tangle-blueprint-expert skill was stale: required references were broken symlinks to missing /home/drew/.openclaw/workspace/docs
- Updated the installed skill references and added a durable company skill with repo-grounding guardrails

## Verification
- node /home/drew/code/dotfiles/claude/skills/docs-slop-audit/scripts/scan-docs-slop.mjs <touched blueprint docs> -> 0 findings across 8 files
- rg targeted stale indexer phrases in pages/blueprints and pages/infrastructure/introduction.mdx -> no matches
- yarn format:check -> passed
- yarn check:harness-copy -> passed
- yarn check:tnt-core-sync -> passed
- git diff --check -> passed
- yarn build -> passed; generated 262 static pages and indexed 230 pages
- git merge-tree --write-tree origin/main HEAD -> 87ee61abb66d4fc60efee6e7fc9093feffe42f6b
