### PR TITLE
docs(release-notes): fix release note links

### DIFF
--- a/pages/release-notes/audit-agent/2026-06-29.mdx
+++ b/pages/release-notes/audit-agent/2026-06-29.mdx
@@ -21,4 +21,4 @@ Future customer-visible Audit Agent changes will be posted under this product li
 
 ## Related Links
 
-- [Public status page](https://tangle.tools/status)
+- [Audit Agent](https://audits.tangle.tools)

--- a/pages/release-notes/blueprint-agent/2026-06-29.mdx
+++ b/pages/release-notes/blueprint-agent/2026-06-29.mdx
@@ -21,5 +21,4 @@ Future customer-visible Blueprint Agent changes will be posted under this produc
 
 ## Related Links
 
-- [Tangle Blueprint Agent](https://tangle.tools/services/blueprint-agent)
-- [Public status page](https://tangle.tools/status)
+- [Blueprint Agent](https://ai.tangle.tools)

--- a/pages/release-notes/blueprint-agent/index.mdx
+++ b/pages/release-notes/blueprint-agent/index.mdx
@@ -6,7 +6,6 @@ description: Public release notes for Tangle Blueprint Agent.
 # Blueprint Agent Release Notes
 
 Public product: [ai.tangle.tools](https://ai.tangle.tools).
-Product page: [Tangle Blueprint Agent](https://tangle.tools/services/blueprint-agent).
 
 | Date          | Release note                                                         | Customer action       |
 | ------------- | -------------------------------------------------------------------- | --------------------- |

--- a/pages/release-notes/browser-agent/2026-06-29.mdx
+++ b/pages/release-notes/browser-agent/2026-06-29.mdx
@@ -21,5 +21,4 @@ Future customer-visible Browser Agent changes will be posted under this product 
 
 ## Related Links
 
-- [Tangle Browser Agent](https://tangle.tools/services/browser-agent)
-- [Public status page](https://tangle.tools/status)
+- [Browser Agent](https://browser.tangle.tools)

--- a/pages/release-notes/browser-agent/index.mdx
+++ b/pages/release-notes/browser-agent/index.mdx
@@ -6,7 +6,6 @@ description: Public release notes for Tangle Browser Agent.
 # Browser Agent Release Notes
 
 Public product: [browser.tangle.tools](https://browser.tangle.tools).
-Product page: [Tangle Browser Agent](https://tangle.tools/services/browser-agent).
 
 | Date          | Release note                                                       | Customer action       |
 | ------------- | ------------------------------------------------------------------ | --------------------- |

--- a/pages/release-notes/index.mdx
+++ b/pages/release-notes/index.mdx
@@ -9,8 +9,7 @@ Release notes are organized by product line.
 Hosted products use dated entries.
 `tnt-core` releases use versioned entries.
 
-For current service reachability, use the [public status page](https://tangle.tools/status).
-For security practices, use the [security page](https://tangle.tools/security).
+Use each product-line public URL for service reachability and support entry points.
 
 ## Views
 

--- a/pages/release-notes/router/2026-06-29.mdx
+++ b/pages/release-notes/router/2026-06-29.mdx
@@ -21,5 +21,5 @@ Future customer-visible Router changes will be posted under this product line.
 
 ## Related Links
 
+- [Router](https://router.tangle.tools)
 - [Tangle Gateway](/gateway)
-- [Public status page](https://tangle.tools/status)

--- a/pages/release-notes/sandbox/2026-06-29.mdx
+++ b/pages/release-notes/sandbox/2026-06-29.mdx
@@ -21,5 +21,4 @@ Future customer-visible sandbox changes will be posted under this product line.
 
 ## Related Links
 
-- [Tangle Sandbox](https://tangle.tools/services/sandbox)
-- [Public status page](https://tangle.tools/status)
+- [Tangle Sandbox](https://sandbox.tangle.tools)

--- a/pages/release-notes/sandbox/index.mdx
+++ b/pages/release-notes/sandbox/index.mdx
@@ -6,7 +6,6 @@ description: Public release notes for Tangle Sandbox.
 # Sandbox Release Notes
 
 Public product: [sandbox.tangle.tools](https://sandbox.tangle.tools).
-Product page: [Tangle Sandbox](https://tangle.tools/services/sandbox).
 
 | Date          | Release note                                                 | Customer action       |
 | ------------- | ------------------------------------------------------------ | --------------------- |


### PR DESCRIPTION
## Summary
- remove dead `tangle.tools/status`, `tangle.tools/security`, and old `tangle.tools/services/*` release-note links
- replace product links with live product URLs
- keep the release-note process PR #160 intact while restoring link-check health

## Checks
- `yarn check:release-notes`
- `lychee --verbose --no-progress --max-concurrency 16 --max-retries 5 --retry-wait-time 2 --accept '100..=103,200..=299,403,429' 'pages/release-notes/**/*.mdx' RELEASE_NOTES_PROCESS.md` returned 19/19 OK\n- `yarn format:check`\n- `node /home/drew/code/dotfiles-r163-install/claude/skills/docs-slop-audit/scripts/scan-docs-slop.mjs pages/release-notes`\n- `rg -n "https://tangle\\.tools/(status|security|services/[a-z-]+)|Protocol and SDKs|Tangle Protocol and SDKs|Vanta|A-LIGN|auditors?|evidence package|sampling request|<<<<<<<|=======|>>>>>>>" pages/release-notes RELEASE_NOTES_PROCESS.md` returned no matches\n- `yarn build` generated 285 static pages and indexed 246 Pagefind pages