### PR TITLE
feat(discovery): add agent-readable docs entrypoints

### DIFF
--- a/public/.well-known/tangle-agent.json
+++ b/public/.well-known/tangle-agent.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": "2026-06-16",
+  "name": "Tangle Docs",
+  "description": "Documentation for Tangle Blueprints, operators, sandbox runtime, Router, and x402 payments.",
+  "homepage": "https://docs.tangle.tools/",
+  "llms": "https://docs.tangle.tools/llms.txt",
+  "product_manifest": "https://tangle.tools/.well-known/tangle-agent.json",
+  "recommended_first_reads": [
+    "https://docs.tangle.tools/developers/cli/quickstart",
+    "https://docs.tangle.tools/developers/blueprints/introduction",
+    "https://docs.tangle.tools/infrastructure/sandboxing"
+  ],
+  "install": [
+    "npm install @tangle-network/tcloud",
+    "npm install @tangle-network/sandbox",
+    "npm install -g @tangle-network/browser-agent-driver"
+  ]
+}

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -1,0 +1,20 @@
+# Tangle Docs
+
+Tangle Docs explain how to build and operate services on Tangle: Blueprints, operators, sandbox runtime, Router, and x402 payments.
+
+## Core pages
+
+- Docs home: https://docs.tangle.tools/
+- Developers: https://docs.tangle.tools/developers
+- Blueprints: https://docs.tangle.tools/developers/blueprints/introduction
+- Blueprint quickstart: https://docs.tangle.tools/developers/cli/quickstart
+- Sandbox docs: https://docs.tangle.tools/infrastructure/sandboxing
+- Router: https://router.tangle.tools/
+- Marketing overview: https://tangle.tools/
+
+## Agent guidance
+
+- Use the Tangle product manifest at https://tangle.tools/.well-known/tangle-agent.json.
+- Use Router OpenAPI at https://router.tangle.tools/openapi.json for model-routing calls.
+- Install scoped npm packages only: `@tangle-network/tcloud`, `@tangle-network/sandbox`, `@tangle-network/browser-agent-driver`.
+- Use `TANGLE_API_KEY` for authenticated calls.

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://docs.tangle.tools/</loc>
+  </url>
+  <url>
+    <loc>https://docs.tangle.tools/developers</loc>
+  </url>
+  <url>
+    <loc>https://docs.tangle.tools/developers/cli/quickstart</loc>
+  </url>
+  <url>
+    <loc>https://docs.tangle.tools/developers/blueprints/introduction</loc>
+  </url>
+  <url>
+    <loc>https://docs.tangle.tools/infrastructure/sandboxing</loc>
+  </url>
+</urlset>


### PR DESCRIPTION
## Summary
- Add /llms.txt for docs discovery.
- Add /.well-known/tangle-agent.json with recommended first reads and install commands.
- Add /sitemap.xml that points at real built docs routes, including /infrastructure/sandboxing.

## Verification
- git merge-tree --write-tree origin/main HEAD
- yarn next build
- dist/llms.txt, dist/sitemap.xml, and dist/.well-known/tangle-agent.json are present.