### PR TITLE
docs(platform): Authentication & API keys

### DIFF
--- a/pages/_meta.ts
+++ b/pages/_meta.ts
@@ -14,6 +14,10 @@ const meta: Meta = {
     title: "Vision",
     type: "page",
   },
+  platform: {
+    title: "Platform",
+    type: "page",
+  },
   vibe: {
     title: "Workbench",
     type: "page",

--- a/pages/platform/_meta.ts
+++ b/pages/platform/_meta.ts
@@ -1,0 +1,7 @@
+import type { Meta } from "nextra";
+
+const meta: Meta = {
+  authentication: "Authentication & API keys",
+};
+
+export default meta;

--- a/pages/platform/authentication.mdx
+++ b/pages/platform/authentication.mdx
@@ -1,0 +1,47 @@
+# Authentication & API keys
+
+One account, one API key, one balance — across every Tangle product.
+
+## Sign in
+
+Create your account at [id.tangle.tools](https://id.tangle.tools), then sign in with email and password, GitHub, Google, or X — or an Ethereum wallet, by signing a message (nothing goes on-chain).
+
+## Get an API key
+
+Open **API keys** in [id.tangle.tools](https://id.tangle.tools) and create one. Keys start with `sk-tan-`. You see the full key only once — copy it now, and keep it secret: anyone who has it can spend your balance.
+
+Save it:
+
+```bash
+export TANGLE_API_KEY="sk-tan-paste-your-key-here"
+```
+
+## Use it
+
+Send the key as a bearer token. This one call checks the key and returns your balance:
+
+```bash
+curl -sS https://id.tangle.tools/v1/billing/balance \
+  -H "Authorization: Bearer $TANGLE_API_KEY"
+```
+
+```json
+{
+  "success": true,
+  "data": {
+    "balance": 42.50,
+    "lifetimeSpent": 128.00
+  }
+}
+```
+
+- `data.balance` — your spendable credit, in US dollars.
+- `data.lifetimeSpent` — total you've spent to date, in US dollars.
+
+A `401` with `"code": "UNAUTHORIZED"` means the key is missing or wrong.
+
+## If a key leaks
+
+Revoke it in [id.tangle.tools](https://id.tangle.tools) under **API keys** — a revoked key stops working. Use a separate key for each app or environment, so revoking one never breaks the others.
+
+Add credit and manage your plan at [id.tangle.tools](https://id.tangle.tools).


### PR DESCRIPTION
The first page of the product-docs fill: how to sign in, get an API key, use it, and check your balance — for the whole Tangle platform (id.tangle.tools).

## Why this first
Every product's docs need "how do I get a key." It didn't exist. This unblocks the rest of the fill (Intelligence, Browser Agent, Sandbox, …).

## How it was made (the ship-gate)
- **Drafted from the platform-api code**, not memory.
- **Every command live-verified against production.** Notably: `GET /v1/billing/balance` is the real auth endpoint (200 with a valid key, **401 with a bogus one**), and it returns the balance in the same call. `GET /account/me` returns 200 to *anyone* (it's the web-app shell) — so it is deliberately **not** used as a key check; documenting it would teach a false positive.
- **Graded by a 5-persona panel** (Jobs / Stripe-docs / Dunford / skeptical staff eng / Altman): v1 scored 6.0 (the skeptic caught the false-positive endpoint at 4/10); v2 scored 7.2 after the fix; v3 (this PR) adds key-revocation guidance, trims undocumented JSON fields, and cuts repetition.

## Notes
- Response example uses real field names (`data.balance`, `data.lifetimeSpent`) with illustrative values.
- New top-level **Platform** nav section.