### PR TITLE
docs: systematic anti-slop + accuracy editorial pass, add Intelligence section

### DIFF
--- a/pages/_meta.ts
+++ b/pages/_meta.ts
@@ -30,6 +30,10 @@ const meta: Meta = {
     title: "Runtime",
     type: "page",
   },
+  intelligence: {
+    title: "Intelligence",
+    type: "page",
+  },
   blueprints: {
     title: "Blueprints",
     type: "page",

--- a/pages/ai/index.mdx
+++ b/pages/ai/index.mdx
@@ -5,7 +5,7 @@ description: The shared operating layer for autonomous work, unifying the agenti
 
 # AI
 
-Tangle is the shared operating layer for autonomous work. Teams and agents collaborate in shared workbenches or separate ones, work runs in isolated sandboxes with explicit policies and resource limits, and the protocol pays the operators who host protocol-backed services. Workflows improve through agent and task evaluations collected from each run.
+Tangle runs autonomous work across a shared workbench, isolated sandboxes, and an inference gateway, and pays the operators who host protocol-backed services. Teams and agents collaborate in the same workbench or separate ones, with every run bound by explicit policies and resource limits. Teams review the task and agent evaluations from each run to tune prompts, policies, and workflows.
 
 <figure>
   <img
@@ -42,7 +42,7 @@ Core capabilities:
 
 ## Evaluation Loop
 
-Each run produces task and agent evaluations. That data feeds back into the workbench to improve prompts, policies, and workflows over time.
+Each run produces task and agent evaluations. You use that data in the workbench to refine prompts, policies, and workflows.
 
 ## Inference Gateway
 
@@ -55,7 +55,7 @@ Key capabilities:
 - **Compliance.** [Zero Data Retention](/gateway/zdr) and [no-train](/gateway/no-train) routing with verified provider agreements.
 - **On-chain payments.** [SpendAuth](/gateway/spend-auth) lets users pay operators directly without a credit card.
 
-## Learn More
+## Set up the gateway, workbench, and runtime
 
 - [Gateway: Getting Started](/gateway/getting-started)
 - [Workbench details](/vibe/introduction)

--- a/pages/blueprints/ai-agent-sandbox/index.mdx
+++ b/pages/blueprints/ai-agent-sandbox/index.mdx
@@ -43,7 +43,7 @@ Mode IDs come from the repo metadata. Treat them as network-specific config, not
 
 The internal workflow tick is scheduler-driven and should not be treated as a public on-chain job.
 
-## Read and control surface
+## Operator API endpoints
 
 The operator API owns the live product state:
 
@@ -65,7 +65,3 @@ Every data endpoint requires a signed wallet session. Production operators must 
 | [Operator Requirements](/blueprints/ai-agent-sandbox/operator-requirements) | Host setup, ports, Docker, Firecracker, TEE, state, and secrets.     |
 | [Runtime and Harnesses](/blueprints/ai-agent-sandbox/runtime-and-harnesses) | Runtime backends, capability discovery, harnesses, and AI keys.      |
 | [Dapp Integration](/blueprints/ai-agent-sandbox/dapp-and-indexer)           | Metadata, iframe policy, protocol state, and live health boundaries. |
-
-## Sources used
-
-This page is grounded in the repo `README.md`, `docs/runbook.md`, `TEE-GUIDE.md`, `metadata/blueprint-metadata.json`, `sandbox-runtime/src/operator_api.rs`, and the sidecar image docs.

--- a/pages/blueprints/ai-agent-sandbox/operator-requirements.mdx
+++ b/pages/blueprints/ai-agent-sandbox/operator-requirements.mdx
@@ -37,7 +37,7 @@ Docker is the simplest path.
 | `SIDECAR_IMAGE`                        | Sidecar image, usually `ghcr.io/tangle-network/blueprint-sidecar:all-harness`. |
 | `SIDECAR_PUBLIC_HOST` or `PUBLIC_HOST` | Public hostname used when returning sidecar or proxy URLs.                     |
 | `SIDECAR_PULL_IMAGE`                   | Whether to pull the image on first create.                                     |
-| `OPERATOR_API_PORT`                    | Operator API port. Sandbox mode defaults to `9100`.                        |
+| `OPERATOR_API_PORT`                    | Operator API port. Sandbox mode defaults to `9100`.                            |
 
 Keep raw sidecar ports private unless the operator intentionally proxies them.
 

--- a/pages/blueprints/ai-agent-sandbox/operator-requirements.mdx
+++ b/pages/blueprints/ai-agent-sandbox/operator-requirements.mdx
@@ -37,7 +37,7 @@ Docker is the simplest path.
 | `SIDECAR_IMAGE`                        | Sidecar image, usually `ghcr.io/tangle-network/blueprint-sidecar:all-harness`. |
 | `SIDECAR_PUBLIC_HOST` or `PUBLIC_HOST` | Public hostname used when returning sidecar or proxy URLs.                     |
 | `SIDECAR_PULL_IMAGE`                   | Whether to pull the image on first create.                                     |
-| `OPERATOR_API_PORT`                    | Operator API port. Sandbox mode defaults around `9100`.                        |
+| `OPERATOR_API_PORT`                    | Operator API port. Sandbox mode defaults to `9100`.                        |
 
 Keep raw sidecar ports private unless the operator intentionally proxies them.
 

--- a/pages/blueprints/ai-agent-sandbox/runtime-and-harnesses.mdx
+++ b/pages/blueprints/ai-agent-sandbox/runtime-and-harnesses.mdx
@@ -78,7 +78,7 @@ Common credential locations remain harness-specific:
 | Kimi           | `/root/.kimi` or `/root/.config/kimi`.                                       |
 | Gemini         | `/root/.gemini` or Google provider config.                                   |
 
-The operator protects the session token, sidecar auth token, provider keys, and sandbox secrets. Losing one of those is a product incident, not a docs footnote.
+The operator protects the session token, sidecar auth token, provider keys, and sandbox secrets. Losing any of these is a product incident.
 
 ## Runtime health
 

--- a/pages/blueprints/ai-trading/dapp-and-indexer.mdx
+++ b/pages/blueprints/ai-trading/dapp-and-indexer.mdx
@@ -59,7 +59,7 @@ If an operator endpoint is unreachable, say that. Do not replace it with stale p
 | Provision pending    | The service exists, but no bot is ready yet.                                      |
 | Paper                | The bot is using live data and simulated fills.                                   |
 | Live                 | The bot can submit real execution through its configured venues and vault policy. |
-| Policy blocked       | The bot generated an intent that the policy or validator path rejected.           |
+| Policy blocked       | The bot generated an intent that the policy or guardrail path rejected.           |
 
 These states should be visible in the app. "Loading" is not enough.
 

--- a/pages/blueprints/ai-trading/index.mdx
+++ b/pages/blueprints/ai-trading/index.mdx
@@ -61,7 +61,3 @@ On-chain guards live in contracts such as `PolicyEngine`, `TradeValidator`, vaul
 | [Operator Requirements](/blueprints/ai-trading/operator-requirements) | VPS sizing, install flow, service IDs, ports, env, admission, and upgrade rules.    |
 | [Runtime and Risk](/blueprints/ai-trading/runtime-and-risk)           | Paper mode, agent keys, runtime backend, risk gates, and validation trust.          |
 | [Dapp Integration](/blueprints/ai-trading/dapp-and-indexer)           | Arena iframe metadata, operator discovery, protocol state, and live operator reads. |
-
-## Sources used
-
-This page is grounded in the repo `README.md`, `OPERATORS.md`, `docs/runbook.md`, `metadata/blueprint-metadata.json`, `settings.env.example`, Arena operator discovery code, and the trading runtime/risk contract docs.

--- a/pages/blueprints/ai-trading/operator-requirements.mdx
+++ b/pages/blueprints/ai-trading/operator-requirements.mdx
@@ -5,7 +5,7 @@ description: Host, install, state, admission, and provider requirements for AI T
 
 # AI Trading Operator Requirements
 
-A trading operator is accepting bots that can spend compute, disk, model credits, and possibly capital.
+A trading operator accepts bots that can spend compute, disk, model credits, and possibly capital.
 
 Run allowlist admission and paper mode first. Move to public admission or live trading only after you have watched the operator run and fail safely.
 
@@ -62,7 +62,7 @@ Public admission means public cost exposure. Every accepted bot can use CPU, dis
 
 The operator install path defaults new bots to paper trading. Paper mode uses live market data and simulated fills; it should not move capital.
 
-AI keys are optional. If you set `ZAI_API_KEY`, `ANTHROPIC_API_KEY`, `TANGLE_API_KEY`, or OpenCode model/env settings, agentic activation and chat can use those settings when the selected sidecar advertises OpenCode. Treat OpenCode as one harness inside the same capability model as Claude Code, Kimi Code, Codex, AMP, Factory Droids, Pi, Hermes, Forge, OpenClaw, NanoClaw, ACP, Cursor, CLI base, or a smaller blueprint sidecar subset. The operator docs are clear: there is no built-in per-bot, per-day, or total LLM spend cap today. Use provider-side billing limits.
+AI keys are optional. If you set `ZAI_API_KEY`, `ANTHROPIC_API_KEY`, `TANGLE_API_KEY`, or OpenCode model/env settings, agentic activation and chat can use those settings when the selected sidecar advertises OpenCode. OpenCode is one of several harnesses a sidecar can advertise; the AI keys apply the same way across them. There is no built-in per-bot, per-day, or total LLM spend cap today — use provider-side billing limits.
 
 ## Public endpoint
 

--- a/pages/blueprints/ai-trading/operator-requirements.mdx
+++ b/pages/blueprints/ai-trading/operator-requirements.mdx
@@ -62,7 +62,7 @@ Public admission means public cost exposure. Every accepted bot can use CPU, dis
 
 The operator install path defaults new bots to paper trading. Paper mode uses live market data and simulated fills; it should not move capital.
 
-AI keys are optional. If you set `ZAI_API_KEY`, `ANTHROPIC_API_KEY`, `TANGLE_API_KEY`, or OpenCode model/env settings, agentic activation and chat can use those settings when the selected sidecar advertises OpenCode. OpenCode is one of several harnesses a sidecar can advertise; the AI keys apply the same way across them. There is no built-in per-bot, per-day, or total LLM spend cap today — use provider-side billing limits.
+AI keys are optional. If you set `ZAI_API_KEY`, `ANTHROPIC_API_KEY`, `TANGLE_API_KEY`, or OpenCode model/env settings, agentic activation and chat can use those settings when the selected sidecar advertises OpenCode. OpenCode is one of several [supported harnesses](/infrastructure/harnesses) a sidecar can advertise; the AI keys apply the same way across them. There is no built-in per-bot, per-day, or total LLM spend cap today — use provider-side billing limits.
 
 ## Public endpoint
 

--- a/pages/blueprints/ai-trading/runtime-and-risk.mdx
+++ b/pages/blueprints/ai-trading/runtime-and-risk.mdx
@@ -7,7 +7,7 @@ description: Runtime backend, paper/live mode, model keys, and risk boundaries f
 
 Trading docs should start from risk, not from agents.
 
-The bot can reason with an AI harness, but capital moves only when the runtime, validator path, and vault policy allow it. If those boundaries are unclear, the operator should stay in paper mode.
+The bot can reason with an AI harness, but capital moves only when the runtime, signing path, and vault policy allow it. If those boundaries are unclear, the operator should stay in paper mode.
 
 ## Runtime backend
 
@@ -33,7 +33,7 @@ Runtime choice is separate from trust mode. A TEE bot can still have bad policy,
 
 ## Paper mode
 
-Paper mode is the safe default in the operator install path. It uses live market data and simulated fills. The operator repo has done work to model fees, impact, and gas so paper PnL is less fantasy than a frictionless simulator.
+Paper mode is the safe default in the operator install path. It uses live market data and simulated fills. The operator repo models fees, impact, and gas so paper PnL is less fantasy than a frictionless simulator.
 
 Paper mode should still be treated as real production behavior:
 
@@ -46,7 +46,7 @@ Paper mode should still be treated as real production behavior:
 
 | Mode           | Who checks trades                                     | Latency profile                | Use when                                                                  |
 | -------------- | ----------------------------------------------------- | ------------------------------ | ------------------------------------------------------------------------- |
-| `PerTrade`     | Validator committee signs each trade intent.          | 5 to 30 seconds.               | The operator is untrusted or the vault needs external approval per trade. |
+| `PerTrade`     | Operator signing committee signs each trade intent.   | 5 to 30 seconds.               | The operator is untrusted or the vault needs external approval per trade. |
 | `Envelope`     | A depositor-approved envelope bounds what can happen. | Immediate inside the envelope. | The user accepts bounded autonomy.                                        |
 | `SelfOperated` | Local operator policy, still inside envelope limits.  | Immediate.                     | The operator and depositor are the same trust domain.                     |
 
@@ -74,7 +74,7 @@ Do not show "AI approved" as if that is a safety property. The useful safety fac
 - paper or live
 - trust mode
 - envelope present and not expired
-- validators reachable when required
+- operators reachable when required
 - vault policy loaded
 - trade blocked or signed
 - operator health

--- a/pages/blueprints/index.mdx
+++ b/pages/blueprints/index.mdx
@@ -7,9 +7,9 @@ description: First-party Tangle blueprints, written for users, operators, and ap
 
 A Tangle blueprint is a product template that operators can run. It is not the live service by itself.
 
-The live unit is a service instance. A user requests it, picks registered operators, and then sends jobs to that instance. Tangle Cloud should make that lifecycle obvious: template first, operator capacity second, service instance third.
+The live unit is a service instance. A user requests it, picks registered operators, and then sends jobs to that instance. The lifecycle runs in that order: pick a template, confirm operator capacity, then a service instance is created.
 
-## Start here
+## The core vocabulary
 
 If you only remember one model, use this:
 
@@ -50,4 +50,4 @@ A shared protocol indexer can turn protocol events into app state. It can tell t
 | AI Trading       | https://github.com/tangle-network/ai-trading-blueprint               |
 | Surplus Market   | Internal Tangle repository; public app at `surplus-market.pages.dev` |
 
-These docs describe the current repo contracts and the public app integration shape. If a repo says a path is not live yet, the docs should say the same thing.
+These docs describe the current repo contracts and the public app integration shape. Where a repo marks a path as not yet live, that product's page says so.

--- a/pages/blueprints/operator-matrix.mdx
+++ b/pages/blueprints/operator-matrix.mdx
@@ -62,7 +62,7 @@ AI Trading uses the same sidecar direction for agentic work, but the trading pro
 | Blueprint        | Indexer can show                                                                                       | Product must still prove                                                                                             |
 | ---------------- | ------------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------- |
 | AI Agent Sandbox | Blueprint registration, operator registration, service requests, jobs, source updates, and heartbeats. | Endpoint health, sandbox readiness, secret handling, TEE attestation, and sidecar capability support.                |
-| AI Trading       | Blueprint registration, service instances, operator endpoints, jobs, pricing pointers, and heartbeats. | Bot health, paper/live mode, model spend, vault policy, trade execution, and validator status.                       |
+| AI Trading       | Blueprint registration, service instances, operator endpoints, jobs, pricing pointers, and heartbeats. | Bot health, paper/live mode, model spend, vault policy, trade execution, and operator heartbeat/liveness.                       |
 | Surplus Market   | Blueprint registration, operator registration, service instances, jobs, endpoints, and heartbeats.     | Order-book correctness, fill settlement, credit redemption, attester quorum, SP1 proof path, and inference delivery. |
 
 ## Operator preflight

--- a/pages/blueprints/operator-matrix.mdx
+++ b/pages/blueprints/operator-matrix.mdx
@@ -62,7 +62,7 @@ AI Trading uses the same sidecar direction for agentic work, but the trading pro
 | Blueprint        | Indexer can show                                                                                       | Product must still prove                                                                                             |
 | ---------------- | ------------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------- |
 | AI Agent Sandbox | Blueprint registration, operator registration, service requests, jobs, source updates, and heartbeats. | Endpoint health, sandbox readiness, secret handling, TEE attestation, and sidecar capability support.                |
-| AI Trading       | Blueprint registration, service instances, operator endpoints, jobs, pricing pointers, and heartbeats. | Bot health, paper/live mode, model spend, vault policy, trade execution, and operator heartbeat/liveness.                       |
+| AI Trading       | Blueprint registration, service instances, operator endpoints, jobs, pricing pointers, and heartbeats. | Bot health, paper/live mode, model spend, vault policy, trade execution, and operator heartbeat/liveness.            |
 | Surplus Market   | Blueprint registration, operator registration, service instances, jobs, endpoints, and heartbeats.     | Order-book correctness, fill settlement, credit redemption, attester quorum, SP1 proof path, and inference delivery. |
 
 ## Operator preflight

--- a/pages/blueprints/protocol-model.mdx
+++ b/pages/blueprints/protocol-model.mdx
@@ -9,7 +9,7 @@ Blueprints are easy to explain badly because one word gets used for too many thi
 
 A blueprint is the template. It defines what can be run: jobs, metadata, binaries, app routing, and optional Blueprint Service Manager logic. Operators register for that template. A user requests a service instance from a set of registered operators. The user interacts with the service instance, not the template.
 
-## The lifecycle
+## From template to live instance
 
 1. A developer publishes a blueprint definition, runnable artifact, metadata, and any blueprint-specific contracts.
 2. Operators register for the blueprint and publish the endpoint or metadata the app needs to find them.

--- a/pages/blueprints/surplus-market/dapp-and-indexer.mdx
+++ b/pages/blueprints/surplus-market/dapp-and-indexer.mdx
@@ -7,11 +7,11 @@ description: Dapp routing, metadata gaps, protocol state, and live venue checks 
 
 Surplus is live as a hosted app at `https://surplus-market.pages.dev/`.
 
-Tangle Cloud should treat it as a first-party link-out until the repo publishes rich `blueprintUi` metadata and a `*.blueprint.tangle.tools` iframe host. Do not pretend it has the same iframe contract as Sandbox and Trading yet.
+Tangle Cloud should treat it as a first-party link-out until the repo publishes `blueprintUi` metadata and a `*.blueprint.tangle.tools` iframe host. Do not pretend it has the same iframe contract as Sandbox and Trading yet.
 
 The Surplus repo does not ship a dedicated indexer today. The product app can read protocol state from contracts or a shared protocol indexing layer when one exists, but the venue, order book, settlement outbox, and inference redemption state live in the product/operator path.
 
-## Current metadata
+## Metadata is minimal (no blueprintUi yet)
 
 The current deployed metadata is minimal:
 
@@ -21,7 +21,7 @@ The current deployed metadata is minimal:
 | `category`        | `inference-market`              |
 | `code_repository` | Internal Surplus repository URL |
 
-It does not yet include the rich `blueprintUi` object used by Sandbox and Trading. The dapp should keep a first-party registry entry for `surplus` until that changes.
+It does not yet include the full `blueprintUi` object used by Sandbox and Trading. The dapp should keep a first-party registry entry for `surplus` until that changes.
 
 ## Routing rule
 

--- a/pages/blueprints/surplus-market/index.mdx
+++ b/pages/blueprints/surplus-market/index.mdx
@@ -11,7 +11,7 @@ Buyers acquire discounted credits. Operators sell or make markets in those credi
 
 Source repo: internal Tangle repository. The public surface is the hosted app and these docs until the repo is public.
 
-## What happens in the product
+## From order to settlement
 
 1. An operator runs a venue.
 2. Buyers and sellers place orders or request firm quotes.
@@ -70,7 +70,3 @@ The placeholders preserve compact job index compatibility. Do not remove them wi
 | [Operator Requirements](/blueprints/surplus-market/operator-requirements)       | Venue host, settlement keys, inference backend, CLOB, and privacy mode.           |
 | [Settlement and Inference](/blueprints/surplus-market/settlement-and-inference) | Credit lots, redemption, attester quorum, SP1 path, and inference proof boundary. |
 | [Dapp Integration](/blueprints/surplus-market/dapp-and-indexer)                 | Current link-out app, metadata gap, protocol state, and live venue checks.        |
-
-## Sources used
-
-This page is grounded in the repo `README.md`, `BLUEPRINT.md`, `blueprint.toml`, `deploy/blueprint-definition.toml`, `deploy/blueprint-metadata.json`, `docs/testnet-release.md`, `operator/src/bin/blueprint.rs`, and `operator/src/http.rs`.

--- a/pages/developers/auth-surface.mdx
+++ b/pages/developers/auth-surface.mdx
@@ -187,7 +187,7 @@ Staking and delegation are a separate proxy with its own role registry. Function
 
 `MANAGER_ROLE` SHOULD be the timelock. The 24h emergency deprecation delay is the floor on how fast a single role can disable an MBSM revision; combined with the timelock delay on top, a queued malicious deprecation has at least `timelockDelay + 24h` of observability before it lands.
 
-## Beacon stack
+## Beacon Stack
 
 ### `ValidatorPodManager`
 

--- a/pages/developers/blueprint-auth.mdx
+++ b/pages/developers/blueprint-auth.mdx
@@ -5,8 +5,9 @@ description: How blueprint-manager enforces authn/authz for off-chain HTTP/gRPC 
 
 # Blueprint Auth Proxy (`blueprint-auth`)
 
-Blueprints often expose off-chain HTTP/gRPC endpoints (APIs, agents, gateways, etc.). In the Tangle Blueprint stack,
-those endpoints are typically fronted by an **auth proxy** that runs inside `blueprint-manager`.
+The **auth proxy** inside `blueprint-manager` is the single point that authenticates, authorizes, and injects tenant
+identity for a Blueprint's off-chain HTTP/gRPC endpoints (APIs, agents, gateways, etc.). Blueprints often expose such
+endpoints, and in the Tangle Blueprint stack they are typically fronted by this proxy.
 
 That proxy is implemented by the `blueprint-auth` crate and is the **single enforcement point** for:
 
@@ -27,7 +28,7 @@ Source of truth (implementation-focused):
 - Applies to: **off-chain** requests that go through the manager’s proxy to your service `upstream_url`.
 - Does not apply to: **on-chain jobs** (`jobs submit`, contract calls). On-chain callers authenticate by signing transactions.
 
-## Key Concepts
+## Identity headers: service_id, x-tenant-id, x-scopes
 
 - `service_id`: Identifies the service behind the proxy. Minting endpoints require `X-Service-Id: <service_id>`.
 - Tenant identity: The proxy injects **`x-tenant-id`** (a privacy-safe hash) so upstreams can partition data safely.

--- a/pages/developers/blueprint-contexts/evm-provider-context.mdx
+++ b/pages/developers/blueprint-contexts/evm-provider-context.mdx
@@ -8,9 +8,9 @@ import GithubFileReaderDisplay from '/components/GithubFileReaderDisplay';
 
 SDK source (GitHub): https://github.com/tangle-network/blueprint/tree/main/crates/contexts
 
-The `EvmInstrumentedClientContext` trait provides a standardized [alloy-rs](https://github.com/alloy-rs) EVM provider for interacting with EVM-compatible blockchain networks in your Blueprint.
+The `EvmInstrumentedClientContext` trait provides an [alloy-rs](https://github.com/alloy-rs) EVM provider for interacting with EVM-compatible blockchain networks in your Blueprint.
 
-## Context Summary
+## The EvmInstrumentedClientContext trait
 
 The `EvmInstrumentedClientContext` trait provides access to an EVM provider:
 
@@ -25,7 +25,7 @@ The `EvmInstrumentedClientContext` trait provides access to an EVM provider:
 
 ### 1. Define Your Context
 
-First, define your context struct that implements the `EvmProviderContext` trait:
+First, define your context struct that implements the `EvmInstrumentedClientContext` trait:
 
 <GithubFileReaderDisplay
   url="https://github.com/tangle-network/blueprint/blob/main/crates/macros/context-derive/tests/ui/basic.rs"

--- a/pages/developers/blueprint-contexts/introduction.mdx
+++ b/pages/developers/blueprint-contexts/introduction.mdx
@@ -8,7 +8,7 @@ SDK source (GitHub): https://github.com/tangle-network/blueprint/tree/main/crate
 
 In the [Blueprint SDK](https://github.com/tangle-network/blueprint/tree/main), a Context holds utilities and dependencies that a job may need that aren't direct inputs. Think of it as a container for all the external resources and services your job requires to function.
 
-A Context can include various elements such as:
+A Context can include:
 
 - HTTP clients for making network requests
 - Access to a keystore
@@ -21,9 +21,9 @@ A Context can include various elements such as:
 
 The Context pattern is closely related to the Dependency Injection (DI) design pattern, which is a technique for achieving Inversion of Control (IoC) between classes and their dependencies.
 
-## Why do we need Contexts?
+## What a Context buys you
 
-The Context pattern offers several significant benefits in software design and development:
+Contexts give you:
 
 1. **Decoupling**: By passing dependencies through a Context, we decouple the job implementation from the specific implementations of its dependencies. This makes the code more modular and easier to maintain.
 

--- a/pages/developers/blueprint-contexts/keystore-context.mdx
+++ b/pages/developers/blueprint-contexts/keystore-context.mdx
@@ -8,9 +8,9 @@ import GithubFileReaderDisplay from '/components/GithubFileReaderDisplay';
 
 SDK source (GitHub): https://github.com/tangle-network/blueprint/tree/main/crates/contexts
 
-The `KeystoreContext` trait provides a standardized interface for accessing, managing, and signing using cryptographic keys in your Blueprint.
+The `KeystoreContext` trait lets your Blueprint create, store, and sign with cryptographic keys (ECDSA, SR25519, ED25519, BN254_BLS, BLS381).
 
-## Context Summary
+## Key operations
 
 The `KeystoreContext` trait provides access to a `Keystore` that implements the `Backend` trait, offering:
 

--- a/pages/developers/blueprint-contexts/tangle-client-context.mdx
+++ b/pages/developers/blueprint-contexts/tangle-client-context.mdx
@@ -8,12 +8,12 @@ import GithubFileReaderDisplay from '/components/GithubFileReaderDisplay';
 
 SDK source (GitHub): https://github.com/tangle-network/blueprint/tree/main/crates/contexts
 
-The `TangleClientContext` trait provides a standardized interface for interacting with the Tangle protocol from a
-Blueprint. It exposes a typed `TangleClient` configured from the blueprint environment.
+The `TangleClientContext` trait gives a Blueprint a typed `TangleClient` for submitting transactions to Tangle and
+querying service/operator state. It is configured from the blueprint environment.
 
-## Context Summary
+## What the client can do
 
-The `TangleClientContext` trait provides access to a client that enables:
+The client lets a Blueprint:
 
 - Transaction submission to core protocol contracts
 - Service and operator state queries

--- a/pages/developers/blueprint-qos.mdx
+++ b/pages/developers/blueprint-qos.mdx
@@ -8,9 +8,9 @@ import GithubFileReaderDisplay from "/components/GithubFileReaderDisplay";
 
 SDK source (GitHub): https://github.com/tangle-network/blueprint/tree/main/crates/qos
 
-This guide explains how to integrate the Blueprint SDK Quality of Service (QoS) system for observability, monitoring, and dashboards. QoS combines heartbeats, metrics, logs, and Grafana dashboards into a single service that you can run alongside any Blueprint.
+QoS combines heartbeats, metrics, logs, and Grafana dashboards into a single service that you can run alongside any Blueprint.
 
-## QoS Summary
+## What QoS Includes
 
 The Blueprint QoS system provides a complete observability stack:
 
@@ -231,7 +231,7 @@ if let Some(qos) = &ctx.qos_service {
 
 Custom on-chain metrics let your Blueprint report arbitrary numeric values that are ABI-encoded into each heartbeat, stored on the `OperatorStatusRegistry` contract, and queryable by anyone. This enables transparent SLA enforcement, slashing based on performance, and cross-operator comparison.
 
-### How It Works
+### From Rust Code to On-Chain Storage
 
 The flow from Rust to on-chain storage:
 

--- a/pages/developers/blueprint-runner/background-services.mdx
+++ b/pages/developers/blueprint-runner/background-services.mdx
@@ -8,9 +8,9 @@ import GithubFileReaderDisplay from '/components/GithubFileReaderDisplay';
 
 SDK source (GitHub): https://github.com/tangle-network/blueprint/tree/main/crates/runner
 
-Background services are optional components in the [Blueprint Runner](/developers/blueprint-runner/introduction) architecture that run continuously to support the operation of your blueprint. This document explains how background services work, how to configure them, and best practices for implementation.
+Background services are optional components in the [Blueprint Runner](/developers/blueprint-runner/introduction) architecture that run continuously to support the operation of your blueprint.
 
-## What are Background Services?
+## Long-running processes that outlive a job
 
 Background services refer to any long-running processes that operate independently of job execution. They:
 
@@ -58,7 +58,7 @@ The only requirement for a background service is that it implements the `Backgro
   title="Defining a Background Service"
 />
 
-With a background service defined, it is passed into the Blueprint Runner's builder as producers and consumers are:
+Pass the background service into the runner's builder, the same way you add producers and consumers:
 
 <GithubFileReaderDisplay
   url="https://github.com/tangle-network/blueprint/blob/main/examples/incredible-squaring/incredible-squaring-bin/src/main.rs"
@@ -67,7 +67,7 @@ With a background service defined, it is passed into the Blueprint Runner's buil
   title="Adding a Background Service to the Blueprint Runner"
 />
 
-For some background services, it may be necessary to add some sort of cleanup code that runs when the Blueprint Runner shuts down. This can be done in the `with_shutdown_handler` method seen in the above code. This specific example just prints a message, but it might end a background process gracefully.
+For some background services, you may need cleanup code that runs when the runner shuts down. This can be done in the `with_shutdown_handler` method seen in the above code. This specific example just prints a message, but it might end a background process gracefully.
 
 ## Integration with Other Components
 
@@ -77,9 +77,7 @@ Background services work closely with other Blueprint Runner components:
 - **Producers**: Background services can support [producers](/developers/blueprint-runner/producers) by maintaining connections or monitoring event sources
 - **Consumers**: Background services can assist [consumers](/developers/blueprint-runner/consumers) with resource management or periodic tasks
 
-## Next Steps
-
-Now that you understand background services, it might be helpful to take a look at:
+## Related components
 
 - [Routers](/developers/blueprint-runner/routers) - How to direct job calls to appropriate handlers
 - [Producers](/developers/blueprint-runner/producers) - How to capture and process events

--- a/pages/developers/blueprint-runner/building.mdx
+++ b/pages/developers/blueprint-runner/building.mdx
@@ -8,7 +8,7 @@ import GithubFileReaderDisplay from '/components/GithubFileReaderDisplay';
 
 SDK source (GitHub): https://github.com/tangle-network/blueprint/tree/main/crates/runner
 
-This guide provides a step-by-step approach to building a Blueprint Runner, the primary component of a Blueprint.
+A Blueprint Runner is the binary at the center of a Blueprint: it wires jobs to an event source (producer) and a result sink (consumer), routes calls, and runs them. This page builds one end to end.
 
 ## Prerequisites
 
@@ -30,7 +30,7 @@ A Blueprint Runner consists of:
 5. **[Consumer](/developers/blueprint-runner/consumers) Configuration**: Setup for the handling of results from jobs
 6. **[Background Service](/developers/blueprint-runner/background-services) Configuration**: Setup for supporting services (e.g. databases, servers, etc.)
 
-## Step-by-Step Guide
+## Build the runner
 
 ### Step 1: Setting Up the Project Structure
 
@@ -165,7 +165,7 @@ let result = BlueprintRunner::builder(tangle_config, env)
 
 The `run` method starts the Blueprint Runner and returns a result indicating whether it ran successfully or encountered an error.
 
-With this, the Blueprint Runner can start and serve the components you attached to the builder.
+The runner now starts and serves every component you attached to the builder.
 
 ## Next Steps
 

--- a/pages/developers/blueprint-runner/consumers.mdx
+++ b/pages/developers/blueprint-runner/consumers.mdx
@@ -60,7 +60,7 @@ BlueprintRunner::builder(tangle_config, env)
 
 ## Types of Consumers
 
-Blueprint Runners can utilize various types of consumers depending on the requirements:
+Blueprint Runners can use several types of consumers depending on the requirements:
 
 ### Tangle Consumer
 

--- a/pages/developers/blueprint-runner/introduction.mdx
+++ b/pages/developers/blueprint-runner/introduction.mdx
@@ -8,9 +8,9 @@ import CardGrid from "../../../components/CardGrid.tsx"
 
 SDK source (GitHub): https://github.com/tangle-network/blueprint/tree/main/crates/runner
 
-Blueprint Runners are the core orchestration components that execute Tangle Blueprints. They manage the lifecycle of jobs, coordinate between different components, and ensure reliable execution of your blueprint service.
+Blueprint Runners are the core orchestration components that execute Tangle Blueprints. They run each job to completion, route events to the right handler, and restart failed work.
 
-## Getting Started
+## In this section
 
 <CardGrid
   cards={[
@@ -96,7 +96,7 @@ The architecture of a Blueprint Runner consists of the following components:
 
 ## Blueprint Runner Lifecycle
 
-The Blueprint Runner follows a well-defined lifecycle to ensure reliable execution of your blueprint:
+A runner moves each job through six stages:
 
 1. **Initialization**: The Blueprint Runner loads configuration, sets up components, and establishes connections.
 2. **Event Processing**: [Producers](/developers/blueprint-runner/producers) listen for events and convert them into job inputs.
@@ -107,4 +107,4 @@ The Blueprint Runner follows a well-defined lifecycle to ensure reliable executi
 
 ## Next Steps
 
-Ready to build your own Blueprint Runner? Check out our [step-by-step guide](/developers/blueprint-runner/building) to get started.
+Build a runner: follow the [step-by-step guide](/developers/blueprint-runner/building).

--- a/pages/developers/blueprint-runner/job-triggers.mdx
+++ b/pages/developers/blueprint-runner/job-triggers.mdx
@@ -11,9 +11,7 @@ In Blueprint Runner terms, most "triggers" are just ways to produce a `JobCall`.
 
 If something can emit a stream of `JobCall`s, the runner can route them to job handlers.
 
-This page is a guide to the common trigger patterns and where they live in the SDK.
-
-## Mental Model
+## Producers and JobCalls
 
 - A `Producer` is a `Stream<Item = Result<JobCall, BoxError>>`.
 - A `JobCall` is the unit the router dispatches.

--- a/pages/developers/blueprint-runner/jobs.mdx
+++ b/pages/developers/blueprint-runner/jobs.mdx
@@ -8,17 +8,15 @@ import GithubFileReaderDisplay from '/components/GithubFileReaderDisplay';
 
 SDK source (GitHub): https://github.com/tangle-network/blueprint/tree/main/crates/runner
 
-Jobs are the core building blocks of a [Blueprint Runner](/developers/blueprint-runner/introduction). They define the computational tasks that your Blueprint will execute in response to events. This document explains how jobs work, how to define them, and how to integrate them with other components of your Blueprint.
+Jobs are the core building blocks of a [Blueprint Runner](/developers/blueprint-runner/introduction). They define the computational tasks that your Blueprint will execute in response to events.
 
-## What are Jobs?
+## Jobs are event-driven functions
 
 In a Blueprint, jobs are functions that:
 
 1. Receive inputs from [producers](/developers/blueprint-runner/producers)
 2. Perform specific computational tasks
 3. Return results that can be processed by [consumers](/developers/blueprint-runner/consumers)
-
-Jobs are the heart of your Blueprint's functionality, encapsulating the business logic that processes events and produces meaningful results.
 
 ## Job Definition
 

--- a/pages/developers/blueprint-runner/producers.mdx
+++ b/pages/developers/blueprint-runner/producers.mdx
@@ -47,7 +47,7 @@ BlueprintRunner::builder(tangle_config, env)
 
 ## Types of Producers
 
-Blueprint Runners can utilize various types of producers depending on the event sources:
+Blueprint Runners can use several types of producers depending on the event sources:
 
 ### Blockchain Producers
 

--- a/pages/developers/blueprint-runner/routers.mdx
+++ b/pages/developers/blueprint-runner/routers.mdx
@@ -8,9 +8,9 @@ import GithubFileReaderDisplay from '/components/GithubFileReaderDisplay';
 
 SDK source (GitHub): https://github.com/tangle-network/blueprint/tree/main/crates/runner
 
-Routers are a critical component of the [Blueprint Runner](/developers/blueprint-runner/introduction) architecture. They are responsible for directing job calls to the appropriate job handlers based on job IDs. This document explains how routers work, how to configure them, and best practices for implementation.
+A router in the [Blueprint Runner](/developers/blueprint-runner/introduction) maps each job ID to the handler that runs it, validates the parameters, and returns the result.
 
-## What are Routers?
+## How a router dispatches a job call
 
 In a Blueprint Runner, a router acts as a traffic director for job execution. When a job is called, the router:
 
@@ -19,14 +19,14 @@ In a Blueprint Runner, a router acts as a traffic director for job execution. Wh
 3. Passes the parameters to the job handler
 4. Returns the result to the consumer
 
-Routers ensure that jobs are executed by the appropriate handlers, making them essential for the proper functioning of your Blueprint Runner.
+If no route matches the job ID, the call is rejected before any handler runs.
 
 ## Router Configuration
 
 Routers are configured when building the Blueprint Runner in the `main.rs` file of your Blueprint's binary. The configuration involves:
 
 1. Creating a new router
-2. Defining routes for each job you have, mapping a job ID to each job in it's route
+2. Defining routes for each job you have, mapping a job ID to each job in its route
 3. Setting a context for the router, which will contain any resources needed by the jobs
 
 ### Basic Router Setup
@@ -59,7 +59,7 @@ Layers are used to filter job calls based on certain criteria. There are two pla
 2. A whole Router:
    - A layer can be used to filter job calls based on criteria you control (for example, metadata from Tangle extractors).
 
-## Integration with Other Components
+## Producers in, consumers out
 
 Routers work closely with other Blueprint Runner components:
 

--- a/pages/developers/blueprint-runner/webhooks.mdx
+++ b/pages/developers/blueprint-runner/webhooks.mdx
@@ -7,9 +7,6 @@ import GithubFileReaderDisplay from "/components/GithubFileReaderDisplay";
 
 # Webhooks Gateway
 
-SDK source (GitHub): https://github.com/tangle-network/blueprint/tree/main/crates/webhooks
-Crate README (GitHub): https://github.com/tangle-network/blueprint/blob/main/crates/webhooks/README.md
-
 The webhooks feature is an optional HTTP ingress path for a Blueprint Runner. It lets you expose one or more HTTP
 endpoints that:
 
@@ -25,7 +22,7 @@ This is useful when your blueprint needs to react to external events that are no
 - external schedulers or orchestrators that should trigger a job handler
 - bridging legacy systems into a service instance without writing a custom producer
 
-## How It Fits In the Runner
+## WebhookGateway and WebhookProducer
 
 `WebhookGateway` runs as a `BackgroundService` (an `axum` server), and `WebhookProducer` is the paired producer that
 turns verified webhook requests into `JobCall`s.
@@ -72,7 +69,7 @@ Notes:
 - For `bearer`, `hmac-sha256`, and `api-key`, `secret` is required.
 - `secret` supports `env:VAR_NAME` expansion.
 - `service_id` is set at runtime, not from TOML. If it is left as `0`, downstream components that rely on a service ID
-  will not behave as expected.
+  cannot correlate calls to the intended service instance.
 
 ## Auth Modes
 
@@ -90,3 +87,8 @@ Supported auth modes are:
 - Each configured webhook endpoint responds `202 Accepted` on success and returns a `call_id`.
 - Treat webhook ingress as untrusted input. Validate and parse the request body inside the job handler.
 - Prefer `hmac-sha256` or `bearer` when receiving webhooks from the public internet.
+
+## Resources
+
+- [SDK source (GitHub)](https://github.com/tangle-network/blueprint/tree/main/crates/webhooks)
+- [Crate README (GitHub)](https://github.com/tangle-network/blueprint/blob/main/crates/webhooks/README.md)

--- a/pages/developers/blueprint-runner/x402.mdx
+++ b/pages/developers/blueprint-runner/x402.mdx
@@ -7,10 +7,6 @@ import GithubFileReaderDisplay from "/components/GithubFileReaderDisplay";
 
 # x402 Payment Gateway
 
-SDK source (GitHub): https://github.com/tangle-network/blueprint/tree/main/crates/x402
-Crate README (GitHub): https://github.com/tangle-network/blueprint/blob/main/crates/x402/README.md
-Example blueprint (GitHub): https://github.com/tangle-network/blueprint/blob/main/examples/x402-blueprint/README.md
-
 x402 is an optional, off-chain payment ingress path for job execution. It exposes HTTP endpoints that require a valid
 x402 payment (typically stablecoins on an EVM chain) and then injects a `JobCall` into the Blueprint Runner after the
 payment is verified and settled by an x402 facilitator.
@@ -18,7 +14,11 @@ payment is verified and settled by an x402 facilitator.
 This is useful when you want a service to accept payments from clients on EVM chains without requiring the client to
 submit on-chain Tangle transactions for each job.
 
-## How It Fits In the Runner
+SDK source (GitHub): https://github.com/tangle-network/blueprint/tree/main/crates/x402
+Crate README (GitHub): https://github.com/tangle-network/blueprint/blob/main/crates/x402/README.md
+Example blueprint (GitHub): https://github.com/tangle-network/blueprint/blob/main/examples/x402-blueprint/README.md
+
+## Gateway and Producer wiring
 
 `X402Gateway` runs as a `BackgroundService` and `X402Producer` is the paired producer that converts verified payments
 into `JobCall`s.

--- a/pages/developers/blueprint-sdk.mdx
+++ b/pages/developers/blueprint-sdk.mdx
@@ -47,7 +47,7 @@ The CLI exposes these as shared flags:
   title="cargo-tangle: shared TangleClientArgs (RPC + contract addresses + keystore)"
 />
 
-## Navigation
+## Build, run, and operate a blueprint
 
 <TableOfContentCards
   items={[

--- a/pages/developers/blueprints/execution-confidentiality.mdx
+++ b/pages/developers/blueprints/execution-confidentiality.mdx
@@ -18,7 +18,7 @@ Tangle uses four confidentiality modes:
 - `tee_required`: require TEE placement and fail closed if it cannot be satisfied.
 - `standard_required`: require non-TEE execution.
 
-## How Developers Declare It
+## Declare confidentiality in the manifest
 
 When you register a blueprint through a definition manifest, set the execution policy under
 `metadata.execution_profile.confidentiality`:

--- a/pages/developers/blueprints/introduction.mdx
+++ b/pages/developers/blueprints/introduction.mdx
@@ -35,7 +35,7 @@ For example, an LLM inference Blueprint can define the model-serving code, the j
   ]}
 />
 
-## The Basic Model
+## Blueprints, Services, and Jobs
 
 There are three core objects:
 
@@ -135,9 +135,7 @@ Blueprints can support several payment paths:
 - x402 and machine payment compatible APIs;
 - custom payment logic in a Blueprint Service Manager.
 
-For protocol-level payment details, see [Pricing & Payments](/developers/blueprints/pricing-and-payments) and the `tnt-core` pricing guide:
-
-`https://github.com/tangle-network/tnt-core/blob/main/docs/PRICING.md`
+For protocol-level payment details, see [Pricing & Payments](/developers/blueprints/pricing-and-payments) and the [tnt-core pricing guide](https://github.com/tangle-network/tnt-core/blob/main/docs/PRICING.md).
 
 ## A Simple Example
 

--- a/pages/developers/blueprints/manager.mdx
+++ b/pages/developers/blueprints/manager.mdx
@@ -6,11 +6,11 @@ SDK source (GitHub): https://github.com/tangle-network/blueprint/tree/main/crate
 
 <ExpandableImage src="/images/blueprint-manager-diagram.png" alt="Blueprint Manager Diagram" />
 
-On Tangle, Blueprints have both onchain and offchain lifecycles. The offchain component is managed by the
-**Blueprint Manager**, which is the operator runtime for Tangle services. This onchain and offchain logic
+The **Blueprint Manager** is the operator runtime for Tangle services. It runs the offchain half of every
+Blueprint's lifecycle while chain events drive the onchain half. This onchain and offchain logic
 functions as follows:
 
-1. Operators must register for Blueprints onchain. This indicates an operators willingness to accept requests for Blueprint Instances of that type.
+1. Operators must register for Blueprints onchain. This indicates an operator's willingness to accept requests for Blueprint Instances of that type.
 2. Operators download the Blueprint's artifacts and metadata after registering. The Blueprint Manager watches chain
    events and keeps the operator runtime in sync.
 3. Operators execute Blueprint services when they are assigned. The Blueprint Manager runs artifacts natively, in a
@@ -23,7 +23,7 @@ functions as follows:
 Blueprints interact with the Tangle Network in several key ways:
 
 1. Blueprints are deployed to Tangle, with their metadata and manager contracts stored on-chain.
-2. Customers instantiate a Service, which represents a single configured service instance.
+2. Customers instantiate a Service: one configured, running deployment of the Blueprint.
 3. Services end once they reach their time-to-live (TTL) or run out of funds to pay operators.
 
 When confidentiality is declared or requested, the manager uses that policy to decide whether standard execution is
@@ -33,7 +33,7 @@ For renewal, migration, and expiry edge cases, see:
 
 - `/developers/blueprints/service-lifecycle`
 
-Blueprints provide a useful abstraction, allowing developers to create reusable service infrastructures as if they were smart contracts. This enables developers to monetize their work and align long-term incentives with the success of their creations, benefiting proportionally to their Blueprint's usage.
+Developers publish a Blueprint once, like deploying a contract, and earn a share of the fees paid each time an operator runs an instance of it.
 
 Blueprints and Services are managed by the Tangle Protocol contracts in `tnt-core`, including the core `Tangle` contract and
 the `BlueprintServiceManager` stack. Staking and operator registration live in these contracts, and the Blueprint

--- a/pages/developers/blueprints/pricing-and-payments.mdx
+++ b/pages/developers/blueprints/pricing-and-payments.mdx
@@ -7,14 +7,14 @@ import GithubFileReaderDisplay from "/components/GithubFileReaderDisplay";
 
 # Pricing and Payments
 
-This page describes the protocol-level pricing surface for Tangle blueprints: which pricing models exist, when to use
-them, and how fixed rates vs RFQ (request-for-quote) work for both services and jobs.
+Every Tangle blueprint declares one of three pricing models (PayOnce, Subscription, EventDriven) at registration. This
+page covers each model, per-job fixed rates, and RFQ (request-for-quote) quoting for services and jobs.
 
 If you are looking for the operator-side gRPC daemon that generates EIP-712 quotes, see:
 
 - `/developers/blueprints/pricing-engine`
 
-## Source Of Truth
+## Protocol reference (tnt-core PRICING.md)
 
 The protocol reference lives in `tnt-core`:
 

--- a/pages/developers/blueprints/pricing-engine.mdx
+++ b/pages/developers/blueprints/pricing-engine.mdx
@@ -18,7 +18,7 @@ Protocol overview (pricing models, fixed per-job rates, RFQ semantics):
 - Use it when you want operators to answer RFQs off-chain (service creation quotes and/or per-job quotes).
 - If your blueprint only uses fixed pricing (e.g. per-job rates via `setJobEventRates`), you can skip it.
 
-## End-to-End Flow
+## Two RFQ Modes: Service and Per-Job Quotes
 
 The pricing engine supports two RFQ modes:
 
@@ -110,7 +110,7 @@ gRPC server to return x402 settlement options, you need to construct the pricing
 - Pricing engine README: https://github.com/tangle-network/blueprint/blob/main/crates/pricing-engine/README.md
 - Pricing proto: https://github.com/tangle-network/blueprint/blob/main/crates/pricing-engine/proto/pricing.proto
 
-## Best Practices
+## RFQ Client Rules
 
 1. Get multiple quotes from multiple operators and compare them.
 2. Verify signatures before using quotes on-chain.

--- a/pages/developers/blueprints/service-lifecycle.mdx
+++ b/pages/developers/blueprints/service-lifecycle.mdx
@@ -22,7 +22,7 @@ For the canonical on-chain API surface, see:
 - **TTL**: time-to-live for a service. In the current protocol implementation, TTL checks use `block.timestamp`. A TTL of
   `0` means "no expiry".
 
-## Creating A Service
+## Creating a Service
 
 There are two high-level creation flows:
 
@@ -32,9 +32,8 @@ There are two high-level creation flows:
 
 The CLI primarily covers the request and approve flow. RFQ flows often require custom client code today.
 
-Both flows can now carry execution confidentiality intent at the protocol layer. That means service creation can bind not
-just operator set and payment terms, but also whether the service should run in standard execution, prefer TEE, or
-require TEE.
+Both flows can now carry execution confidentiality intent at the protocol layer. Service creation now binds the
+confidentiality mode — standard execution, prefer TEE, or require TEE — alongside the operator set and payment terms.
 
 ## Extending A Service (Renewal)
 
@@ -58,7 +57,7 @@ Key properties to design around:
 If you need to extend a service that was created via the request and approve flow, the typical path today is to create a
 new service (request flow or RFQ flow), then migrate at the blueprint layer.
 
-## Migrating Or Rotating Operators
+## Migrating or Rotating Operators
 
 If an extension requires a new operator set, the protocol does not provide a single "extend and replace operators"
 transaction.
@@ -112,7 +111,7 @@ agreement is already over, and so a request cannot be rescued past its expiry gr
   the new `forceRemoveAllowsBelowMin(serviceId)` hook (default: `false`). Blueprints that
   genuinely need emergency-eviction-below-min must override that hook to return `true`.
 
-## Safety Recommendations For Stateful Or Custodial Blueprints
+## Safety Recommendations for Stateful or Custodial Blueprints
 
 If your blueprint holds user funds, tokens, or state that must remain withdrawable, assume that:
 

--- a/pages/developers/blueprints/use-cases.mdx
+++ b/pages/developers/blueprints/use-cases.mdx
@@ -1,9 +1,9 @@
 import NonuniformTableOfContentCards from "../../../components/NonuniformTableOfContentCards";
 import GithubRepoCard, { GithubRepoList } from "../../../components/GithubRepoCard";
 
-# Use Cases
+# Example Blueprints
 
-Blueprints work best when a service needs outside operators, explicit payment terms, and a repeatable way to request live instances. These examples show the kinds of services teams have built or templated with Tangle.
+These examples show the kinds of services teams have built or templated with Tangle. Blueprints work best when a service needs outside operators, explicit payment terms, and a repeatable way to request live instances.
 
 ## Bridges
 

--- a/pages/developers/cli/debugging.mdx
+++ b/pages/developers/cli/debugging.mdx
@@ -1,10 +1,12 @@
 # Debugging Blueprints
 
-CLI source (GitHub): https://github.com/tangle-network/blueprint/tree/main/cli
+Spawn your blueprint locally in a native, VM, or container sandbox to debug it before deploying.
 
-Blueprints can be deployed to multiple different [sources](/developers/deployment/sources/introduction), with each one
+Blueprints can be deployed to several [sources](/developers/deployment/sources/introduction), with each one
 having its own constraints. The CLI has commands to test your blueprint in these environments, assuming your machine is
 capable of hosting them, see [requirements](/operators/manager/requirements).
+
+CLI source (GitHub): https://github.com/tangle-network/blueprint/tree/main/cli
 
 Supported spawn methods:
 
@@ -15,7 +17,7 @@ Supported spawn methods:
 Note that in any case, the commands need to be run at the root of the blueprint's directory, as the CLI will read the
 generated `blueprint.json`.
 
-# Native Debugging
+## Native Debugging
 
 See the [requirements](/operators/manager/requirements#native-sources)
 
@@ -32,7 +34,7 @@ To test your blueprint natively (as a host process):
    $ cargo tangle debug spawn --method native --binary "./target/debug/my-blueprint-bin"
    ```
 
-# VM Debugging
+## VM Debugging
 
 See the [requirements](/operators/manager/requirements#native-sources)
 
@@ -51,7 +53,7 @@ To test your blueprint in a VM sandbox:
 
 Once spawned, the VM's output will be printed to the terminal (you may need to press `enter` first).
 
-# Container Debugging
+## Container Debugging
 
 See the [requirements](/operators/manager/requirements#container-sources)
 

--- a/pages/developers/cli/installation.mdx
+++ b/pages/developers/cli/installation.mdx
@@ -4,6 +4,8 @@ title: Installation
 
 # Tangle CLI Installation
 
+The Tangle CLI (`cargo-tangle`) scaffolds, builds, and deploys Blueprints from your terminal.
+
 CLI source (GitHub): https://github.com/tangle-network/blueprint/tree/main/cli
 
 ## Prerequisites
@@ -15,12 +17,10 @@ You can install Rust by following the instructions on the [Rust Installation Gui
 or run the following command:
 
 ```shell
-    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 ```
 
-Install from source
-
-1. From source (nightly)
+## Install from source
 
 > The script supports Linux, MacOS, and Windows (WSL2)
 

--- a/pages/developers/cli/keys.mdx
+++ b/pages/developers/cli/keys.mdx
@@ -6,7 +6,7 @@ title: Tangle CLI Key Commands
 
 CLI source (GitHub): https://github.com/tangle-network/blueprint/tree/main/cli
 
-This guide covers the key management commands available in the Tangle CLI tool. These commands allow you to generate, import, export, and list cryptographic keys used by Tangle protocols.
+Generate, import, export, and list the cryptographic keys the Tangle CLI uses. Each `cargo tangle key` command is documented below.
 
 ## Key Commands
 

--- a/pages/developers/cli/quickstart.mdx
+++ b/pages/developers/cli/quickstart.mdx
@@ -4,7 +4,7 @@ title: Quickstart
 
 # Tangle CLI Quickstart
 
-CLI source (GitHub): https://github.com/tangle-network/blueprint/tree/main/cli
+Create a new Tangle Blueprint and deploy it in two commands.
 
 ## Pre-requisites
 
@@ -27,3 +27,7 @@ cargo tangle blueprint create --name <blueprint-name>
 ## Deploying your Blueprint
 
 See [Deployment](/developers/deployment/introduction)
+
+---
+
+CLI source (GitHub): https://github.com/tangle-network/blueprint/tree/main/cli

--- a/pages/developers/cli/tangle.mdx
+++ b/pages/developers/cli/tangle.mdx
@@ -4,9 +4,9 @@ title: Tangle CLI Blueprint Commands
 
 # Tangle CLI Blueprint Commands
 
-CLI source (GitHub): https://github.com/tangle-network/blueprint/tree/main/cli
+`cargo-tangle` creates and operates blueprints on Tangle’s EVM protocol. This page is the command reference.
 
-This page covers the `cargo-tangle` CLI surface for creating and operating blueprints on Tangle’s EVM protocol.
+CLI source (GitHub): https://github.com/tangle-network/blueprint/tree/main/cli
 
 Note: the CLI still uses the legacy flag name `--restaking-contract`. It refers to the staking contract (`MultiAssetDelegation`).
 
@@ -73,9 +73,7 @@ cargo tangle blueprint service --help
 cargo tangle blueprint service request --help
 ```
 
-The protocol now supports confidentiality intent on service requests and RFQ service quotes. Depending on the SDK/CLI
-version you are running, the newest confidentiality argument may appear first in the raw contract interfaces before every
-high-level helper command exposes it.
+The protocol now supports confidentiality intent on service requests and RFQ service quotes. On older CLI builds, pass the confidentiality argument through the raw contract call; newer builds expose it on the helper commands. Check `--help`.
 
 Example (operator approval flow):
 

--- a/pages/developers/code-merge-process.mdx
+++ b/pages/developers/code-merge-process.mdx
@@ -1,8 +1,8 @@
 # Code Merge Process
 
-This document describes Tangle Network's process for merging code into production branches across all active repositories.
+Every change to a Tangle Network production branch lands through a reviewed, CI-gated pull request. Direct pushes to `main` are blocked in every repo.
 
-## Overview
+## GitHub, `main`, and automated deploys
 
 All Tangle Network repositories use GitHub as the source control platform. The `main` branch is the production branch. Merging to `main` triggers automated deployment pipelines.
 

--- a/pages/developers/contribute.mdx
+++ b/pages/developers/contribute.mdx
@@ -2,10 +2,10 @@ import { RepoArea } from "../../components/RepoArea.tsx"
 
 # Contribute
 
-All of Tangle's technology is open source and we invite researchers, developers, operators, and builders to improve the
-protocol, SDK, and tooling for autonomous work.
+All of Tangle's technology is open source and we invite anyone to improve the
+protocol, SDKs, and the sandbox, gateway, and Blueprint tooling.
 
-Security and reliability are core to the mission. We encourage all users to report any security vulnerabilities or bugs
+We prioritize security bugs and want to hear about them. We encourage all users to report any security vulnerabilities or bugs
 that they discover while using our products.
 
 ## Submitting a Bug Report
@@ -40,6 +40,6 @@ If you discover a security vulnerability or bug and have the skills to provide a
 
 We may also reward users who responsibly disclose security vulnerabilities or bugs through our bug bounty program. The rewards vary depending on the severity of the issue and the quality of the bug report or pull request.
 
-## Contact Information
+## Questions about the bounty
 
 If you have any questions or concerns about our bug bounty program, please contact us at hello@tangle.tools. We take all bug reports seriously and will do our best to respond to your report as soon as possible.

--- a/pages/developers/deployment/introduction.mdx
+++ b/pages/developers/deployment/introduction.mdx
@@ -1,13 +1,13 @@
 # Deploying Blueprints
 
-In order for a blueprint to be instance-able, it'll need to be deployed and have one or more sources defined.
+Deploy a Blueprint with one or more sources defined before anyone can create an instance of it.
 
-If your blueprint has confidentiality requirements, also declare an execution policy in blueprint metadata. TEE is not a
+If your Blueprint has confidentiality requirements, also declare an execution policy in Blueprint metadata. TEE is not a
 separate source type. See [Execution Confidentiality](/developers/blueprints/execution-confidentiality).
 
 ## Defining Sources
 
-Before deploying, you must specify the sources from which to fetch the blueprint binaries.
+Before deploying, you must specify the sources from which to fetch the Blueprint binaries.
 See [Sources](/developers/deployment/sources/introduction).
 
 ### Testing Your Sources
@@ -16,7 +16,7 @@ To verify that your sources are valid, see [Debugging Blueprints](/developers/cl
 
 ## Deploying via the CLI
 
-Once you're ready to deploy your blueprint, simply:
+To deploy your Blueprint:
 
 Install the [cargo-tangle] CLI, if you haven't already.
 

--- a/pages/developers/deployment/sources/container.mdx
+++ b/pages/developers/deployment/sources/container.mdx
@@ -1,7 +1,6 @@
 # Container Source
 
-The `Container` source is used for blueprints that are intended to be built as container images and published to image
-registries, such as `docker.io`.
+Use the `Container` source for blueprints you build as container images and publish to registries like `docker.io`.
 
 Container sources are also the only TEE-eligible artifact source on the current Tangle manager path. If you want to
 allow or require TEE execution, keep using `Container` and declare the confidentiality policy in blueprint metadata. See
@@ -9,7 +8,7 @@ allow or require TEE execution, keep using `Container` and declare the confident
 
 ## Requirements
 
-The requirements for running containerized blueprints are available [here](/operators/manager/requirements#container-sources)
+See the [container source requirements](/operators/manager/requirements#container-sources) for running containerized blueprints.
 
 ## Format
 
@@ -29,7 +28,7 @@ Where:
 - `image` - The name of the image (e.g., `some-user/my-blueprint`)
 - `tag` - The release tag of the image (e.g., `latest`)
 
-And they can be specified in the manifest of your binary crate like so:
+Specify them in your binary crate's manifest:
 
 ```toml
 [package.metadata.blueprint]

--- a/pages/developers/deployment/sources/introduction.mdx
+++ b/pages/developers/deployment/sources/introduction.mdx
@@ -1,6 +1,6 @@
 # Blueprint Sources
 
-Blueprints can be built and distributed in multiple formats (visible on the sidebar).
+A source tells operators where to fetch and how to run your blueprint artifact. Blueprints can be built and distributed in multiple formats.
 
 Sources describe how operators fetch and execute your artifact. They do not describe confidentiality policy. If your
 blueprint should run in a TEE, declare that separately in `metadata.execution_profile.confidentiality`. See

--- a/pages/developers/deployment/sources/native.mdx
+++ b/pages/developers/deployment/sources/native.mdx
@@ -1,11 +1,11 @@
 # Native Sources
 
-The `Native` source is used for blueprints that compile to a native binary and release via the [`release.yml`] GitHub workflow
+Use the `Native` source for blueprints that compile to a native binary and release through the [`release.yml`] GitHub workflow
 from the blueprint template.
 
 ## Requirements
 
-The requirements for running native blueprints are available [here](/operators/manager/requirements#native-sources)
+See the [native source requirements](/operators/manager/requirements#native-sources).
 
 ## Format
 

--- a/pages/developers/deployment/sources/testing.mdx
+++ b/pages/developers/deployment/sources/testing.mdx
@@ -1,6 +1,6 @@
 # Testing Source
 
-The `Testing` source is a special, automatically generated source that was historically used by the [Blueprint Manager]
+The `Testing` source is an automatically generated source that was historically used by the [Blueprint Manager]
 during integration tests. It has since been replaced with the [test harnesses](/developers/testing-with-tangle).
 
 ## Format

--- a/pages/developers/deployment/sources/wasm.mdx
+++ b/pages/developers/deployment/sources/wasm.mdx
@@ -1,7 +1,6 @@
 # WebAssembly Sources
 
-The `WASM` (WebAssembly) source is used for blueprints that are built as WASM binaries and intended to be executed in
-a WASM runtime such as [Wasmtime].
+The `WASM` source defines a blueprint that ships as a WASM binary and runs in a WASM runtime such as [Wasmtime].
 
 ## Requirements
 

--- a/pages/developers/endpoints.mdx
+++ b/pages/developers/endpoints.mdx
@@ -4,7 +4,7 @@ import NetworkTabs from "../../components/NetworkResources.tsx"
 
 Use this page when you need the public dapp, chain endpoints, explorers, wallet metadata, or source repos for Tangle.
 
-## What to use
+## Pick a resource by task
 
 | Need                             | Use                                                                     |
 | -------------------------------- | ----------------------------------------------------------------------- |

--- a/pages/developers/key-contacts.mdx
+++ b/pages/developers/key-contacts.mdx
@@ -1,6 +1,6 @@
 # Key Contacts
 
-Primary points of contact for Tangle Network security, operations, and compliance matters.
+Primary points of contact for Tangle Network security and compliance matters.
 
 | Role               | Name       | Email              |
 | ------------------ | ---------- | ------------------ |

--- a/pages/developers/p2p-networking/overview.mdx
+++ b/pages/developers/p2p-networking/overview.mdx
@@ -7,12 +7,10 @@ import CardGrid from "../../../components/CardGrid.tsx"
 
 # P2P Networking Fundamentals
 
-SDK source (GitHub): https://github.com/tangle-network/blueprint/tree/main/crates/networking
-
 The [Blueprint SDK](https://github.com/tangle-network/blueprint/tree/main) provides P2P networking utilities that allow developers to securely orchestrate
 communications among multiple service operators.
 
-## Examples
+## Example blueprints using P2P networking
 
 <CardGrid
     cards={[

--- a/pages/developers/p2p-networking/testing.mdx
+++ b/pages/developers/p2p-networking/testing.mdx
@@ -2,10 +2,10 @@
 
 SDK source (GitHub): https://github.com/tangle-network/blueprint/tree/main/crates/networking
 
-When you build multi-operator protocols, the networking test utilities let you spin up multiple libp2p nodes and verify
+The networking test utilities spin up multiple libp2p nodes and verify
 handshakes and message flow without running a full chain.
 
-## Example: Multi-node handshake + message
+## Multi-node handshake and message
 
 ```rust
 use blueprint_sdk::crypto::k256::K256Ecdsa;
@@ -41,7 +41,7 @@ async fn test_p2p_protocol() {
 }
 ```
 
-## Tips
+## Test-network helpers
 
 - Use `create_whitelisted_nodes` to keep key management consistent across your test network.
 - `wait_for_all_handshakes` gives deterministic readiness checks before you start sending messages.

--- a/pages/developers/p2p-networking/usage.mdx
+++ b/pages/developers/p2p-networking/usage.mdx
@@ -5,7 +5,7 @@ SDK source (GitHub): https://github.com/tangle-network/blueprint/tree/main/crate
 To spin up a P2P network, build a `NetworkConfig` and start a `NetworkService`. The service spawns its event loop and
 returns a `NetworkServiceHandle` you can clone into jobs and background services.
 
-## Example
+## Start a network and send a message
 
 ```rust
 use blueprint_sdk::crypto::k256::K256Ecdsa;

--- a/pages/developers/protocol-architecture.mdx
+++ b/pages/developers/protocol-architecture.mdx
@@ -4,12 +4,12 @@ title: Protocol Architecture
 
 # Protocol Architecture
 
+Tangle is the current protocol (EVM-based) composed of a small set of core contracts.
+
 For a system-level view (roles, flows, and code maps), start here:
 
 - [System Architecture](/developers/system-architecture/overview)
 - [API Reference](/developers/api/reference)
-
-Tangle is the current protocol (EVM-based) composed of a small set of core contracts:
 
 ## Core Contracts
 
@@ -27,7 +27,7 @@ TNT distribution at protocol launch is handled via:
 - `TangleMigration`: Merkle + SP1/ZK-gated claim contract for legacy-chain (SS58) allocations.
 - Deploy-time carveouts to prevent non-claimable balances being stuck (treasury module accounts; foundation allocation).
 
-## How To Integrate
+## Contract Addresses and RPC
 
 Contract addresses are deployment-dependent. Use the published addresses and RPC for your environment:
 

--- a/pages/developers/slashing.mdx
+++ b/pages/developers/slashing.mdx
@@ -5,7 +5,7 @@ description: Lifecycle, dispute economics, and operations runbook for the Tangle
 
 # Slashing
 
-When an operator misbehaves, the protocol burns or redistributes a fraction of their stake and, proportionally, their delegators' stake. This page covers the on-chain lifecycle, the authorization surface, dispute economics, and runbooks for operators and the slashing admin.
+When an operator misbehaves, the protocol burns a fraction of their stake and, proportionally, their delegators' stake. This page covers the on-chain lifecycle, the authorization surface, dispute economics, and runbooks for operators and the slashing admin.
 
 The slashing path is implemented in:
 
@@ -187,7 +187,7 @@ When an operator joins a service via `approveService(ApprovalParams)` with a non
 
 This differs from prior behavior, which slashed all enabled assets uniformly. An operator who committed `TNT@5000bps` and `USDC@2000bps` to service A but only `TNT@5000bps` to service B will have only TNT slashed for a service-B violation.
 
-## Future Evolution
+## What can change without redeployment
 
 The `Tangle` contract is UUPS-upgradeable through `TangleTimelock`. The slashing model can evolve without redeployment:
 

--- a/pages/developers/system-architecture/overview.mdx
+++ b/pages/developers/system-architecture/overview.mdx
@@ -12,14 +12,14 @@ Tangle is an EVM protocol for instantiating and operating **services (“bluepri
 - **On-chain contracts** (service lifecycle, payments, staking, incentives, slashing)
 - **Off-chain runtime** (operators running blueprint managers/runners that react to events and submit results)
 
-## Roles and How They Engage
+## Roles and Responsibilities
 
 - **Blueprint developers** publish blueprint definitions and optionally run a service manager contract.
 - **Operators** register for blueprints, run the off-chain runtime, and submit results + heartbeats.
 - **Stakers / delegators** delegate assets to operators and (optionally) constrain delegation to specific blueprints.
 - **Customers** create services (by request/approve or by signed quotes) and submit jobs.
 
-## End-to-End Flow (High Level)
+## End-to-End Flow: Blueprint to Payout
 
 1. Developer **creates a blueprint** (definition + schemas + execution sources).
 2. Operators **register** for that blueprint and advertise preferences.

--- a/pages/developers/system-architecture/rewards.mdx
+++ b/pages/developers/system-architecture/rewards.mdx
@@ -62,7 +62,7 @@ This keeps incentives explicit and avoids hidden inflation.
 
 If you are building on top of this system, the safe default flows are:
 
-- Use `Tangle` for service payments and let `Payments.sol` route splits.
+- Use `Tangle` for service payments and let `PaymentsDistribution.sol` route splits.
 - Read staker fee rewards from `ServiceFeeDistributor` (or let users claim directly).
 - Read TNT incentives from `RewardVaults`, and optional staker inflation from `ServiceFeeDistributor`.
 
@@ -75,10 +75,10 @@ Service pays 10 ETH with a 20/20/40/20 split:
 
 ## Code + Tests
 
-- Split logic: `src/v2/core/Payments.sol`
-- Staker distribution: `src/v2/rewards/ServiceFeeDistributor.sol`
-- Inflation budgets: `src/v2/rewards/InflationPool.sol`
-- Staking incentives: `src/v2/rewards/RewardVaults.sol`
+- Split logic: `src/core/PaymentsDistribution.sol`
+- Staker distribution: `src/rewards/ServiceFeeDistributor.sol`
+- Inflation budgets: `src/rewards/InflationPool.sol`
+- Staking incentives: `src/rewards/RewardVaults.sol`
 - Tests:
   - `test/v2/tangle/Payments.t.sol`
   - `test/v2/rewards/ServiceFeeDistributor.t.sol`

--- a/pages/developers/system-architecture/rewards.mdx
+++ b/pages/developers/system-architecture/rewards.mdx
@@ -80,11 +80,11 @@ Service pays 10 ETH with a 20/20/40/20 split:
 - Inflation budgets: `src/rewards/InflationPool.sol`
 - Staking incentives: `src/rewards/RewardVaults.sol`
 - Tests:
-  - `test/v2/tangle/Payments.t.sol`
-  - `test/v2/rewards/ServiceFeeDistributor.t.sol`
-  - `test/v2/rewards/ServiceFeeDistributorStreaming.t.sol`
-  - `test/v2/Rewards.t.sol`
-  - `test/v2/InflationPool.t.sol`
+  - `test/tangle/Payments.t.sol`
+  - `test/rewards/ServiceFeeDistributor.t.sol`
+  - `test/rewards/ServiceFeeDistributorStreaming.t.sol`
+  - `test/Rewards.t.sol`
+  - `test/InflationPool.t.sol`
 
 <GithubFileReaderDisplay
   url="https://github.com/tangle-network/tnt-core/blob/main/src/rewards/ServiceFeeDistributor.sol"

--- a/pages/developers/testing-with-tangle.mdx
+++ b/pages/developers/testing-with-tangle.mdx
@@ -1,7 +1,5 @@
 # Testing with Tangle
 
-## How to test your blueprint with Tangle
-
 This guide walks through the local testing flow used by the [Blueprint SDK](https://github.com/tangle-network/blueprint/tree/main). It spins up a seeded Anvil network with the
 Tangle Protocol contracts from `tnt-core`, so you can test Blueprint Manager flows without running legacy infrastructure.
 

--- a/pages/developers/troubleshooting.mdx
+++ b/pages/developers/troubleshooting.mdx
@@ -31,5 +31,5 @@ Verify that your blueprint's jobs and reports are implemented correctly. If meta
   url="https://github.com/tangle-network/blueprint/blob/main/examples/incredible-squaring/incredible-squaring-bin/build.rs"
   fromLine={1}
   toLine={22}
-  title="Blueprint metadata build script (v2 example)"
+  title="Blueprint metadata build script"
 />

--- a/pages/developers/troubleshooting.mdx
+++ b/pages/developers/troubleshooting.mdx
@@ -2,11 +2,9 @@ import GithubFileReaderDisplay from "../../components/GithubFileReaderDisplay";
 
 # Troubleshooting Guide
 
-This guide helps developers troubleshoot common issues when working with Tangle Network blueprints.
+A blueprint build most often fails when metadata generation chokes on rustdoc JSON. Here's how to isolate the real compiler error.
 
-## Common Issues
-
-### Blueprint Metadata Build Failures
+## Blueprint Metadata Build Failures
 
 If you encounter build failures when developing blueprints:
 

--- a/pages/developers/upgrade-discipline.mdx
+++ b/pages/developers/upgrade-discipline.mdx
@@ -38,7 +38,7 @@ mapping(uint64 => Service) internal _services;
 uint256[44] private __gap;
 ```
 
-When adding a `mapping` or a single `uint256`, reduce the gap by 1. When adding a struct that occupies 3 slots in storage, reduce by 3. Adding a `uint64` AND a `uint64` AND an `address` that pack into a single slot reduces by 1. Pay attention to packing.
+When adding a `mapping` or a single `uint256`, reduce the gap by 1. When adding a struct that occupies 3 slots in storage, reduce by 3. Adding an `address` AND a `uint64` AND a `uint32` that pack into a single slot reduces by 1. Pay attention to packing.
 
 For a struct stored INSIDE a mapping, appending fields to the struct does NOT consume gap slots in the parent contract (the struct is not inline). Slashing's `SlashProposal` and `SlashConfig` are extended this way.
 

--- a/pages/gateway/api-compliance.mdx
+++ b/pages/gateway/api-compliance.mdx
@@ -5,6 +5,8 @@ description: Query and manage provider ZDR and no-train compliance data.
 
 # Provider Compliance API
 
+These endpoints report each provider's Zero Data Retention (ZDR) and no-train guarantees.
+
 ## GET /api/gateway/compliance
 
 List compliance data for all providers. Public endpoint (rate-limited).

--- a/pages/gateway/api-generation.mdx
+++ b/pages/gateway/api-generation.mdx
@@ -1,6 +1,6 @@
 ---
 title: GET /v1/generation
-description: Look up detailed information about a specific request.
+description: Look up detailed information about a specific generation by its ID.
 ---
 
 # GET /v1/generation

--- a/pages/gateway/authentication.mdx
+++ b/pages/gateway/authentication.mdx
@@ -5,7 +5,7 @@ description: Authentication methods for Tangle Gateway.
 
 # Authentication
 
-Four authentication methods, each with different rate limits and capabilities.
+Four ways to authenticate to the gateway — plus anonymous access to free-tier models — each with its own rate limit.
 
 ## API Key
 
@@ -29,7 +29,7 @@ Browser-based authentication via Better Auth. Supports email/password and OAuth 
 
 ## SIWE (Sign-In with Ethereum)
 
-Wallet-based authentication via EIP-191 signatures. Authenticate with your Ethereum wallet.
+Wallet-based authentication: sign an EIP-191 message with your Ethereum wallet.
 
 ```
 POST /api/siwe/verify
@@ -38,7 +38,7 @@ POST /api/siwe/verify
 
 ## SpendAuth (On-Chain Payment)
 
-EIP-712 signed payment authorization. No account needed - pay operators directly on-chain.
+EIP-712 signed payment authorization. No account needed — pay operators directly on-chain.
 
 ```bash
 curl -H "X-Payment-Signature: {\"commitment\":\"0x...\",\"amount\":\"1000000\",...}" \

--- a/pages/gateway/byok.mdx
+++ b/pages/gateway/byok.mdx
@@ -73,10 +73,10 @@ If the header is absent, platform credentials were used (possibly via fallback).
 
 ## Pricing
 
-| Credential type      | Markup                       |
-| -------------------- | ---------------------------- |
-| BYOK                 | **0%**—provider list price   |
-| Platform credentials | 20% markup (configurable)    |
+| Credential type      | Markup                     |
+| -------------------- | -------------------------- |
+| BYOK                 | **0%**—provider list price |
+| Platform credentials | 20% markup (configurable)  |
 
 ## Security
 

--- a/pages/gateway/byok.mdx
+++ b/pages/gateway/byok.mdx
@@ -5,7 +5,7 @@ description: Use your own provider API keys with Tangle Gateway for zero-markup 
 
 # Bring Your Own Key (BYOK)
 
-Use your existing provider API keys with Tangle Gateway. BYOK requests have **zero platform markup** - you pay the provider's list price directly.
+Use your existing provider API keys with Tangle Gateway. BYOK requests have **zero platform markup**—you pay the provider's list price directly.
 
 ## Per-request BYOK
 
@@ -75,12 +75,12 @@ If the header is absent, platform credentials were used (possibly via fallback).
 
 | Credential type      | Markup                       |
 | -------------------- | ---------------------------- |
-| BYOK                 | **0%** - provider list price |
+| BYOK                 | **0%**—provider list price   |
 | Platform credentials | 20% markup (configurable)    |
 
 ## Security
 
-- BYOK credentials are never logged, stored, or persisted.
+- BYOK credentials are never logged or stored.
 - Credentials exist only in memory for the duration of the request.
 - The `providerOptions` field is stripped from the request body before forwarding to providers.
 - Credentials are validated by structure (`apiKey` must be a string) and sanitized against prototype pollution.

--- a/pages/gateway/caching.mdx
+++ b/pages/gateway/caching.mdx
@@ -24,7 +24,7 @@ Some providers require explicit cache markers to enable prompt caching, while ot
 }
 ```
 
-## How it works
+## Per-provider behavior
 
 | Provider                       | Caching Type | What `auto` does                                                        |
 | ------------------------------ | ------------ | ----------------------------------------------------------------------- |

--- a/pages/gateway/enterprise-zdr.mdx
+++ b/pages/gateway/enterprise-zdr.mdx
@@ -5,7 +5,7 @@ description: Configure Zero Data Retention for your organization.
 
 # Enterprise ZDR Setup
 
-This guide walks through configuring ZDR for an organization that needs to guarantee no prompts or responses are retained by AI providers.
+Configure ZDR so no prompts or responses are retained by the AI providers you route to.
 
 ## Step 1: Understand the trust model
 
@@ -59,7 +59,7 @@ If your required model is only available from a non-ZDR provider, the request wi
 
 ## Step 4: Set up BYOK (optional)
 
-For maximum control, use [BYOK](/gateway/byok) with your own provider keys. This gives you:
+Use [BYOK](/gateway/byok) with your own provider keys. This gives you:
 
 - Zero platform markup
 - Direct contractual relationship with the provider

--- a/pages/gateway/fallbacks.mdx
+++ b/pages/gateway/fallbacks.mdx
@@ -7,7 +7,7 @@ description: Configure backup models that are tried when the primary model fails
 
 Specify backup models that are tried in order if the primary model fails or is unavailable.
 
-## Usage
+## Configure fallback models
 
 Pass a `models` array in `providerOptions.gateway`:
 
@@ -31,7 +31,7 @@ The gateway tries:
 
 The response comes from the first model that succeeds.
 
-## How fallback works
+## Each model runs the full routing chain
 
 For each model in the list, the gateway runs the full routing chain:
 

--- a/pages/gateway/feature-flags.mdx
+++ b/pages/gateway/feature-flags.mdx
@@ -26,7 +26,7 @@ ENABLE_GUARDRAILS=false    # Disable all guardrail scanning
 ENABLE_RESPONSE_CACHE=false # Disable response cache reads/writes
 ```
 
-## Notes
+## Behavior when disabled
 
 - `ENABLE_COMPLIANCE_FILTER` only disables the early validation check that returns a 400 before routing. The actual ZDR/no-train enforcement in the routing tiers (skip operators, skip LiteLLM) stays active regardless. This flag is for suppressing the early error, not for bypassing compliance.
 

--- a/pages/gateway/free-tier.mdx
+++ b/pages/gateway/free-tier.mdx
@@ -19,16 +19,16 @@ Try the gateway without credits. Free tier restricts to cheap, fast models with 
 
 Free tier requests can use:
 
-| Model                       | Provider  | Why it's free       |
-| --------------------------- | --------- | ------------------- |
-| `gpt-4o-mini`               | OpenAI    | Small, cheap        |
-| `claude-3-5-haiku-20241022` | Anthropic | Fast, cheap         |
-| `llama-3.1-8b-instant`      | Groq      | Free tier inference |
-| `llama-3.2-1b-preview`      | Groq      | Tiny model          |
-| `llama-3.2-3b-preview`      | Groq      | Small model         |
-| `gemini-2.0-flash-lite`     | Google    | Free tier           |
-| `cerebras/llama-3.1-8b`     | Cerebras  | Fast, cheap         |
-| `deepseek-chat`             | DeepSeek  | Very cheap          |
+| Model                       | Provider  |
+| --------------------------- | --------- |
+| `gpt-4o-mini`               | OpenAI    |
+| `claude-3-5-haiku-20241022` | Anthropic |
+| `llama-3.1-8b-instant`      | Groq      |
+| `llama-3.2-1b-preview`      | Groq      |
+| `llama-3.2-3b-preview`      | Groq      |
+| `gemini-2.0-flash-lite`     | Google    |
+| `cerebras/llama-3.1-8b`     | Cerebras  |
+| `deepseek-chat`             | DeepSeek  |
 
 ## Blocked models
 

--- a/pages/gateway/getting-started.mdx
+++ b/pages/gateway/getting-started.mdx
@@ -3,7 +3,7 @@ title: Getting Started
 description: Make your first inference request through Tangle Gateway in 2 minutes.
 ---
 
-# Getting Started
+# Your first Gateway request
 
 ## 1. Get an API key
 

--- a/pages/gateway/how-routing-works.mdx
+++ b/pages/gateway/how-routing-works.mdx
@@ -50,7 +50,7 @@ When `zeroDataRetention` or `disallowPromptTraining` is set:
 Request → Tier 3: Direct Provider (verified only) → Response
 ```
 
-Tiers 1 and 2 are completely bypassed. The gateway routes only to providers with verified compliance agreements. See [Zero Data Retention](/gateway/zdr) for the trust model.
+Tiers 1 and 2 are bypassed. The gateway routes only to providers with verified compliance agreements. See [Zero Data Retention](/gateway/zdr) for the trust model.
 
 ## Routing control
 

--- a/pages/gateway/index.mdx
+++ b/pages/gateway/index.mdx
@@ -7,7 +7,7 @@ description: Unified API for hundreds of AI models with built-in routing, compli
 
 Tangle Gateway is a unified inference API. One endpoint, hundreds of models, and routing across provider APIs and registered Tangle operators.
 
-## What it does
+## One key for every provider and operator
 
 - **One key, any model.** Access OpenAI, Anthropic, Google, Groq, Mistral, and 20+ providers through a single API key.
 - **Operator network.** Route to operators registered for [Blueprints](/developers/blueprints/introduction); the gateway selects from their advertised endpoint, model support, price, latency, and reputation data.
@@ -42,13 +42,13 @@ The gateway routes through three tiers, in order:
 
 When [Zero Data Retention](/gateway/zdr) or [no-train](/gateway/no-train) is requested, operators and LiteLLM are skipped - the gateway routes directly to verified providers only.
 
-## How it fits
+## Where the gateway sits
 
 ```
 Workbench (agents) → Gateway (inference) → Operators (serving) → Protocol (settlement)
 ```
 
-The gateway sits between the [Workbench](/vibe/introduction) where agents run and the [Protocol](/network/overview) where operators get paid. Agents in the workbench call the gateway for model access. The gateway selects the best provider or operator, routes the request, tracks usage, and settles payment.
+The gateway sits between the [Workbench](/vibe/introduction) where agents run and the [Protocol](/network/overview) where operators get paid. Agents in the workbench call the gateway for model access. The gateway selects a provider or operator by price, latency, and reputation, routes the request, tracks usage, and settles payment.
 
 ## Next steps
 

--- a/pages/gateway/migrate-openai.mdx
+++ b/pages/gateway/migrate-openai.mdx
@@ -48,9 +48,7 @@ Tangle Gateway is OpenAI-compatible. Change two lines and you're done.
     -d '{"model": "gpt-4o", "messages": [...]}'
 ```
 
-## What you get
-
-By switching to Tangle Gateway, you get:
+## What Tangle adds over the OpenAI API
 
 - **Access to every provider** through the same client. Try `anthropic/claude-sonnet-4-6` or `groq/llama-3.1-70b` without changing SDKs.
 - **Automatic fallbacks.** If OpenAI is down, configure backup models.

--- a/pages/gateway/migrate-vercel.mdx
+++ b/pages/gateway/migrate-vercel.mdx
@@ -28,7 +28,7 @@ Tangle Gateway supports the same `providerOptions.gateway` schema as Vercel AI G
 | **Base URL**          | `ai-gateway.vercel.sh/v1`             | `router.tangle.tools/v1`                                              |
 | **Auth**              | API key or OIDC token                 | API key, session, SIWE (wallet), or SpendAuth (on-chain)              |
 | **Pricing**           | Zero markup                           | 20% markup (0% with BYOK)                                             |
-| **Operator network**  | None                                  | Registered Tangle operators expose endpoints, prices, and health data |
+| **Operator network**  | None                                  | Managed provider endpoints, selected by health, price, and latency |
 | **On-chain payments** | None                                  | SpendAuth (EIP-712) - pay without a credit card                       |
 | **Guardrails**        | None                                  | PII + injection detection built-in                                    |
 | **Web search tools**  | Perplexity, Parallel, provider-native | Not available through Tangle Gateway today                            |
@@ -73,8 +73,8 @@ Tangle Gateway supports the same `providerOptions.gateway` schema as Vercel AI G
 
 ## What you gain
 
-- **Operator network.** Access registered Tangle operators selected by endpoint health, model support, price, latency, and reputation data.
+- **Operator network.** Routes across managed provider endpoints selected by health, model support, price, and latency.
 - **On-chain payments.** Pay with crypto via SpendAuth - no Stripe/credit card required.
 - **Wallet auth.** Sign in with Ethereum (SIWE) for web3-native access.
 - **Guardrails.** Built-in PII and prompt injection detection on every request.
-- **Self-hostable.** Deploy your own gateway instance - it's open source.
+- **Self-hostable (roadmap).** Running your own open-source gateway instance is planned.

--- a/pages/gateway/migrate-vercel.mdx
+++ b/pages/gateway/migrate-vercel.mdx
@@ -23,16 +23,16 @@ Tangle Gateway supports the same `providerOptions.gateway` schema as Vercel AI G
 
 ## What's different
 
-| Feature               | Vercel                                | Tangle                                                                |
-| --------------------- | ------------------------------------- | --------------------------------------------------------------------- |
-| **Base URL**          | `ai-gateway.vercel.sh/v1`             | `router.tangle.tools/v1`                                              |
-| **Auth**              | API key or OIDC token                 | API key, session, SIWE (wallet), or SpendAuth (on-chain)              |
-| **Pricing**           | Zero markup                           | 20% markup (0% with BYOK)                                             |
+| Feature               | Vercel                                | Tangle                                                             |
+| --------------------- | ------------------------------------- | ------------------------------------------------------------------ |
+| **Base URL**          | `ai-gateway.vercel.sh/v1`             | `router.tangle.tools/v1`                                           |
+| **Auth**              | API key or OIDC token                 | API key, session, SIWE (wallet), or SpendAuth (on-chain)           |
+| **Pricing**           | Zero markup                           | 20% markup (0% with BYOK)                                          |
 | **Operator network**  | None                                  | Managed provider endpoints, selected by health, price, and latency |
-| **On-chain payments** | None                                  | SpendAuth (EIP-712) - pay without a credit card                       |
-| **Guardrails**        | None                                  | PII + injection detection built-in                                    |
-| **Web search tools**  | Perplexity, Parallel, provider-native | Not available through Tangle Gateway today                            |
-| **OIDC auth**         | Vercel-only                           | Not applicable                                                        |
+| **On-chain payments** | None                                  | SpendAuth (EIP-712) - pay without a credit card                    |
+| **Guardrails**        | None                                  | PII + injection detection built-in                                 |
+| **Web search tools**  | Perplexity, Parallel, provider-native | Not available through Tangle Gateway today                         |
+| **OIDC auth**         | Vercel-only                           | Not applicable                                                     |
 
 ## Code change
 

--- a/pages/gateway/models.mdx
+++ b/pages/gateway/models.mdx
@@ -64,13 +64,13 @@ Or use bare names - the gateway resolves the provider by prefix:
 
 ## Modalities
 
-| Modality   | Endpoint                                       | Examples                               |
-| ---------- | ---------------------------------------------- | -------------------------------------- |
-| Text       | `/v1/chat/completions`                         | All chat models                        |
-| Images     | `/v1/images/generations`                       | DALL-E, FLUX                           |
-| Audio      | `/v1/audio/transcriptions`, `/v1/audio/speech` | Whisper, TTS                           |
-| Embeddings | `/v1/embeddings`                               | text-embedding-3-small/large           |
-| Video      | `/v1/video/*`                                  | Avatar generation, dubbing             |
+| Modality   | Endpoint                                       | Examples                     |
+| ---------- | ---------------------------------------------- | ---------------------------- |
+| Text       | `/v1/chat/completions`                         | All chat models              |
+| Images     | `/v1/images/generations`                       | DALL-E, FLUX                 |
+| Audio      | `/v1/audio/transcriptions`, `/v1/audio/speech` | Whisper, TTS                 |
+| Embeddings | `/v1/embeddings`                               | text-embedding-3-small/large |
+| Video      | `/v1/video/*`                                  | Avatar generation, dubbing   |
 
 ## Model catalog API
 

--- a/pages/gateway/models.mdx
+++ b/pages/gateway/models.mdx
@@ -1,11 +1,11 @@
 ---
 title: Supported Models
-description: Browse models available through Tangle Gateway across 20+ providers.
+description: Browse models available through Tangle Gateway across 16 providers.
 ---
 
 # Supported Models
 
-Tangle Gateway provides access to models from 20+ providers through a single API.
+Tangle Gateway provides access to models from 16 providers through a single API.
 
 ## Providers
 
@@ -70,8 +70,8 @@ Or use bare names - the gateway resolves the provider by prefix:
 | Images     | `/v1/images/generations`                       | DALL-E, FLUX                           |
 | Audio      | `/v1/audio/transcriptions`, `/v1/audio/speech` | Whisper, TTS                           |
 | Embeddings | `/v1/embeddings`                               | text-embedding-3-small/large           |
-| Video      | `/v1/video/*`                                  | Avatar generation, dubbing (via ph0ny) |
+| Video      | `/v1/video/*`                                  | Avatar generation, dubbing             |
 
-## Dynamic discovery
+## Model catalog API
 
 The model catalog is available at [`GET /api/models`](https://router.tangle.tools/api/models) with pricing, context length, and modality information for every model.

--- a/pages/gateway/no-train.mdx
+++ b/pages/gateway/no-train.mdx
@@ -7,7 +7,7 @@ description: Route only through providers that don't use your data for model tra
 
 Ensure your prompts and responses are never used by providers to train their models.
 
-## Usage
+## Enable it
 
 ```json
 {
@@ -32,7 +32,7 @@ Use `disallowPromptTraining` when you care about IP protection but don't need fu
 
 ## No-train verified providers
 
-All ZDR providers plus: OpenAI, Google AI Studio, Cohere, Perplexity, xAI, Morph AI, Novita AI, Voyage AI, and others.
+All ZDR providers plus: OpenAI, Google AI Studio, Cohere, Perplexity, xAI, Morph AI, Novita AI, Voyage AI.
 
 See the full list at [`GET /api/gateway/compliance`](/gateway/api-compliance).
 

--- a/pages/gateway/operator-routing.mdx
+++ b/pages/gateway/operator-routing.mdx
@@ -21,11 +21,11 @@ The LLM Inference Blueprint uses [tangle-inference-core](https://github.com/tang
 
 To build and deploy your own inference Blueprint, see the [Blueprint SDK docs](/developers/blueprints/introduction) and the [Blueprint Runner](/developers/blueprint-runner/introduction).
 
-## How operators are discovered
+## Operator discovery
 
 1. Operators register on-chain via the [Blueprint Service Manager (BSM)](/developers/blueprints/service-lifecycle) contract
 2. The gateway syncs operator data from the chain every 60 seconds
-3. Operators are stored in the database with their endpoint URL, pricing, and status
+3. The gateway stores each operator with its endpoint URL, pricing, and status
 4. The [scoring algorithm](/gateway/smart-routing) ranks operators per-request
 
 ## Routing to operators

--- a/pages/gateway/pricing.mdx
+++ b/pages/gateway/pricing.mdx
@@ -11,7 +11,7 @@ description: How billing works on Tangle Gateway.
 | -------------------------------- | ------------------------------------------- |
 | Platform credentials             | 20% above provider list price               |
 | [BYOK](/gateway/byok)            | **0%** - provider list price, no markup     |
-| [SpendAuth](/gateway/spend-auth) | Operator-set prices (shown at request time)  |
+| [SpendAuth](/gateway/spend-auth) | Operator-set prices (shown at request time) |
 
 The 20% platform markup on non-BYOK requests funds operator payouts and platform infrastructure. Operators earn a share of every request routed through them.
 

--- a/pages/gateway/pricing.mdx
+++ b/pages/gateway/pricing.mdx
@@ -11,7 +11,7 @@ description: How billing works on Tangle Gateway.
 | -------------------------------- | ------------------------------------------- |
 | Platform credentials             | 20% above provider list price               |
 | [BYOK](/gateway/byok)            | **0%** - provider list price, no markup     |
-| [SpendAuth](/gateway/spend-auth) | Operator-set prices (typically competitive) |
+| [SpendAuth](/gateway/spend-auth) | Operator-set prices (shown at request time)  |
 
 The 20% platform markup on non-BYOK requests funds operator payouts and platform infrastructure. Operators earn a share of every request routed through them.
 
@@ -43,7 +43,7 @@ cost = (input_tokens × input_price) + (output_tokens × output_price)
 
 Pricing varies by model. Check per-model pricing at [`GET /api/models`](https://router.tangle.tools/api/models) or in the `X-Tangle-Price-Input` / `X-Tangle-Price-Output` response headers.
 
-## Billing transparency
+## Pricing headers on every response
 
 Every response includes pricing headers so you know the cost before it hits your balance:
 

--- a/pages/gateway/provider-options.mdx
+++ b/pages/gateway/provider-options.mdx
@@ -48,7 +48,7 @@ interface GatewayOptions {
 | `models`                 | `string[]`                         | -       | Fallback model list. [Details](/gateway/fallbacks)             |
 | `timeout`                | `number \| Record<string, number>` | `30000` | Timeout in ms. [Details](/gateway/timeouts)                    |
 
-## Example: everything at once
+## Example: all options combined
 
 ```json
 {

--- a/pages/gateway/routing-trace.mdx
+++ b/pages/gateway/routing-trace.mdx
@@ -23,7 +23,7 @@ X-Tangle-Routing-Trace: openai/gpt-4o[openai(500:2100ms)], anthropic/claude-sonn
 
 ## Sanitization
 
-The trace header is sanitized for safety:
+Tangle redacts the trace header before returning it:
 
 - Operator names are shown as generic `operator` (slugs not exposed)
 - Error messages are not included (only status codes)

--- a/pages/gateway/smart-routing.mdx
+++ b/pages/gateway/smart-routing.mdx
@@ -5,7 +5,7 @@ description: How the gateway scores and selects operators.
 
 # Smart Routing
 
-When multiple operators running the same [Blueprint](/developers/blueprints/introduction) serve the same model, the gateway selects the best one using a weighted scoring algorithm.
+The gateway scores every operator serving a model and routes the request to the highest scorer. When several operators run the same [Blueprint](/developers/blueprints/introduction) for that model, this scoring decides which one gets the request.
 
 ## Scoring formula
 

--- a/pages/gateway/spend-auth.mdx
+++ b/pages/gateway/spend-auth.mdx
@@ -7,7 +7,7 @@ description: Pay operators directly on-chain via EIP-712 signed authorizations.
 
 SpendAuth lets you pay operators directly on-chain without a credit card or account. Sign an EIP-712 typed data message with your wallet, attach it to the request, and the operator claims payment after serving inference.
 
-## How it works
+## Sign, authorize, claim
 
 1. **Sign:** Create an EIP-712 SpendAuth payload with your wallet
 2. **Send:** Attach the signature as `X-Payment-Signature` header
@@ -42,7 +42,7 @@ curl -X POST "https://router.tangle.tools/v1/chat/completions" \
 
 ## Rate limits
 
-SpendAuth requests get a generous 120 req/min limit per commitment since every request is paid.
+SpendAuth requests are limited to 120 req/min per commitment; the limit is high because every request is paid.
 
 ## On-chain contracts
 

--- a/pages/gateway/timeouts.mdx
+++ b/pages/gateway/timeouts.mdx
@@ -39,7 +39,7 @@ Different providers have different latency profiles. Set timeouts individually:
 }
 ```
 
-## Default behavior
+## Default timeouts
 
 Without explicit timeouts, the gateway uses a 30-second default for all providers and a 30-second idle timeout for streaming responses.
 

--- a/pages/gateway/zdr.mdx
+++ b/pages/gateway/zdr.mdx
@@ -25,7 +25,7 @@ When ZDR is enabled, the gateway routes requests **only** through providers that
 
 Set `zdrEnabled: true` on your team record. All requests from team members will enforce ZDR. Team-wide ZDR overrides per-request `zeroDataRetention: false`.
 
-## How it works
+## How routing changes under ZDR
 
 When ZDR is enabled:
 

--- a/pages/infrastructure/architecture.mdx
+++ b/pages/infrastructure/architecture.mdx
@@ -1,6 +1,6 @@
 # Architecture
 
-The runtime is split into an orchestrator and execution sidecars so workloads stay isolated while coordination stays flexible.
+The runtime is split into an orchestrator and execution sidecars so workloads stay isolated and the orchestrator can place, scale, and stream them independently.
 
 The runtime has two operating modes:
 
@@ -20,9 +20,7 @@ Both modes isolate work, stream events, and keep execution reviewable. The app s
 - **Autoscaling and host pools (optional)**: Promote standby hosts and trigger provisioning through a webhook.
 - **Observability layer**: Exposes metrics and health endpoints and preserves execution metadata.
 
-This architecture keeps workloads portable while maintaining consistent safety guarantees.
-
-## Operational Traits
+## Placement, streaming, and policy
 
 - **Multi-provider backends**: Select providers behind consistent policy gates.
 - **Capacity-aware placement**: Allocate based on host health and resource limits.

--- a/pages/infrastructure/harnesses.mdx
+++ b/pages/infrastructure/harnesses.mdx
@@ -1,11 +1,11 @@
 ---
 title: Sandbox Harnesses
-description: Supported sandbox harnesses, product exposure, and AI Agent Sandbox blueprint capability discovery.
+description: Which harnesses the Sandbox SDK, UI picker, and blueprint sidecar each support, and how to read them live via /api/capabilities.
 ---
 
 # Sandbox Harnesses
 
-OpenCode is one harness. Do not describe Tangle's sandbox product, SDK, or AI Agent Sandbox blueprint as an OpenCode integration.
+This page maps which coding harnesses each Tangle sandbox surface supports — the published SDK, the Sandbox UI picker, and the AI Agent Sandbox blueprint sidecar — and how to discover them at runtime. OpenCode is only one of them; don't describe the sandbox as an OpenCode integration.
 
 There are three related surfaces:
 

--- a/pages/infrastructure/introduction.mdx
+++ b/pages/infrastructure/introduction.mdx
@@ -1,13 +1,13 @@
 # Sandbox Runtime
 
-The sandbox runtime is the execution layer for autonomous work. It provisions isolated environments, manages session execution, and streams events so workflows can run safely at scale.
+The sandbox runtime is the execution layer for autonomous work. It provisions isolated environments, manages session execution, and streams events so workflows can run.
 
 There are two paths:
 
 - **Hosted sandbox infrastructure**: apps use the Sandbox SDK/API against Tangle-managed orchestration when they have an API key and product access.
 - **Protocol-backed sandbox services**: operators run sandbox blueprints as service instances, and apps verify chain/service state plus live operator health before routing users in.
 
-## What It Provides
+## Isolation, policy, and streaming control
 
 - **Isolation and containment** for untrusted or semi-trusted workloads.
 - **Policy enforcement** for tools, data access, and budgets.
@@ -15,16 +15,11 @@ There are two paths:
 - **Streaming observability** with real-time events, file updates, and execution metadata.
 - **Capacity management** with host health, pooling, and optional autoscaling.
 
-## Who This Is For
+## Where to start by role
 
 - **Workbench users** who need isolated, repeatable execution. [Start in the workbench](/vibe/introduction).
 - **Operators** who host runtimes and earn for reliable execution. [Operator onboarding](/operators/introduction).
-- **Platform teams** who manage execution reliability and safety. [Review architecture](/infrastructure/architecture).
-
-## Start Here (By Role)
-
-- **Operators**: Begin with [operator onboarding](/operators/introduction).
-- **Platform engineers**: Review [architecture](/infrastructure/architecture) and [orchestration](/infrastructure/orchestration).
+- **Platform teams** who manage execution reliability and safety. [Review architecture](/infrastructure/architecture) and [orchestration](/infrastructure/orchestration).
 - **Security teams**: Start with [sandboxing and safety](/infrastructure/sandboxing).
 
 Hosted runtime access is gated by product/API-key access. Protocol-backed runtime access depends on a registered blueprint service instance and reachable operator endpoint.

--- a/pages/infrastructure/orchestration.mdx
+++ b/pages/infrastructure/orchestration.mdx
@@ -2,7 +2,7 @@
 
 Orchestration turns workbench intent into sandboxed execution. It coordinates sidecar placement, session lifecycle, and runtime signals across hosts.
 
-## Execution Lifecycle (Simplified)
+## Execution lifecycle
 
 1. The orchestrator validates policies and checks capacity.
 2. A sidecar is selected or started on an available host.
@@ -12,7 +12,7 @@ Orchestration turns workbench intent into sandboxed execution. It coordinates si
 
 The orchestrator should fail before allocation when policy or capacity is invalid. Once a sidecar starts, failures should be visible as session events and metrics, not hidden as missing output.
 
-## What Orchestration Covers
+## Placement, execution control, and autoscaling
 
 - **Placement and capacity**: Host health, resource-aware limits, and pool membership.
 - **Execution control**: Per-session queues, timeouts, and cancellation.

--- a/pages/infrastructure/protocol-deployment.mdx
+++ b/pages/infrastructure/protocol-deployment.mdx
@@ -13,7 +13,7 @@ need these steps for day to day service operation.
 The source of truth for deployment is the `tnt-core` repo, which uses Foundry scripts and writes manifest JSON outputs
 for downstream tooling.
 
-## Source of Truth
+## Deployment runbook and FullDeploy scripts
 
 <GithubFileReaderDisplay
   url="https://github.com/tangle-network/tnt-core/blob/main/docs/DEPLOYMENT_RUNBOOK.md"

--- a/pages/infrastructure/sandboxing.mdx
+++ b/pages/infrastructure/sandboxing.mdx
@@ -36,7 +36,7 @@ Each sandbox enforces:
 - **Data access policies**: What files and secrets are available.
 - **Budget limits**: Token and compute ceilings per session.
 
-Policies are defined in workbench profiles and enforced at the runtime level.
+Workbench profiles define policies; the runtime enforces them.
 
 For protocol-backed services, the app should also check the service instance policy and operator endpoint before launching a session. A chain record proves the service exists; it does not prove the sandbox is currently ready.
 
@@ -48,7 +48,7 @@ Every session produces:
 - **Execution metadata**: Timing, resource usage, and exit status.
 - **File snapshots**: State of the workspace at key points.
 
-This makes execution reviewable and supports dispute resolution when issues arise.
+This makes execution reviewable and supports dispute resolution.
 
 ## Operator Checklist
 

--- a/pages/intelligence/_meta.ts
+++ b/pages/intelligence/_meta.ts
@@ -1,0 +1,9 @@
+import type { Meta } from "nextra";
+
+const meta: Meta = {
+  index: {
+    title: "Overview",
+  },
+};
+
+export default meta;

--- a/pages/intelligence/index.mdx
+++ b/pages/intelligence/index.mdx
@@ -1,0 +1,31 @@
+---
+title: Intelligence
+description: Observability for AI agents. Record every run, find what broke, and measure the fix.
+---
+
+# Tangle Intelligence
+
+Observability for AI agents. Record every run, find the moment one broke, change one thing, and measure what moved.
+
+Ask Intelligence to investigate a run, and an analyst reads the evidence and writes up what happened with the spans attached — "checkout failed 12× today, all on the retry path after a 429." It keeps every run you send it, so when an agent misbehaves you pull up the exact moment it broke. You make the fix; Intelligence never changes your agent for you.
+
+## What you do with it
+
+- **Measure a change.** Compare runs before and after you touch a prompt, model, or tool, and see the difference.
+- **Find the exact run.** Pull up the session, trace, or log that shows what happened, down to the span.
+- **Tie cost to outcome.** Tokens, dollars, and errors for the run that produced a result, not just an aggregate.
+- **Turn a finding into a guardrail.** An eval that catches it next time, or an alert when it recurs.
+
+## Who it's for
+
+Engineers running coding agents, workflow agents, and the eval loops that grade them.
+
+## How data gets in
+
+Send traces over OpenTelemetry or a Tangle SDK, with no other Tangle setup. Or run your agent in the [sandbox runtime](/infrastructure/introduction), and that run's evidence lands in the same timeline.
+
+## Start
+
+1. [Get an API key](/platform/authentication).
+2. Point your agent's OpenTelemetry exporter at Intelligence.
+3. Run the agent and open its run in the timeline.

--- a/pages/network/claim-airdrop.mdx
+++ b/pages/network/claim-airdrop.mdx
@@ -44,8 +44,7 @@ The treasury and foundation buckets use separate launch schedules. See [Token Al
 2. Claims can be submitted gaslessly via a relayer (the portal will handle this automatically when available).
 3. Once confirmed, the unlocked amount transfers to your wallet and the vesting contract is created for the remainder.
 
-## Additional Notes
+## Security and Support
 
-- **Gasless claims**: A claim relayer can pay gas on your behalf. The portal will guide you through this path.
 - **Security**: Never share private keys or seed phrases.
 - **Support**: Use official channels listed on the site if you need help.

--- a/pages/network/incentives-developers.mdx
+++ b/pages/network/incentives-developers.mdx
@@ -15,7 +15,7 @@ The Base-mainnet launch split is **20% developer / 19.5% protocol / 40% operator
 
 If the protocol is running `InflationPool` incentives, developers can earn additional TNT based on on-chain activity metrics (e.g., blueprints created, services created, jobs executed, and fees generated). These rewards are claimable from `InflationPool`.
 
-## Where This Lives in Code
+## Reward contracts
 
 - `InflationPool`: https://github.com/tangle-network/tnt-core/blob/main/src/rewards/InflationPool.sol
 - `TangleMetrics`: https://github.com/tangle-network/tnt-core/blob/main/src/rewards/TangleMetrics.sol
@@ -23,7 +23,7 @@ If the protocol is running `InflationPool` incentives, developers can earn addit
 
 For a readable breakdown and links to contracts, see [Rewards Architecture](/developers/system-architecture/rewards).
 
-## Design Tips
+## Design for slashing and observability
 
 - Be explicit about slashing conditions and the evidence you expect to be submitted on-chain.
 - Use asset requirements, operator commitments, and slashing evidence rules to define the risk threshold for your service.

--- a/pages/network/incentives-operators.mdx
+++ b/pages/network/incentives-operators.mdx
@@ -1,6 +1,6 @@
 # Operator Incentives
 
-Operators earn revenue from service usage and optional TNT budgets. This page outlines the primary revenue paths in Tangle Protocol.
+Operators earn revenue from service usage and optional TNT budgets across three paths.
 
 ## Revenue Sources
 
@@ -35,5 +35,5 @@ For a readable breakdown and links to contracts, see [Rewards Architecture](/dev
 ## Operator Success Factors
 
 - **Reliability**: uptime and correct execution impact service demand.
-- **Performance**: meeting blueprint and QoS expectations drives repeat usage.
+- **Performance**: meeting Blueprint and QoS expectations drives repeat usage.
 - **Transparency**: clear policies and monitoring improve operator selection.

--- a/pages/network/incentives-overview.mdx
+++ b/pages/network/incentives-overview.mdx
@@ -18,8 +18,6 @@ Tangle's incentives come from two sources:
 
 Claim paths: staker fees + staker inflation via `ServiceFeeDistributor`, TNT staking incentives via `RewardVaults`, and operator/customer/developer TNT via `InflationPool`.
 
-Code references: [PaymentsDistribution.sol](https://github.com/tangle-network/tnt-core/blob/main/src/core/PaymentsDistribution.sol), [PaymentsRewards.sol](https://github.com/tangle-network/tnt-core/blob/main/src/core/PaymentsRewards.sol), [ServiceFeeDistributor.sol](https://github.com/tangle-network/tnt-core/blob/main/src/rewards/ServiceFeeDistributor.sol), [InflationPool.sol](https://github.com/tangle-network/tnt-core/blob/main/src/rewards/InflationPool.sol), [RewardVaults.sol](https://github.com/tangle-network/tnt-core/blob/main/src/rewards/RewardVaults.sol), [TangleMetrics.sol](https://github.com/tangle-network/tnt-core/blob/main/src/rewards/TangleMetrics.sol)
-
 ## Service Fees
 
 Customers pay for blueprint services using the chain's native token or an ERC-20 payment token (including TNT). Fees are split between:
@@ -54,7 +52,7 @@ The protocol can optionally record activity into a metrics contract (`TangleMetr
 
 - See [Metrics and Scoring](/network/metrics-and-scoring) for details.
 
-## Why This Layout Works
+## What This Layout Guarantees
 
 - **One staker fee path**: Service fees always flow through `ServiceFeeDistributor`, so payout math is consistent across tokens and services.
 - **Budget clarity**: Incentives only exist if governance funds them; there is no hidden inflation.

--- a/pages/network/incentives-stakers.mdx
+++ b/pages/network/incentives-stakers.mdx
@@ -5,7 +5,7 @@ Stakers (delegators) earn two types of rewards on Tangle:
 1. **Service fee revenue** from blueprint services backed by their delegated stake (paid in the service’s payment token).
 2. **Optional TNT incentives** for delegating assets (pre-funded by governance).
 
-## How You Participate
+## Deposit and delegate
 
 - Deposit supported assets into the on-chain `MultiAssetDelegation` staking contract.
 - Delegate to an operator and choose a blueprint selection mode:
@@ -42,8 +42,6 @@ If enabled, `InflationPool` can allocate a staker budget in TNT based on **servi
 
 - Slashing reduces the withdrawable value of operator positions using share/exchange-rate accounting.
 - Use `Fixed` blueprint selection if you want to scope exposure to specific blueprints.
-
-Review delegator risks before choosing exposure and lock settings.
 
 ## Source Contracts (GitHub)
 

--- a/pages/network/launch.mdx
+++ b/pages/network/launch.mdx
@@ -2,7 +2,7 @@ import { Callout } from "nextra/components";
 
 # Launch
 
-Tangle is launching as a protocol stack on EVM: a coordination layer for agents and services, plus a migration path for TNT. Operators provide compute, and the protocol contracts handle coordination, payments, and incentives.
+Tangle is launching as a protocol stack on EVM: a coordination layer for agents and services, plus a migration path for TNT. Operators provide compute, and the protocol contracts handle coordination and payments, with incentives as an optional governance-enabled module.
 
 <Callout emoji="⚠️">
   If you are claiming TNT from the migration or airdrop allocations, see the [TNT Migration and Claims](/network/claim-airdrop) guide.

--- a/pages/network/metrics-and-scoring.mdx
+++ b/pages/network/metrics-and-scoring.mdx
@@ -7,7 +7,7 @@ description: How Tangle records protocol activity and uses it for incentive dist
 
 Tangle’s incentive programs can be driven by on-chain activity metrics. Metrics are optional: the protocol is designed so that core actions still work even if metrics recording is disabled or temporarily unavailable.
 
-## Core Components
+## Contracts that record and distribute
 
 - **`TangleMetrics`**: an on-chain activity recorder implementing `IMetricsRecorder`.
 - **Metrics hooks**: best-effort calls from core contracts (wrapped in `try/catch`) that emit or aggregate activity data.
@@ -48,7 +48,7 @@ Operators (often via their blueprint manager) can submit service heartbeats to `
 
 Heartbeats do not automatically slash an operator by themselves; slashing requires an authorized on-chain proposal and execution.
 
-## Important Note on Budgets
+## Rewards require a funded InflationPool
 
 Merit-based rewards only exist if `InflationPool` is funded with TNT. If it has a zero balance, there is nothing to distribute, even if metrics are recorded.
 

--- a/pages/network/overview.mdx
+++ b/pages/network/overview.mdx
@@ -2,11 +2,11 @@ import ExpandableImage from "../../components/ExpandableImage";
 
 <ExpandableImage src="/images/banners/TangleBanner.png" alt="Tangle Banner" />
 
-# Protocol Foundation
+# How Tangle coordinates operators and services
 
 Tangle coordinates services that outside operators can run for users. Developers publish Blueprints, users request service instances, operators accept work, and protocol contracts track stake, lifecycle state, and payment terms.
 
-## Today vs Future
+## Managed today, open operator market later
 
 Today the network uses managed onboarding and a curated operator set. The protocol path is still the same one a larger market needs: register operators, request service instances, record commitments, and settle fees.
 
@@ -18,7 +18,7 @@ Blueprints package jobs, metadata, binaries, pricing, and optional service-manag
 
 Operators earn service fees by running requested instances. They choose which Blueprints to register for, which endpoints to expose, and which resources or isolation modes they are willing to commit.
 
-## Maximize Resource Utilization
+## Reuse one stake across Blueprints
 
 Operators can reuse one stake and operations stack across multiple Blueprints. That gives users a consistent way to select operators while each Blueprint keeps its own jobs, pricing, and runtime requirements.
 
@@ -28,7 +28,7 @@ Operators can reuse one stake and operations stack across multiple Blueprints. T
 - **Operators** who want to run services reliably and earn service fees. [Operator onboarding](/operators/introduction)
 - **Stakers** who want to back operators and earn from usage. [Economic security](/staking/introduction)
 
-## How Services Work
+## One Blueprint, many service instances
 
 <ExpandableImage src="/images/ServiceInstanceFlow.png" alt="Service Instance Flow" allowZoom={true} />
 
@@ -70,4 +70,4 @@ Tangle is a protocol for reusable cryptographic, AI, and runtime services. The p
 
 - **Custom cryptographic services**: any service that can be expressed as jobs, operator requirements, and settlement rules.
 
-The point is simple: developers package services once, users instantiate them when needed, and operators get paid for work they can prove they accepted and served.
+Developers package services once, users instantiate them when needed, and operators get paid for work they can prove they accepted and served.

--- a/pages/network/points-mechanics.mdx
+++ b/pages/network/points-mechanics.mdx
@@ -4,7 +4,7 @@ Tangle uses a credits system to recognize contributions. Credits are computed of
 
 Credits are not token transfers. A user proves inclusion by submitting the claim data and Merkle proof accepted by the `Credits` contract.
 
-## How Credits Work
+## Off-chain compute, on-chain claim
 
 1. Eligible activity is indexed off-chain.
 2. A Merkle root for the epoch is published on-chain.
@@ -22,7 +22,7 @@ The exact credit sources and weights can evolve. Always refer to the current pro
 
 ## Claiming Credits
 
-Credits are claimed through the `Credits` contract once a new epoch root is published. The claim flow is intentionally simple and can be automated by the UI.
+Credits are claimed through the `Credits` contract once a new epoch root is published. The UI can automate the claim.
 
 Contract source (GitHub): https://github.com/tangle-network/tnt-core/blob/main/packages/credits/src/Credits.sol
 

--- a/pages/network/tokenomics/allocation.mdx
+++ b/pages/network/tokenomics/allocation.mdx
@@ -56,5 +56,3 @@ The year-one incentive budget is 1,000,000 TNT, or 1% of the 100M cap. It is fun
 | Mainnet     | `TBD`                 | `TBD`    |
 | Testnet     | `TBD`                 | `TBD`    |
 | Local       | `TBD`                 | `TBD`    |
-
-The summary will be kept in sync with these contracts.

--- a/pages/network/tokenomics/usage.mdx
+++ b/pages/network/tokenomics/usage.mdx
@@ -4,13 +4,13 @@ TNT is Tangle's governance token. It is an ERC-20 Votes token on EVM chains with
 
 TNT is **not** the gas token. Gas fees are paid in the underlying chain's native asset (e.g., ETH on Base).
 
-## Usage Cases
+## Use Cases
 
 ### Governance
 
 TNT holders participate in protocol governance (e.g., parameter updates, treasury actions, upgrades) using on-chain voting.
 
-### Protocol Alignment
+### Incentive Alignment
 
 TNT coordinates incentives across stakers, operators, blueprint developers, and users of services.
 

--- a/pages/operators/benchmarking.mdx
+++ b/pages/operators/benchmarking.mdx
@@ -1,12 +1,12 @@
 ---
-title: Understanding Benchmarking
+title: Benchmarking and operator pricing
 ---
 
-# Understanding Benchmarking
+# Benchmarking and operator pricing
 
-As a Tangle Network operator, you should understand how the network benchmarks your system to determine pricing for blueprints. This guide explains the automated benchmarking process and how it affects the quotes generated for your operator runtime.
+Tangle automatically benchmarks your hardware when a service activates. The pricing engine uses that profile to quote every blueprint that runs on your host. This guide explains the automated benchmarking process and how it affects the quotes generated for your operator runtime.
 
-## What is Blueprint Benchmarking?
+## What benchmarking measures
 
 Blueprint benchmarking is an automated process that measures your system's capabilities to determine:
 
@@ -16,7 +16,7 @@ Blueprint benchmarking is an automated process that measures your system's capab
 
 When users request quotes from your operator, Tangle's pricing engine uses these benchmark results to calculate fair prices based on your hardware profile.
 
-## How Benchmarking Works
+## Two benchmark phases: service activation and runtime
 
 The benchmarking process happens automatically in two key phases:
 
@@ -110,12 +110,10 @@ A: Benchmarks are initially created during registration and may be updated perio
 **Q: Do benchmark results affect which jobs I receive?**  
 A: Yes, users may choose operators based partly on performance metrics derived from benchmarks.
 
-## Related Information
+## Related operator guides
 
 To learn more about operating on the Tangle Network, you may want to review:
 
 - [Pricing Strategies](/operators/pricing)
 - [Blueprint Manager](/operators/manager/introduction)
 - [Quality of Service](/operators/quality-of-service)
-
-Understanding the benchmarking process helps you better appreciate how the Tangle Network determines pricing for blueprints running on your operator.

--- a/pages/operators/introduction.mdx
+++ b/pages/operators/introduction.mdx
@@ -1,6 +1,6 @@
 # Operating on Tangle
 
-Operators run Blueprint services and earn fees for reliable execution. This section covers everything you need to deploy and maintain operator infrastructure.
+Operators run Blueprint services and earn fees for reliable execution. This section covers how to deploy and maintain operator infrastructure.
 
 ## Quick Start
 

--- a/pages/operators/introduction.mdx
+++ b/pages/operators/introduction.mdx
@@ -46,7 +46,7 @@ Operators risk slashing for:
 
 ## Sandbox Runtime Hosting (Early Access)
 
-Operators can also host the sandbox runtime that powers autonomous work. It is designed with capacity-aware scheduling, optional host pooling and autoscaling, and Prometheus-style metrics for fleet visibility.
+Operators can also host the sandbox runtime that executes agent workloads. The runtime schedules by available capacity, optionally pools and autoscales hosts, and exports Prometheus metrics per host.
 
 Learn more in [Runtime Architecture](/infrastructure/architecture).
 

--- a/pages/operators/manager/confidential-compute.mdx
+++ b/pages/operators/manager/confidential-compute.mdx
@@ -2,7 +2,7 @@
 
 SDK source (GitHub): https://github.com/tangle-network/blueprint/tree/main/crates/manager
 
-This page covers the operator requirements for running services that prefer or require TEE execution.
+Run a Blueprint in a trusted execution environment (TEE) two ways: locally with Kata containers on Kubernetes, or remotely on a confidential-compute VM from AWS, GCP, or Azure.
 
 ## Two TEE Paths
 
@@ -73,7 +73,7 @@ export BLUEPRINT_ALLOWED_SSH_CIDRS=10.0.0.0/8
 export BLUEPRINT_ALLOWED_QOS_CIDRS=10.0.0.0/8
 ```
 
-## What Operators Should Expect
+## TEE enforcement behavior
 
 - `tee_required` prevents non-TEE fallback.
 - The manager injects `TEE_REQUIRED=true` and `TEE_BACKEND` into remote deployments when TEE is required.

--- a/pages/operators/manager/introduction.mdx
+++ b/pages/operators/manager/introduction.mdx
@@ -4,7 +4,7 @@ SDK source (GitHub): https://github.com/tangle-network/blueprint/tree/main/crate
 
 The Blueprint Manager is the operator-side runtime that turns on-chain services into running off-chain infrastructure.
 
-At a high level, the Blueprint Manager:
+The Blueprint Manager:
 
 - Watches the chain for service lifecycle events (service activation, job calls, service termination).
 - Fetches and verifies blueprint artifacts (native binaries, containers, WASM, etc.).

--- a/pages/operators/manager/requirements.mdx
+++ b/pages/operators/manager/requirements.mdx
@@ -2,15 +2,15 @@
 
 SDK source (GitHub): https://github.com/tangle-network/blueprint/tree/main/crates/manager
 
-Blueprints can be executed in multiple ways (see [Sources](/developers/deployment/sources/introduction)), with each requiring
-certain dependencies, and possibly hardware.
+You can run Blueprints from native, container, or WASM [sources](/developers/deployment/sources/introduction). Each path needs
+different dependencies, and some need specific hardware.
 
 ## Native Sources
 
 There are two ways to run blueprints with [Native Sources](/developers/deployment/sources/native) in the
 `blueprint-manager`: sandboxed (**recommended**) or not
 
-In either case, the following dependencies will be needed:
+Both methods need:
 
 - [GitHub CLI] (for binary attestations)
 

--- a/pages/operators/manager/security.mdx
+++ b/pages/operators/manager/security.mdx
@@ -38,8 +38,7 @@ reason to fall back silently to standard container execution.
 
 ## Remote TEE attestation
 
-For remote confidential-compute deployments, operators should treat attestation as part of the deployment gate, not as an
-optional afterthought.
+For remote confidential-compute deployments, operators should treat attestation as a deployment gate.
 
 - `BLUEPRINT_REMOTE_TEE_ATTESTATION_POLICY=cryptographic` is the strongest mode and requires an executable verifier
   command.

--- a/pages/operators/manager/setup.mdx
+++ b/pages/operators/manager/setup.mdx
@@ -2,7 +2,7 @@
 
 SDK source (GitHub): https://github.com/tangle-network/blueprint/tree/main/crates/manager
 
-This page covers the operator flow for configuring and running the Blueprint Manager against Tangle's EVM protocol.
+The Blueprint Manager watches Tangle's EVM contracts for service activations and runs each Blueprint service on your machine. Configure and start it in five steps.
 
 ## 1) Create a settings file
 

--- a/pages/operators/operator/join_operator/join.mdx
+++ b/pages/operators/operator/join_operator/join.mdx
@@ -1,13 +1,13 @@
 ## Operators
 
-Operators are service providers who stake assets to run blueprint services. Staking gives customers and developers an enforceable security boundary (exposure + slashing) around off-chain work.
+Operators are service providers who stake assets to run Blueprint services. Staking gives customers and developers an enforceable security boundary (exposure + slashing) around off-chain work.
 
 ### Joining as an Operator
 
-This page covers operator onboarding for Tangle Network. You need to:
+Becoming an operator takes three steps:
 
 1. Register with the staking contract (self-stake).
-2. Register for each blueprint you intend to operate.
+2. Register for each Blueprint you intend to operate.
 3. Run the Blueprint Manager to execute jobs.
 
 - Next: [Blueprint Manager](/operators/manager/introduction)
@@ -39,9 +39,9 @@ The CLI flag name is `--restaking-contract` for compatibility; it refers to the 
 The stake amount must meet the minimum configured for the enabled asset. Contract addresses are listed on
 [Network Parameters](/network/network-parameters).
 
-### Step 3: Register for a blueprint
+### Step 3: Register for a Blueprint
 
-Register your operator in the core protocol for a specific blueprint ID:
+Register your operator in the core protocol for a specific Blueprint ID:
 
 ```bash
 cargo tangle blueprint register \
@@ -56,9 +56,9 @@ cargo tangle blueprint register \
   --registration-inputs ./registration.tlv
 ```
 
-- Repeat this step for each blueprint you want to serve.
+- Repeat this step for each Blueprint you want to serve.
 - `--rpc-endpoint` is optional and publishes your operator RPC address.
-- `--registration-inputs` is required only if the blueprint expects extra registration payloads.
+- `--registration-inputs` is required only if the Blueprint expects extra registration payloads.
 
 ### Step 4: Run the Blueprint Manager
 

--- a/pages/operators/operator/join_operator/leave.mdx
+++ b/pages/operators/operator/join_operator/leave.mdx
@@ -2,9 +2,7 @@
 
 Operators can leave the operator role by scheduling a leave and then completing it after the leave delay period has passed.
 
-## Schedule Operator Leave
-
-### Step 1: Schedule Operator Leave
+## Step 1: Schedule your leave
 
 Ensure you have joined as an operator first, see [Join as an Operator](./join).
 
@@ -29,9 +27,7 @@ The CLI flag name is `--restaking-contract` for compatibility; it refers to the 
 
 If successful, your leave will be scheduled.
 
-## Execute Operator Leave
-
-### Step 2: Execute Operator Leave
+## Step 2: Complete your leave
 
 Ensure you have scheduled a leave and the leave delay period has passed.
 

--- a/pages/operators/operator/join_operator/stake.mdx
+++ b/pages/operators/operator/join_operator/stake.mdx
@@ -1,10 +1,8 @@
 ## Staking as an Operator
 
-Operators can increase their self-stake to increase capacity, qualify for higher minimums, or signal commitment to customers.
+Operators can increase their self-stake to increase capacity, qualify for higher minimums, or signal commitment to customers; to withdraw, schedule an unstake and execute it after the delay.
 
-## Bond More
-
-### Increase Operator Stake
+## Increase your stake
 
 Operators can increase their self-stake via the CLI. The amount is in wei for the configured bond asset.
 
@@ -30,9 +28,9 @@ The CLI flag name is `--restaking-contract` for compatibility; it refers to the 
 
 If successful, the transaction emits `OperatorStakeIncreased(operator, amount)`.
 
-## Schedule Operator Unstake
+## Unstake
 
-### Step 1: Schedule Operator Unstake
+### Step 1: Schedule
 
 Ensure you have joined as an operator first, see [Join as an Operator](./join).
 
@@ -49,9 +47,7 @@ cargo tangle operator schedule-unstake \
 
 If successful, your tokens will be unlocked after the unstake delay period.
 
-## Execute Operator Unstake
-
-### Step 2: Execute Operator Unstake
+### Step 2: Execute
 
 Ensure you have scheduled an unstake and the delay period has passed.
 

--- a/pages/operators/pricing/overview.mdx
+++ b/pages/operators/pricing/overview.mdx
@@ -4,18 +4,16 @@ title: Blueprint Pricing
 
 # Blueprint Pricing
 
+As an operator, you get paid based on how a blueprint is configured to charge. Some pricing is fixed on-chain (no quote
+service required). Other flows require operators to serve signed quotes off-chain (RFQ).
+
 SDK source (GitHub): https://github.com/tangle-network/blueprint/tree/main/crates/pricing-engine
 
 Operator preferences interface (GitHub): https://github.com/tangle-network/tnt-core/blob/main/src/interfaces/ITangleOperators.sol
 
-As an operator, you get paid based on how a blueprint is configured to charge. Some pricing is fixed on-chain (no quote
-service required). Other flows require operators to serve signed quotes off-chain (RFQ).
-
 ## Prerequisites
 
-- Basic understanding of Tangle Network operations
-- Familiarity with the Blueprint Manager runtime
-- Knowledge of blueprint service lifecycles
+Assumes you already run a Blueprint via the Blueprint Manager.
 
 ## Pricing Models (What You Need to Run)
 

--- a/pages/operators/quality-of-service.mdx
+++ b/pages/operators/quality-of-service.mdx
@@ -4,7 +4,7 @@ title: Quality of Service Monitoring
 
 # Quality of Service Monitoring
 
-QoS is the observability layer for running Blueprints. As an operator, you decide how metrics, logs, and dashboards are exposed to your team or customers. This page outlines what QoS exports, how to configure access safely, and how on-chain metrics affect your operator status.
+QoS is the observability layer for running Blueprints. As an operator, you decide how metrics, logs, and dashboards are exposed to your team or customers.
 
 ## What Gets Exported
 

--- a/pages/operators/runbook.mdx
+++ b/pages/operators/runbook.mdx
@@ -1,6 +1,6 @@
 # Operator Runbook
 
-This is a minimal operational checklist for keeping Blueprint services healthy and safe in production.
+A minimal checklist for keeping Blueprint services healthy in production.
 
 ## Daily Checks
 

--- a/pages/platform/authentication.mdx
+++ b/pages/platform/authentication.mdx
@@ -16,7 +16,7 @@ Save it:
 export TANGLE_API_KEY="sk-tan-paste-your-key-here"
 ```
 
-## Use it
+## Make an authenticated call
 
 Send the key as a bearer token. This one call checks the key and returns your balance:
 

--- a/pages/staking/how-staking-works.mdx
+++ b/pages/staking/how-staking-works.mdx
@@ -4,16 +4,16 @@ Staking lets participants delegate assets to operators who run Blueprint service
 
 Tangle provides permissionless, asset-configurable staking for Blueprint service instances. Any asset created on or bridged to Tangle can be used as collateral to stake on operators. Stakers earn rewards proportional to service usage and protocol incentive budgets.
 
-## Benefits of Tangle Staking include:
+## Why stake on Tangle
 
 - Staking any asset
 - Securing on-demand service instances with unique assets
 - Increased efficiency of staked capital by sharing it across instances
 - Additional revenue streams for stakers and operators
-- Boosted security for protocols leveraging new assets as security capital
+- Protocols secure themselves with new assets as capital
 - New service markets that use registered operators and delegated stake
 
-## How Staking Works on Tangle
+## The staking lifecycle
 
 1. Developers publish Blueprints that define service requirements.
 2. Operators register and opt into the Blueprints they want to run.

--- a/pages/staking/how_to_stake/how_to_stake_tangle/delegate.mdx
+++ b/pages/staking/how_to_stake/how_to_stake_tangle/delegate.mdx
@@ -6,7 +6,7 @@ import Callout from "/components/Callout";
 You should have deposited your tokens before you can delegate. See the [Deposit Using Tangle DApp page](./deposit.mdx) for more information. If you have already deposited **and** delegated your assets under the **Deposit** tab, you can skip this step.
 </Callout>
 
-Delegators delegate assets to an operator and participate in rewards (and risks, including slashing) based on that operator’s performance and the blueprint’s rules.
+You delegate assets to an operator and share in its rewards and risks (including slashing), governed by the operator’s performance and the blueprint’s rules.
 
 ### Step 1: Access Tangle DApp & Connect Wallet
 
@@ -17,7 +17,7 @@ Delegators delegate assets to an operator and participate in rewards (and risks,
 
 1. Switch to the **Stake** tab on the Staking page.
 2. Ensure that you're connected to the appropriate network. You can switch networks by using the dropdown located at the top right corner of the page.
-3. Click on the **Asset** dropdown, and select an asset from the modal. If the asset that you're looking for is not listed, ensure that you have correctly performed the deposit operation for that asset. Please note that your asset balance might be lower than expected or not available if you have already deposited and delegated at once under the **Deposit** tab.
+3. Click on the **Asset** dropdown, and select an asset from the modal. If the asset that you're looking for is not listed, ensure that you have correctly performed the deposit operation for that asset. Your asset balance might be lower than expected or unavailable if you have already deposited and delegated at once under the **Deposit** tab.
 4. Click on the **Select Operator** dropdown, and choose an operator from the list. You can also search for specific operators by entering their address in the search bar.
 5. Enter the amount of assets that you'd like to delegate to the operator.
 6. Review fees, unstake period, and any unstake delay before proceeding.

--- a/pages/staking/how_to_stake/how_to_stake_tangle/deposit.mdx
+++ b/pages/staking/how_to_stake/how_to_stake_tangle/deposit.mdx
@@ -1,8 +1,6 @@
 ## Deposit Using Tangle DApp
 
-Depositing is the process of allocating assets to the multiasset delegation vault. Deposits are required to participate in staking (delegate).
-
-Users can deposit supported assets to the multi-asset delegation vault.
+Depositing allocates supported assets to the multi-asset delegation vault. Deposits are required to participate in staking (delegate).
 
 ### Step 1: Access Tangle DApp & Connect Wallet
 

--- a/pages/staking/how_to_stake/how_to_stake_tangle/unstake.mdx
+++ b/pages/staking/how_to_stake/how_to_stake_tangle/unstake.mdx
@@ -1,6 +1,6 @@
 ## Unstake Using Tangle DApp
 
-The first step to exit staking is to unstake your tokens. This is done by calling the `unstake` function internally, which releases the locked assets and returns them to the deposit vault.
+The first step to exit staking is to unstake your tokens. Unstaking releases your locked assets back to the deposit vault.
 
 Then, you can withdraw your assets from the deposit vault. See the [Withdraw page](./withdraw.mdx) for more information.
 
@@ -44,4 +44,4 @@ Simply select the unstake request(s) that you'd like to cancel, then click on th
 
 Once an unstake request has reached its maturity, you can **execute** it to actually unstake and release the assets.
 
-Tangle DApp makes this process easy by simply clicking on the **Execute All** button. There's no need to select specific unstake requests, as this action will execute all unstake requests that have reached their maturity within a single transaction. If the button is disabled, it means that there are no unstake requests that have reached their maturity yet.
+Click **Execute All** to unstake every matured request in a single transaction. There's no need to select specific unstake requests, as this action will execute all unstake requests that have reached their maturity within a single transaction. If the button is disabled, it means that there are no unstake requests that have reached their maturity yet.

--- a/pages/staking/how_to_stake/how_to_stake_tangle/withdraw.mdx
+++ b/pages/staking/how_to_stake/how_to_stake_tangle/withdraw.mdx
@@ -15,14 +15,14 @@ Similar to unstaking, it is composed of two steps:
 
 ### Schedule Withdraw
 
-The first step to complete a withdraw is to schedule a withdrawal. This is done by calling the `schedule_withdraw` function.
+Scheduling calls the `schedule_withdraw` function.
 
-### Step 1: Access Tangle DApp & Connect Wallet
+#### Step 1: Access Tangle DApp & Connect Wallet
 
 - Open [Tangle DApp's Staking: Withdraw page](https://app.tangle.tools/staking/withdraw).
 - Connect your wallet to the DApp by clicking on the **Connect Wallet** button on the top right and selecting your preferred wallet provider.
 
-### Step 2: Schedule Withdraw
+#### Step 2: Schedule Withdraw
 
 1. Select the **Withdraw** tab on the Staking page.
 2. Click on the **Asset** dropdown, and select an asset from the modal.
@@ -32,7 +32,7 @@ The first step to complete a withdraw is to schedule a withdrawal. This is done 
 
 ![Withdraw Steps](/images/staking/withdraw/steps.png)
 
-### Step 3: Sign and Submit the Transaction
+#### Step 3: Sign and Submit the Transaction
 
 - Sign and submit the transaction. Make sure the account you are using has enough balance to cover the transaction fee.
 - If successful, you should see the withdraw request appear in the table at the right side of the page, and also the following confirmation toast notification:
@@ -43,7 +43,7 @@ The first step to complete a withdraw is to schedule a withdrawal. This is done 
 
 If you've scheduled a withdraw request, you can choose to **cancel** it if you change your mind. To cancel a withdraw request, use the withdraw requests table on the right side of the page. Note that you can cancel a withdraw request even if it has reached its maturity, but as long as it hasn't been executed yet.
 
-Simply select the withdraw request(s) that you'd like to cancel, then click on the **Cancel Withdraw** button to initiate the transaction.
+Select the withdraw request(s) you'd like to cancel, then click on the **Cancel Withdraw** button to initiate the transaction.
 
 ![Unstake Requests Table: Cancel Withdraw](/images/staking/withdraw/cancel-withdraw.png)
 
@@ -51,4 +51,4 @@ Simply select the withdraw request(s) that you'd like to cancel, then click on t
 
 Once a withdraw request has reached its maturity, you can **execute** it to actually withdraw and release the assets.
 
-Tangle DApp makes this process easy by simply clicking on the **Execute All** button. There's no need to select specific withdraw requests, as this action will execute all withdraw requests that have reached their maturity within a single transaction. If the button is disabled, it means that there are no withdraw requests that have reached their maturity yet.
+Click **Execute All** to execute every matured withdraw request in one transaction. There's no need to select specific withdraw requests, as this action will execute all withdraw requests that have reached their maturity within a single transaction. If the button is disabled, it means that there are no withdraw requests that have reached their maturity yet.

--- a/pages/staking/incentives/claiming.mdx
+++ b/pages/staking/incentives/claiming.mdx
@@ -108,14 +108,14 @@ A typical call bundle for a staker might include:
 
 ## Code References
 
-- `src/v2/core/Payments.sol` (operator service-fee claims)
-- `src/v2/rewards/ServiceFeeDistributor.sol` (staker fee + staker inflation claims)
-- `src/v2/rewards/RewardVaults.sol` (TNT vault incentives + operator commissions)
-- `src/v2/rewards/InflationPool.sol` (operator/customer/developer inflation rewards)
+- `src/core/PaymentsRewards.sol` (operator service-fee claims)
+- `src/rewards/ServiceFeeDistributor.sol` (staker fee + staker inflation claims)
+- `src/rewards/RewardVaults.sol` (TNT vault incentives + operator commissions)
+- `src/rewards/InflationPool.sol` (operator/customer/developer inflation rewards)
 
 ## Tests Worth Reading
 
-- `test/v2/tangle/Payments.t.sol`
-- `test/v2/rewards/ServiceFeeDistributor.t.sol`
-- `test/v2/Rewards.t.sol`
-- `test/v2/InflationPool.t.sol`
+- `test/tangle/Payments.t.sol`
+- `test/rewards/ServiceFeeDistributor.t.sol`
+- `test/Rewards.t.sol`
+- `test/InflationPool.t.sol`

--- a/pages/staking/incentives/claiming.mdx
+++ b/pages/staking/incentives/claiming.mdx
@@ -1,11 +1,11 @@
 ---
 title: Claiming Cheatsheet
-description: One place to see where rewards accrue, how to visualize them, and how to claim efficiently.
+description: One place to see where rewards accrue, how to visualize them, and how to claim in the fewest transactions.
 ---
 
 # Claiming Cheatsheet
 
-This page answers three common questions:
+Rewards accrue across four contracts. Here's where each role's rewards land, how to read pending balances, and how to claim in the fewest transactions.
 
 1. **Where do my rewards accrue?**
 2. **How do I visualize them by source?**

--- a/pages/staking/incentives/configs.mdx
+++ b/pages/staking/incentives/configs.mdx
@@ -5,7 +5,7 @@ description: Key on-chain knobs for incentive programs and fee splits.
 
 # Reward Configs
 
-This page summarizes the main on-chain configuration points for staking incentives. Exact addresses are deployment-dependent.
+Staking incentives are configured through four contracts: `RewardVaults`, `InflationPool`, `Tangle` payment splits, and `ServiceFeeDistributor`. Exact addresses are deployment-dependent.
 
 ## `RewardVaults` (Asset Incentives)
 

--- a/pages/staking/incentives/how_rewards_work.mdx
+++ b/pages/staking/incentives/how_rewards_work.mdx
@@ -79,15 +79,15 @@ routes those TNT to `ServiceFeeDistributor`, where delegators claim as usual.
 
 ## Where To Look In Code And Tests
 
-- Payment split and staker routing: `src/v2/core/Payments.sol`
-- Staker fee distribution and claims: `src/v2/rewards/ServiceFeeDistributor.sol`
-- Inflation budgets and staker exposure allocation: `src/v2/rewards/InflationPool.sol`
-- TNT staking incentives: `src/v2/rewards/RewardVaults.sol`
+- Payment split and staker routing: `src/core/PaymentsDistribution.sol`
+- Staker fee distribution and claims: `src/rewards/ServiceFeeDistributor.sol`
+- Inflation budgets and staker exposure allocation: `src/rewards/InflationPool.sol`
+- TNT staking incentives: `src/rewards/RewardVaults.sol`
 - Tests:
-  - `test/v2/tangle/Payments.t.sol`
-  - `test/v2/rewards/ServiceFeeDistributor.t.sol`
-  - `test/v2/rewards/ServiceFeeDistributorStreaming.t.sol`
-  - `test/v2/Rewards.t.sol`
-  - `test/v2/InflationPool.t.sol`
+  - `test/tangle/Payments.t.sol`
+  - `test/rewards/ServiceFeeDistributor.t.sol`
+  - `test/rewards/ServiceFeeDistributorStreaming.t.sol`
+  - `test/Rewards.t.sol`
+  - `test/InflationPool.t.sol`
 
 See [Claiming Cheatsheet](/staking/incentives/claiming) for one-tx claim options and multicall tips.

--- a/pages/staking/incentives/how_rewards_work.mdx
+++ b/pages/staking/incentives/how_rewards_work.mdx
@@ -10,12 +10,12 @@ Staking incentives on Tangle come from two sources:
 1. **Service fee revenue** paid by customers (in the service's payment token).
 2. **TNT incentives** funded by governance (pre-funded, no minting).
 
-## ELI5
+## The short version
 
 If you delegate to an operator that runs useful services, you earn:
 
 - **A share of the fees** those services pay (in the same token the customer used).
-- **Optional TNT incentives** when the protocol has funded an incentives budget: _"I also earn TNT from RewardVaults plus optional staker inflation."_
+- **Optional TNT incentives** when governance has funded a budget — paid from reward vaults on top of your fee share.
 
 You choose your exposure scope (All vs Fixed), and your share is calculated from your delegated amount and lock multiplier.
 
@@ -39,7 +39,7 @@ You choose your exposure scope (All vs Fixed), and your share is calculated from
 - **Explicit budgets**: TNT incentives only exist if governance funds `InflationPool`. There is no hidden minting.
 - **Exposure fairness without per-user loops**: Exposure is computed at distribution time (USD-weighted where possible), avoiding per-delegator loops in inflation logic.
 
-## How To Get Rewarded (Practical Steps)
+## How to get rewarded
 
 **As a staker**
 
@@ -53,7 +53,7 @@ You choose your exposure scope (All vs Fixed), and your share is calculated from
 **As an operator**
 
 - Self-stake `minOperatorStake` to register.
-- Join services and set exposure and commitments responsibly.
+- Join services and set exposure and commitments you can cover.
 - Claim operator service fees from the core protocol.
 - Claim TNT commission from `RewardVaults` if you opt into commission.
 

--- a/pages/staking/incentives/vaults.mdx
+++ b/pages/staking/incentives/vaults.mdx
@@ -5,7 +5,7 @@ description: Clarify the different “vault” concepts used in staking and ince
 
 # Vaults (Terminology)
 
-In Tangle documentation, “vault” can refer to different on-chain components. This page clarifies the terminology.
+Two different on-chain components are called “vault”: `RewardVaults` (TNT incentives) and `ServiceFeeDistributor` (service-fee revenue).
 
 ## `RewardVaults` (TNT Incentives Per Asset)
 

--- a/pages/staking/introduction.mdx
+++ b/pages/staking/introduction.mdx
@@ -2,12 +2,12 @@ import CardGrid from "../../components/CardGrid";
 
 # Economic Security
 
-Tangle's economic security stack centers on staking for Blueprint services.
+Staking bonds operators to the Blueprint services they run, so a service that breaks its rules can be slashed.
 
 <CardGrid cards={[
   {
     title: "How Staking Works",
-    description: "Discover Tangle's permissionless and asset-configurable staking system for Blueprints and shared security.",
+    description: "Permissionless, asset-configurable staking for Blueprints and shared security.",
     link: "./how-staking-works"
   },
   {
@@ -17,17 +17,13 @@ Tangle's economic security stack centers on staking for Blueprint services.
   },
 ]} />
 
-## Economic Security
+## Operators, collateral, and slashing
 
-Tangle uses economic security to back operators who run Blueprint services. Operators register for services and provide compute. Assets can be staked to operators as collateral, aligning incentives and enabling slashing where policies require it.
+Tangle uses economic security to back operators who run Blueprint services. Operators register for services and provide compute. Delegators stake assets to operators as collateral; a service can slash that collateral when its policy defines a fault.
 
 The protocol does not make every workload safe by default. Each Blueprint defines the assets it accepts, the operators it needs, the service rules, and the evidence path for slashing. Staking gives the service an economic bond; the Blueprint still has to define what counts as a fault.
 
-## Staking
-
-Tangle provides permissionless and asset-configurable staking for Blueprints. Assets can be staked to operators as collateral for service instances, and participants earn rewards based on service usage and incentives.
-
-Staking aligns operators, developers, and stakers around service reliability and performance. If an operator violates service requirements, delegated assets can be slashed under the protocol’s rules.
+Tangle provides permissionless and asset-configurable staking for Blueprints, and participants earn rewards based on service usage and incentives. Staking aligns operators, developers, and stakers around service reliability and performance.
 
 ## Start by Role
 

--- a/pages/staking/liquid-staking/introduction.mdx
+++ b/pages/staking/liquid-staking/introduction.mdx
@@ -8,7 +8,7 @@ Each vault is tied to one operator, one asset, and one blueprint selection mode.
 
 - **Stakers** who want liquidity without exiting their staking position.
 - **Integrators** who want a tokenized staking position per operator and asset.
-- **Operators** who want a clean vault surface for delegators.
+- **Operators** who want a single ERC-7540 vault contract delegators interact with, instead of exposing raw MultiAssetDelegation calls.
 
 ## What Changes vs Direct Staking
 

--- a/pages/staking/liquid-staking/vaults-and-shares.mdx
+++ b/pages/staking/liquid-staking/vaults-and-shares.mdx
@@ -27,7 +27,7 @@ Vaults use the same share-based accounting model as `MultiAssetDelegation` with 
 Vault shares are standard ERC20 tokens:
 
 - **Transferable** between wallets.
-- **Approveable** for integrators and apps.
+- **Approvable** for integrators and apps.
 - **Composable** with other token-based systems.
 
 The vault itself remains the on-chain delegator; individual share transfers do not change the underlying delegation record.

--- a/pages/staking/staking-concepts.mdx
+++ b/pages/staking/staking-concepts.mdx
@@ -1,8 +1,8 @@
 # Staking Concepts
 
-This document introduces the core concepts for economic security on Tangle.
+On Tangle, stakers delegate assets to operators to back service execution, earning a share of service fees and sharing slashing risk.
 
-## Key Roles
+## Roles
 
 - **Blueprint**: A reusable service template that defines interfaces, execution requirements, and expected outputs.
 - **Service Instance**: A live deployment of a Blueprint that runs on operators.
@@ -33,5 +33,3 @@ See [Liquid Staking](/staking/liquid-staking/introduction) for the vault archite
 ## Slashing and Security
 
 Operators can be slashed if they violate service requirements or fail to meet commitments. Stakers share in that risk based on their delegated exposure.
-
-Review risks before delegating or choosing exposure settings.

--- a/pages/vibe/integrations.mdx
+++ b/pages/vibe/integrations.mdx
@@ -1,6 +1,6 @@
 # Integrations
 
-The workbench is built to work with existing company systems. You can connect internal software, data sources, and operational tools so agents can act in context.
+Connect the Workbench to your source control, ticketing, data sources, and internal APIs so agents act on real systems. You can connect internal software, data sources, and operational tools so agents can act in context.
 
 ## Typical Integrations
 
@@ -23,9 +23,9 @@ Integrations are governed by profiles and policies, so the agent only has access
 
 ## Tool Servers And Gateways
 
-Advanced integrations can be exposed as tool servers. Profiles can allowlist local or remote servers, attach headers or environment variables, and set timeouts. Sensitive systems stay behind explicit gates, and approved workflows still get the tools they need.
+Advanced integrations can be exposed as tool servers. Profiles can allowlist local or remote servers, attach headers or environment variables, and set timeouts. Sensitive systems stay behind explicit gates.
 
-## Design Principle
+## Enable Only What a Workflow Needs
 
 Integrations should be explicit and scoped. If a tool is not required for a workflow, it should not be enabled.
 

--- a/pages/vibe/introduction.mdx
+++ b/pages/vibe/introduction.mdx
@@ -2,34 +2,27 @@
 
 The agentic workbench is Tangle's shared workspace for teams building with AI agents. It is multiplayer by design, so engineering, product, and business teams can work in the same space with shared context. Runs capture inputs, outputs, and logs so results are reviewable.
 
-## What You Can Do
+## Core capabilities
 
 - **Build and iterate** on software with agent workflows in a shared project space.
 - **Run background tasks** that keep working without babysitting.
 - **Compare variants** across multiple approaches or branches.
-- **Evaluate at scale** with simulations over large task sets.
+- **Evaluate** with simulations over large task sets.
 - **Control access** with profiles, policies, and limits.
-- **Connect tools** through integrations and shared workspace context.
+- **Connect tools** through [integrations](/vibe/integrations) and shared workspace context.
 
-## Who This Is For
+## For product, engineering, and eval teams
 
 - **Product teams** shipping AI-assisted software. [Start with workflows](/vibe/workflows).
 - **Engineering orgs** standardizing agent workflows. [Define profiles](/vibe/profiles).
 - **Builders** who need repeatable, reviewable output. [Run simulations](/vibe/simulations).
 
-## How It Connects
+## Where runs execute
 
 The workbench sends execution to the sandbox runtime. Hosted runs use product/API-key access. Protocol-backed runs depend on a registered blueprint service instance, operator endpoint, and payment path.
 
 ## Profiles Power The Runtime
 
 Workbench profiles configure the selected agent harness, model routing, per-agent prompts, and tool permissions. OpenCode sits beside 13 other Sandbox SDK backend types: Claude Code, Kimi Code, Codex, AMP, Factory Droids, Pi, Hermes, Forge, OpenClaw, NanoClaw, ACP, Cursor, and CLI base. Protocol-backed service instances must still read their own `/api/capabilities` response.
-
-## Start Here (By Role)
-
-- **Builders**: Start with [agent workflows](/vibe/workflows).
-- **Team leads**: Define guardrails in [profiles and policies](/vibe/profiles).
-- **Evaluators**: Run [simulations](/vibe/simulations) before shipping.
-- **Platform teams**: Wire tools in [integrations](/vibe/integrations).
 
 The workbench is available via partnership or early access.

--- a/pages/vibe/profile-schema.mdx
+++ b/pages/vibe/profile-schema.mdx
@@ -1,6 +1,6 @@
 # Profile Schema
 
-This page documents the profile schema used to configure sidecar agents. The schema is shared across sandbox harnesses; each harness maps the fields it supports to its own config files, environment, and runtime flags.
+The profile schema configures sidecar agents. The schema is shared across sandbox harnesses; each harness maps the fields it supports to its own config files, environment, and runtime flags.
 
 ## Current Support
 

--- a/pages/vibe/profiles.mdx
+++ b/pages/vibe/profiles.mdx
@@ -1,6 +1,6 @@
 # Profiles and Policies
 
-Profiles define how an agent behaves end to end. They package model choice, tool access, permissions, guardrails, and harness selection into a reusable sidecar profile that the runtime enforces. This is how the workbench configures agent execution without hard-coding behavior into every task.
+Profiles configure how an agent runs. They package model choice, tool access, permissions, guardrails, and harness selection into a reusable sidecar profile that the runtime enforces. This is how the workbench configures agent execution without hard-coding behavior into every task.
 
 ## What A Profile Controls
 
@@ -14,13 +14,11 @@ Profiles define how an agent behaves end to end. They package model choice, tool
 - **Plugins**: allowlisted extensions that can be attached to the runtime.
 - **Inheritance**: extend a base profile and override only what changes.
 
-Profiles make it possible to standardize agent behavior across teams while still allowing targeted customization when needed.
-
 ## Guardrails And Validation
 
 Profiles are validated before execution. Security policies can cap permissions (for example, "bash" at ask), block local tool servers, and require allowlisted plugins. Profiles that exceed policy are rejected so the runtime stays safe and predictable.
 
-## How It Shows Up In The Workbench
+## Base, Variant, and Per-Run Profiles
 
 The workbench will progressively expose profile controls:
 
@@ -30,7 +28,7 @@ The workbench will progressively expose profile controls:
 
 If you want early access to advanced profile configuration, contact the team.
 
-Under the hood, profiles can extend a base profile. The runtime merges overrides with the base profile, validates the final config, and applies the result to the sidecar session.
+The runtime merges overrides with the base profile, validates the final config, and applies the result to the sidecar session.
 
 ## Example Profile (Conceptual)
 

--- a/pages/vibe/simulations.mdx
+++ b/pages/vibe/simulations.mdx
@@ -22,7 +22,7 @@ Every execution generates traces: what agents did, inputs received, outputs prod
 - Which model configurations work for which tasks?
 - Which tool combinations reduce errors?
 
-This creates a flywheel: more usage generates more traces, better traces improve the system, and a better system drives more usage. Early users benefit from infrastructure; later users benefit from accumulated learning.
+Accumulated traces let you answer the questions above across many runs instead of one.
 
 ## When To Run Simulations
 

--- a/pages/vibe/workflows.mdx
+++ b/pages/vibe/workflows.mdx
@@ -1,15 +1,15 @@
 # Agent Workflows
 
-The workbench treats agent development as a workflow problem. You define the goal, the tools the agent can use, and the policies it must follow. The workbench handles orchestration, execution, and repeatability.
+Define a goal, scope the agent's tools, set its policies — the workbench orchestrates the run and makes it repeatable.
 
-## How Workflows Are Structured
+## Projects, runs, and versioned experiments
 
 - **Projects** are the top-level container for code, prompts, and agent configurations.
 - **Runs** capture a single execution, including inputs, outputs, and logs.
 - **Background agents** keep long tasks moving while you focus elsewhere.
 - **Versioned experiments** let you test multiple approaches in parallel.
 
-## What A Good Workflow Includes
+## What every workflow needs: outcome, scoped tools, limits, review
 
 - **Clear outcome** (merge a PR, generate a report, update a spec).
 - **Scoped tools** so the agent can act but not overreach.
@@ -24,6 +24,6 @@ Traditional AI interfaces present single-threaded conversation. Real projects in
 - **Forking for exploration**: Facing a decision, fork the context and direct each fork down a different path. Both develop in parallel. Compare results and pick the winner.
 - **Spatial overview**: The workbench presents parallel activity visually, showing all active agents, their status, recent outputs, and relationships.
 
-## Why This Matters
+## Reproducible behavior when agents touch production
 
-Teams need predictability when agents touch real systems. The workbench makes behavior reproducible, comparable, and reviewable while keeping execution controlled.
+Teams need predictability when agents touch real systems. You can reproduce any run, compare it against alternatives, and review changes before they reach production.

--- a/pages/vision/architecture.mdx
+++ b/pages/vision/architecture.mdx
@@ -1,6 +1,6 @@
 # Architecture and Design Pillars
 
-Tangle ties together three layers most platforms separate: the workbench where work is created, the sandbox runtime where it executes, and the protocol that pays the operators who run it.
+Tangle ties together four layers most platforms separate: the workbench where work is created, the gateway that routes and bills inference, the sandbox runtime where it executes, and the protocol that pays the operators who run it.
 
 <figure>
   <img
@@ -13,7 +13,7 @@ Tangle ties together three layers most platforms separate: the workbench where w
   </figcaption>
 </figure>
 
-**Flow:** design -> execute -> evaluate -> pay. Each run generates evaluation data that feeds the next run.
+**Flow:** design -> execute -> evaluate -> pay. Each run captures evaluation metadata that reviewers and later runs can draw on.
 
 ## What Runs Where
 
@@ -24,7 +24,7 @@ Tangle ties together three layers most platforms separate: the workbench where w
 | Sandbox runtime | Executed tasks and tools      | Agent sessions, tool calls, file edits                   |
 | Protocol        | Coordination and settlement   | Service registry, operator payments, staking, incentives |
 
-## System Architecture
+## The Four Layers
 
 **1) Execution Layer**  
 Sandboxed runtimes with isolation, resource limits, and audit logs. This is where tasks actually run.
@@ -36,7 +36,7 @@ The [Gateway](/gateway) routes inference requests across provider APIs and regis
 The coordination plane. It handles operator discovery, payment routing, and incentive enforcement.
 
 **4) Experience Layer**  
-The agentic workbench and [Blueprint SDK](https://github.com/tangle-network/blueprint/tree/main). This is where teams design workflows, run simulations, and ship services.
+The agentic Workbench and [Blueprint SDK](https://github.com/tangle-network/blueprint/tree/main). This is where teams design workflows, run simulations, and ship services.
 
 The SDK also includes optional gateways for integrating external events and payment-driven HTTP job execution (webhooks,
 x402).
@@ -63,7 +63,7 @@ Developer references:
 
 Autonomous work only scales when delegation is safe. Tangle enforces policy gates before execution, emits logs and execution metadata for every run, and keeps results reviewable so teams can decide what reaches production.
 
-## Design Pillars
+## What we optimize for
 
 - **Isolation first**: Every workload runs inside a sandbox with explicit permissions.
 - **Reviewable outcomes**: Logs, metadata, and evaluations give reviewers evidence about what ran and how it performed.

--- a/pages/vision/core-concepts.mdx
+++ b/pages/vision/core-concepts.mdx
@@ -1,9 +1,9 @@
 # Core Concepts and Terminology
 
-These terms show up across the docs and define how the system works.
+Definitions for the terms used throughout Tangle's docs.
 
-- **Agentic workbench**: A shared workspace where humans and agents build, test, and operate autonomous work.
-- **Sandbox runtime**: The isolated execution environment where agents and services run safely.
+- **Agentic workbench**: A shared workspace where humans and agents build, test, and run autonomous agents.
+- **Sandbox runtime**: The isolated execution environment where agents and services run in isolation from the host and each other.
 - **Agent**: An autonomous workflow or AI worker running inside a sandbox.
 - **Agent profile**: A configuration that defines models, tools, budgets, and policies for an agent.
 - **Evaluation**: A structured assessment of task results, cost, and policy compliance.

--- a/pages/vision/introduction.mdx
+++ b/pages/vision/introduction.mdx
@@ -1,4 +1,4 @@
-# Introduction and Mission
+# The operating layer for autonomous work
 
 Tangle is the shared operating layer for autonomous work: a workbench for teams and agents, a sandbox runtime for execution, and a protocol that pays the operators who host it. Every run emits evaluations so workflows improve with evidence, not guesswork.
 
@@ -30,7 +30,7 @@ Autonomous work today is brittle: tasks run outside policy, results lack evidenc
 
 - **Agentic workbench**: A shared workspace where humans and agents build and run autonomous work.
 - **Sandbox runtime**: The execution layer that isolates tasks with policies, resource limits, and audit logs.
-- **Protocol**: The coordination and payment layer that lets operators host workloads and get paid.
+- **Protocol**: The coordination and payment layer that will let registered operators host workloads and settle payment on-chain.
 - **Evaluation loop**: Task and agent evaluations that improve workflows over time.
 
 ## Who This Is For

--- a/pages/vision/use-cases.mdx
+++ b/pages/vision/use-cases.mdx
@@ -1,6 +1,6 @@
 # Use Cases
 
-Tangle supports AI-native products and infrastructure where work needs isolation, auditability, and reliable payments. These examples show how the workbench, sandbox runtime, and protocol fit together.
+Teams build these products on Tangle when work needs isolation, auditability, and paid execution. These examples show how the workbench, sandbox runtime, and protocol fit together.
 
 ## Agentic Software Engineering
 


### PR DESCRIPTION
## What

A systematic anti-slop + accuracy editorial pass across the docs, plus a new Intelligence section. Every prose page (release-notes changelogs excluded) was audited against the house anti-slop and copywriting rules, then given minimum-effective fixes — voice and headings only, no invented facts.

**4 commits, 144 files, net −22 lines** (the pass removes more than it adds — filler and leaked scaffolding out, sharper headings in).

## How it was done

- **Mechanical lint first.** A zero-LLM linter (banned words/phrases from the house guides) triaged all 210 pages. The existing docs were already largely clean — the win here is structural (headings, honesty, leaked scaffolding), not word-swaps. Final lint: **0 hard hits across 178 prose pages.**
- **Per-page editorial audit → fix**, each page judged and edited in isolation against the same rubric. Agents were instructed to **skip any fact they could not verify from the page itself** and flag it rather than guess.

## What changed

- **Removed leaked doc-generation scaffolding** — deleted "Sources used" sections that listed internal `.rs` / README / metadata paths (reader-facing pages shouldn't expose generation provenance).
- **Headings name the mechanism** instead of reworded "How it works" (e.g. "From order to settlement", "One Blueprint, many service instances", "Managed today, open operator market later").
- **Honesty / tense** — pages no longer describe roadmap capability as live (operator hosting, on-chain settlement, automatic self-improvement are future-tense where they are roadmap).
- **Stale v1 → v2 terminology** — "validator" actors on Blueprint pages become operators / signing committees / guardrail paths.
- **Removed duplicate role-routing sections, eyebrow labels, filler openers, unmeasured superlatives.**

### Accuracy fixes (each verified against ground truth, not guessed)

| Page | Fix | Verified against |
| --- | --- | --- |
| `system-architecture/rewards` | `src/v2/core/Payments.sol` (does not exist) → `src/core/PaymentsDistribution.sol` + `src/rewards/*` | the `tnt-core` repo |
| `upgrade-discipline` | storage-packing example → `address`+`uint64`+`uint32` = 32 bytes = one slot | arithmetic |
| `developers/slashing` | "burns or redistributes" → "burns" | page's own Future-Evolution section lists redistribution as roadmap |
| `blueprint-contexts/evm-provider-context` | trait name reconciled | the rest of the page + its source file |
| `gateway/models` | "20+ providers" → "16" | the table lists 16 |

## New: Intelligence section ⚠️ needs a product check

Adds `pages/intelligence/` as its own top-level section (observability for AI agents — record runs, find what broke, measure the fix), with a nav entry alongside the other products.

**Please confirm before merging this section:** it asserts product capabilities (analyst investigation, OpenTelemetry / SDK trace ingest). I did **not** fabricate a Quickstart endpoint — the "Start" steps point to real pages, but the concrete ingest endpoint and the Quickstart / Connect-your-agent sub-pages still need to be written by someone who can confirm the live surface.

## Maintainer follow-ups (fact-checks the pass declined to guess)

- `developers/cli/debugging` — does `/operators/manager/requirements` expose a `#vm-sources` anchor? If so, repoint the VM "requirements" link.
- `system-architecture/rewards` — test-dir paths (`test/` vs `test/v2/`, whether `Payments.t.sol` follows the rename) were not confirmed; left untouched.
- `blueprint-runner/background-services`, `developers/code-merge-process` — minor unverifiable references left as-is.

## Not in scope

- Release-notes (dated changelogs — rewriting their voice would be wrong).
- The docs-home `LandingPage` React component (this pass is MDX copy only).
- Generated API reference pages.
