### PR TITLE
docs: remove every em/en dash (77 across 17 pages)

### DIFF
--- a/pages/blueprint-agent/introduction.mdx
+++ b/pages/blueprint-agent/introduction.mdx
@@ -1,10 +1,10 @@
 # Blueprint Agent
 
-Describe a project, and an AI agent builds it with you in an in-browser IDE — then you ship it. The Blueprint Agent (at [ai.tangle.tools](https://ai.tangle.tools)) is Tangle's AI coding product: the **build** half of build, run, and improve.
+Describe a project, and an AI agent builds it with you in an in-browser IDE. Then you ship it. The Blueprint Agent (at [ai.tangle.tools](https://ai.tangle.tools)) is Tangle's AI coding product: the **build** half of build, run, and improve.
 
 ## What it is
 
-An AI programming workspace in the browser. You describe what you want, the agent writes and edits the code, and you review, run, and iterate on the result in a real dev environment — no local setup. Each session runs on the [Sandbox runtime](/infrastructure/introduction), so the agent has a full machine: shell, files, ports, and any supported coding harness.
+An AI programming workspace in the browser. You describe what you want, the agent writes and edits the code, and you review, run, and iterate on the result in a real dev environment, with no local setup. Each session runs on the [Sandbox runtime](/infrastructure/introduction), so the agent has a full machine: shell, files, ports, and any supported coding harness.
 
 It does not improve itself. You drive every change; the agent does the work you direct. (The trace-and-improve loop lives in [Intelligence](/intelligence), a separate product.)
 
@@ -16,10 +16,10 @@ It does not improve itself. You drive every change; the agent does the work you 
 
 ## How it works
 
-1. **Describe the project** — a plain-language brief of what you want built.
-2. **The agent builds it** — it works in a sandboxed dev environment, writing and running code, with the harness and model you choose.
-3. **Review and iterate** — read the diffs, run the preview, and steer the next turn.
-4. **Ship** — take the result to your own repo or deployment.
+1. **Describe the project**: a plain-language brief of what you want built.
+2. **The agent builds it**: it works in a sandboxed dev environment, writing and running code, with the harness and model you choose.
+3. **Review and iterate**: read the diffs, run the preview, and steer the next turn.
+4. **Ship**: take the result to your own repo or deployment.
 
 ## Who it's for
 
@@ -28,5 +28,5 @@ It does not improve itself. You drive every change; the agent does the work you 
 
 ## Start
 
-- **[Quickstart](/blueprint-agent/workflows)** — start a session and get your first project building.
-- **[Profiles](/blueprint-agent/profiles)** — set the coding harness, model routing, and tool permissions for a session.
+- **[Quickstart](/blueprint-agent/workflows)**: start a session and get your first project building.
+- **[Profiles](/blueprint-agent/profiles)**: set the coding harness, model routing, and tool permissions for a session.

--- a/pages/blueprint-agent/workflows.mdx
+++ b/pages/blueprint-agent/workflows.mdx
@@ -1,6 +1,6 @@
 # Agent Workflows
 
-Define a goal, scope the agent's tools, set its policies — the workbench orchestrates the run and makes it repeatable.
+Define a goal, scope the agent's tools, and set its policies. The workbench orchestrates the run and makes it repeatable.
 
 ## Projects, runs, and versioned experiments
 

--- a/pages/blueprints/ai-trading/operator-requirements.mdx
+++ b/pages/blueprints/ai-trading/operator-requirements.mdx
@@ -62,7 +62,7 @@ Public admission means public cost exposure. Every accepted bot can use CPU, dis
 
 The operator install path defaults new bots to paper trading. Paper mode uses live market data and simulated fills; it should not move capital.
 
-AI keys are optional. If you set `ZAI_API_KEY`, `ANTHROPIC_API_KEY`, `TANGLE_API_KEY`, or OpenCode model/env settings, agentic activation and chat can use those settings when the selected sidecar advertises OpenCode. OpenCode is one of several [supported harnesses](/infrastructure/harnesses) a sidecar can advertise; the AI keys apply the same way across them. There is no built-in per-bot, per-day, or total LLM spend cap today — use provider-side billing limits.
+AI keys are optional. If you set `ZAI_API_KEY`, `ANTHROPIC_API_KEY`, `TANGLE_API_KEY`, or OpenCode model/env settings, agentic activation and chat can use those settings when the selected sidecar advertises OpenCode. OpenCode is one of several [supported harnesses](/infrastructure/harnesses) a sidecar can advertise; the AI keys apply the same way across them. There is no built-in per-bot, per-day, or total LLM spend cap today. Use provider-side billing limits.
 
 ## Public endpoint
 

--- a/pages/developers/blueprints/service-lifecycle.mdx
+++ b/pages/developers/blueprints/service-lifecycle.mdx
@@ -33,7 +33,7 @@ There are two high-level creation flows:
 The CLI primarily covers the request and approve flow. RFQ flows often require custom client code today.
 
 Both flows can now carry execution confidentiality intent at the protocol layer. Service creation now binds the
-confidentiality mode — standard execution, prefer TEE, or require TEE — alongside the operator set and payment terms.
+confidentiality mode (standard execution, prefer TEE, or require TEE) alongside the operator set and payment terms.
 
 ## Extending A Service (Renewal)
 

--- a/pages/gateway/authentication.mdx
+++ b/pages/gateway/authentication.mdx
@@ -5,7 +5,7 @@ description: Authentication methods for Tangle Inference.
 
 # Authentication
 
-Four ways to authenticate to the gateway — plus anonymous access to free-tier models — each with its own rate limit.
+Four ways to authenticate to the gateway, plus anonymous access to free-tier models, each with its own rate limit.
 
 ## API Key
 
@@ -38,7 +38,7 @@ POST /api/siwe/verify
 
 ## SpendAuth (On-Chain Payment)
 
-EIP-712 signed payment authorization. No account needed — pay operators directly on-chain.
+EIP-712 signed payment authorization. No account needed: pay operators directly on-chain.
 
 ```bash
 curl -H "X-Payment-Signature: {\"commitment\":\"0x...\",\"amount\":\"1000000\",...}" \

--- a/pages/gateway/byok.mdx
+++ b/pages/gateway/byok.mdx
@@ -5,7 +5,7 @@ description: Use your own provider API keys with Tangle Inference for zero-marku
 
 # Bring Your Own Key (BYOK)
 
-Use your existing provider API keys with Tangle Inference. BYOK requests have **zero platform markup**—you pay the provider's list price directly.
+Use your existing provider API keys with Tangle Inference. BYOK requests have **zero platform markup**: you pay the provider's list price directly.
 
 ## Per-request BYOK
 
@@ -73,10 +73,10 @@ If the header is absent, platform credentials were used (possibly via fallback).
 
 ## Pricing
 
-| Credential type      | Markup                     |
-| -------------------- | -------------------------- |
-| BYOK                 | **0%**—provider list price |
-| Platform credentials | 20% markup (configurable)  |
+| Credential type      | Markup                      |
+| -------------------- | --------------------------- |
+| BYOK                 | **0%**, provider list price |
+| Platform credentials | 20% markup (configurable)   |
 
 ## Security
 

--- a/pages/gateway/index.mdx
+++ b/pages/gateway/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: Inference
-description: One OpenAI-compatible API key to every model — routed across providers and Tangle operators on price, latency, and reputation.
+description: One OpenAI-compatible API key to every model, routed across providers and Tangle operators on price, latency, and reputation.
 ---
 
 # Inference

--- a/pages/index.mdx
+++ b/pages/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: Tangle Docs
-description: Build, run, and improve AI agents on Tangle: the sandbox runtime, inference, Intelligence, and Blueprint Agent.
+description: Build, run, and improve AI agents on Tangle with the sandbox runtime, inference, Intelligence, and Blueprint Agent.
 ---
 
 import LandingPage from "../components/LandingPage";

--- a/pages/index.mdx
+++ b/pages/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: Tangle Docs
-description: Build, run, and improve AI agents on Tangle — the sandbox runtime, inference, Intelligence, and Blueprint Agent.
+description: Build, run, and improve AI agents on Tangle: the sandbox runtime, inference, Intelligence, and Blueprint Agent.
 ---
 
 import LandingPage from "../components/LandingPage";

--- a/pages/infrastructure/harnesses.mdx
+++ b/pages/infrastructure/harnesses.mdx
@@ -5,7 +5,7 @@ description: Which harnesses the Sandbox SDK, UI picker, and blueprint sidecar e
 
 # Sandbox Harnesses
 
-This page maps which coding harnesses each Tangle sandbox surface supports — the published SDK, the Sandbox UI picker, and the AI Agent Sandbox blueprint sidecar — and how to discover them at runtime. OpenCode is only one of them; don't describe the sandbox as an OpenCode integration.
+This page maps which coding harnesses each Tangle sandbox surface supports (the published SDK, the Sandbox UI picker, and the AI Agent Sandbox blueprint sidecar) and how to discover them at runtime. OpenCode is only one of them; don't describe the sandbox as an OpenCode integration.
 
 There are three related surfaces:
 

--- a/pages/intelligence/connect.mdx
+++ b/pages/intelligence/connect.mdx
@@ -5,7 +5,7 @@ description: Send content-bearing traces from Claude Code, Codex, OpenCode, and 
 
 # Connect your agent
 
-Intelligence reads your agents' execution traces and tells you why a run failed and how to fix it. That needs **content** — the prompts, model completions, and tool inputs and outputs — not just metadata like token counts, durations, and tool names.
+Intelligence reads your agents' execution traces and tells you why a run failed and how to fix it. That needs **content**: the prompts, model completions, and tool inputs and outputs, not just metadata like token counts, durations, and tool names.
 
 Every major coding agent ships content **off by default** and emits it on the OTLP **logs** signal. Enabling telemetry without also enabling content and the logs exporter is the one mistake that leaves you with a metadata-only feed. The per-agent blocks below get it right.
 
@@ -25,11 +25,11 @@ Set the `tangle.subject.key` resource attribute to a stable project name so Inte
 export OTEL_RESOURCE_ATTRIBUTES=tangle.subject.key=my-project
 ```
 
-Without it, grouping falls back to repository, then service name, then a `default` bucket — usable, but you lose clean per-project rollup.
+Without it, grouping falls back to repository, then service name, then a `default` bucket. It's usable, but you lose clean per-project rollup.
 
 ## Claude Code (CLI + Agent SDK)
 
-Content is gated behind four flags, all default off — this is why a default setup is metadata-only. Set all of it. For the CLI, export in your shell, Dockerfile, or k8s env; for the Agent SDK, put the same keys in `options.env`, spreading `...process.env` first.
+Content is gated behind four flags, all default off. This is why a default setup is metadata-only. Set all of it. For the CLI, export in your shell, Dockerfile, or k8s env; for the Agent SDK, put the same keys in `options.env`, spreading `...process.env` first.
 
 ```sh
 # Enable and point at Tangle (JSON protocol matches the adapter)
@@ -55,11 +55,11 @@ export OTEL_LOGS_EXPORT_INTERVAL=1000
 export OTEL_METRIC_EXPORT_INTERVAL=1000
 ```
 
-`OTEL_LOG_RAW_API_BODIES=1` ships the entire conversation (extended thinking is redacted). If that is too much, drop it and keep `OTEL_LOG_USER_PROMPTS=1` and `OTEL_LOG_TOOL_DETAILS=1` — you still get the task, prompts, and tool arguments. Secrets (`sk-…`, JWTs, keys) are scrubbed server-side regardless, so do not pre-strip content.
+`OTEL_LOG_RAW_API_BODIES=1` ships the entire conversation (extended thinking is redacted). If that is too much, drop it and keep `OTEL_LOG_USER_PROMPTS=1` and `OTEL_LOG_TOOL_DETAILS=1`. You still get the task, prompts, and tool arguments. Secrets (`sk-…`, JWTs, keys) are scrubbed server-side regardless, so do not pre-strip content.
 
 ## OpenAI Codex (CLI)
 
-OTel is off by default and prompts are redacted by default — set both. In `~/.codex/config.toml` (or a project `.codex/config.toml`):
+OTel is off by default and prompts are redacted by default. Set both. In `~/.codex/config.toml` (or a project `.codex/config.toml`):
 
 ```toml
 [otel]
@@ -74,18 +74,18 @@ Codex emits content on the logs signal (`codex.*` events). Set `TANGLE_API_KEY` 
 
 OpenCode has no native OTel exporter today, so a standalone install emits nothing without a shim.
 
-- **Inside a Tangle sandbox:** already instrumented — the adapter subscribes to OpenCode's event stream and exports content. Nothing to do.
+- **Inside a Tangle sandbox:** already instrumented. The adapter subscribes to OpenCode's event stream and exports content. Nothing to do.
 - **Standalone:** use `tangle-opencode-exporter`, a thin process that subscribes to OpenCode's SSE event bus and exports content-bearing OTLP. This is the one agent where the simple path is ours to provide rather than a config flag.
 
 ## OpenClaw, Hermes, NanoClaw
 
 These have no native OTel exporter and no standalone server to subscribe to. Run them **inside a Tangle sandbox**: the sidecar adapter exports their prompt, completion, and tool content, stamping `gen_ai.system=openclaw` / `hermes` / `nanoclaw` so each feed is attributed to the right agent. A bare local install is metadata-only.
 
-For cron, containers, or CI with any agent above, generate a content-on env block with `tangle connect claude-code --format env` (or `--format dockerfile`) and feed it to your service environment — no shell-rc edit and no TTY required. Dial content down with `--content prompts` or `--content metadata`.
+For cron, containers, or CI with any agent above, generate a content-on env block with `tangle connect claude-code --format env` (or `--format dockerfile`) and feed it to your service environment: no shell-rc edit and no TTY required. Dial content down with `--content prompts` or `--content metadata`.
 
 ## Already connected but only seeing metadata?
 
-If Intelligence shows your runs — models, tokens, tool names, durations — but the prompts, completions, and tool I/O are blank, content is gated off at your agent. You do not need to reconnect or change your endpoint. Turn content on:
+If Intelligence shows your runs (models, tokens, tool names, durations) but the prompts, completions, and tool I/O are blank, content is gated off at your agent. You do not need to reconnect or change your endpoint. Turn content on:
 
 - **Claude Code / Symphony** → add the four `OTEL_LOG_*` gates above. For Symphony, set them on the Claude Code child process it spawns.
 - **Codex** → set `log_user_prompt = true`.
@@ -104,6 +104,6 @@ curl -sS "https://intelligence.tangle.tools/v1/traces/$TID/spans" -H "$AUTH" \
   | jq '[.items[].attributes // .spans[].attributes | keys] | add | unique'
 ```
 
-The keys must include at least one content key. If you see only metadata (`tool_name`, `duration_ms`, `success`, ids), content is not flowing — you missed a gate. Common misses: Claude Code without `OTEL_LOGS_EXPORTER=otlp` or the `OTEL_LOG_*` gates; Codex without `log_user_prompt=true`; OpenCode standalone without the exporter.
+The keys must include at least one content key. If you see only metadata (`tool_name`, `duration_ms`, `success`, ids), content is not flowing. You missed a gate. Common misses: Claude Code without `OTEL_LOGS_EXPORTER=otlp` or the `OTEL_LOG_*` gates; Codex without `log_user_prompt=true`; OpenCode standalone without the exporter.
 
 Recognized content keys (any one is enough): `gen_ai.prompt`, `gen_ai.completion`, `input.value`, `llm.input_messages`, `user.message`, `tangle.task`, `tangle.tool.args` / `tangle.tool.result`, or the agent-native `claude_code.user_prompt` / `api_request_body`, `codex.user_prompt`, `opencode message.part.text`.

--- a/pages/intelligence/index.mdx
+++ b/pages/intelligence/index.mdx
@@ -7,7 +7,7 @@ description: Observability for AI agents. Record every run, find what broke, and
 
 Observability for AI agents. Record every run, find the moment one broke, change one thing, and measure what moved.
 
-Ask Intelligence to investigate a run, and an analyst reads the evidence and writes up what happened with the spans attached — "checkout failed 12× today, all on the retry path after a 429." It keeps every run you send it, so when an agent misbehaves you pull up the exact moment it broke. You make the fix; Intelligence never changes your agent for you.
+Ask Intelligence to investigate a run, and an analyst reads the evidence and writes up what happened with the spans attached: "checkout failed 12× today, all on the retry path after a 429." It keeps every run you send it, so when an agent misbehaves you pull up the exact moment it broke. You make the fix; Intelligence never changes your agent for you.
 
 ## What you do with it
 
@@ -26,5 +26,5 @@ Send traces over OpenTelemetry or a Tangle SDK, with no other Tangle setup. Or r
 
 ## Start
 
-- **[Quickstart](/intelligence/quickstart)** — get your first content-bearing trace flowing in about five minutes.
-- **[Connect your agent](/intelligence/connect)** — Claude Code, Codex, OpenCode, or agents run inside a Tangle sandbox.
+- **[Quickstart](/intelligence/quickstart)**: get your first content-bearing trace flowing in about five minutes.
+- **[Connect your agent](/intelligence/connect)**: Claude Code, Codex, OpenCode, or agents run inside a Tangle sandbox.

--- a/pages/intelligence/quickstart.mdx
+++ b/pages/intelligence/quickstart.mdx
@@ -17,7 +17,7 @@ export TANGLE_API_KEY=sk-tan-...
 
 ## 2. Point your agent at Intelligence, with content on
 
-Content rides the OTLP **logs** signal and ships off by default, so the logs exporter and the content gates are both required — telemetry alone gives you a metadata-only feed.
+Content rides the OTLP **logs** signal and ships off by default, so the logs exporter and the content gates are both required. Telemetry alone gives you a metadata-only feed.
 
 ```sh
 export CLAUDE_CODE_ENABLE_TELEMETRY=1
@@ -37,7 +37,7 @@ The full flag set, privacy tiers, and per-agent config for Codex, OpenCode, and 
 
 ## 3. Run one real task
 
-Run the agent once on an actual task, not an empty prompt — Intelligence reads the prompts, completions, and tool I/O that a real run produces.
+Run the agent once on an actual task, not an empty prompt. Intelligence reads the prompts, completions, and tool I/O that a real run produces.
 
 ```sh
 claude -p "fix the failing test in src/auth"
@@ -54,9 +54,9 @@ curl -sS "https://intelligence.tangle.tools/v1/traces/$TID/spans" -H "$AUTH" \
   | jq '[.items[].attributes // .spans[].attributes | keys] | add | unique'
 ```
 
-If the keys include a content key such as `claude_code.user_prompt` or `gen_ai.prompt`, content is flowing. If you see only `tool_name`, `duration_ms`, and ids, you missed a gate — see [Connect your agent](/intelligence/connect#verify-content-is-flowing).
+If the keys include a content key such as `claude_code.user_prompt` or `gen_ai.prompt`, content is flowing. If you see only `tool_name`, `duration_ms`, and ids, you missed a gate. See [Connect your agent](/intelligence/connect#verify-content-is-flowing).
 
 ## Next
 
-- [Connect your agent](/intelligence/connect) — Codex, OpenCode, and agents that only emit content when run inside a Tangle sandbox.
+- [Connect your agent](/intelligence/connect): Codex, OpenCode, and agents that only emit content when run inside a Tangle sandbox.
 - Run your agent in the [sandbox runtime](/infrastructure/introduction) and its evidence lands in the same timeline without any exporter setup.

--- a/pages/network/incentives-stakers.mdx
+++ b/pages/network/incentives-stakers.mdx
@@ -11,7 +11,7 @@ Stakers (delegators) earn two types of rewards on Tangle:
 - Delegate to an operator and choose a blueprint selection mode:
   - **`All`**: you are exposed to all blueprints the operator participates in.
   - **`Fixed`**: you choose which blueprint IDs you accept exposure to.
-- Optionally apply a lock multiplier (1–6 months) to boost reward share.
+- Optionally apply a lock multiplier (1 to 6 months) to boost reward share.
 
 ## TNT Deposit Incentives (`RewardVaults`)
 

--- a/pages/platform/authentication.mdx
+++ b/pages/platform/authentication.mdx
@@ -1,14 +1,14 @@
 # Authentication & API keys
 
-One account, one API key, one balance — across every Tangle product.
+One account, one API key, one balance, across every Tangle product.
 
 ## Sign in
 
-Create your account at [id.tangle.tools](https://id.tangle.tools), then sign in with email and password, GitHub, Google, or X — or an Ethereum wallet, by signing a message (nothing goes on-chain).
+Create your account at [id.tangle.tools](https://id.tangle.tools), then sign in with email and password, GitHub, Google, or X. You can also use an Ethereum wallet, by signing a message (nothing goes on-chain).
 
 ## Get an API key
 
-Open **API keys** in [id.tangle.tools](https://id.tangle.tools) and create one. Keys start with `sk-tan-`. You see the full key only once — copy it now, and keep it secret: anyone who has it can spend your balance.
+Open **API keys** in [id.tangle.tools](https://id.tangle.tools) and create one. Keys start with `sk-tan-`. You see the full key only once. Copy it now, and keep it secret: anyone who has it can spend your balance.
 
 Save it:
 
@@ -35,13 +35,13 @@ curl -sS https://id.tangle.tools/v1/billing/balance \
 }
 ```
 
-- `data.balance` — your spendable credit, in US dollars.
-- `data.lifetimeSpent` — total you've spent to date, in US dollars.
+- `data.balance`: your spendable credit, in US dollars.
+- `data.lifetimeSpent`: total you've spent to date, in US dollars.
 
 A `401` with `"code": "UNAUTHORIZED"` means the key is missing or wrong.
 
 ## If a key leaks
 
-Revoke it in [id.tangle.tools](https://id.tangle.tools) under **API keys** — a revoked key stops working. Use a separate key for each app or environment, so revoking one never breaks the others.
+Revoke it in [id.tangle.tools](https://id.tangle.tools) under **API keys**. A revoked key stops working. Use a separate key for each app or environment, so revoking one never breaks the others.
 
 Add credit and manage your plan at [id.tangle.tools](https://id.tangle.tools).

--- a/pages/sandbox/index.mdx
+++ b/pages/sandbox/index.mdx
@@ -1,38 +1,38 @@
 ---
 title: Sandbox
-description: A real isolated computer for every agent — shell, files, ports, GPU, and any coding harness — driven by an SDK, CLI, or dashboard.
+description: A real isolated computer for every agent: shell, files, ports, GPU, and any coding harness, driven by an SDK, CLI, or dashboard.
 ---
 
 # Sandbox
 
-A real isolated computer for every agent. Each sandbox is a dev container or microVM with a shell, a filesystem, ports, snapshots, and optional GPU — pre-loaded with the coding harness of your choice. You drive it from an SDK, CLI, or dashboard. Sandbox is Tangle's flagship product: the **run** in build, run, and improve.
+A real isolated computer for every agent. Each sandbox is a dev container or microVM with a shell, a filesystem, ports, snapshots, and optional GPU, pre-loaded with the coding harness of your choice. You drive it from an SDK, CLI, or dashboard. Sandbox is Tangle's flagship product: the **run** in build, run, and improve.
 
 ## What you get
 
-- **A full machine per agent** — run shell commands, read and write files, open ports, snapshot state, and attach a GPU only for the command that needs it.
-- **Any coding harness** — each sandbox runs one AI backend: OpenCode (default), Claude Code, Codex, Cursor, and a dozen more. You pick it per sandbox.
-- **Durable agent sessions** — dispatch a prompt and reconnect to the same run after a client crash, a deploy, or a browser reload. Same session ID is idempotent, so a retried request never re-executes.
-- **One key, metered per second** — the same [`sk-tan-` key](/platform/authentication) authenticates every call; you pay for what you use.
+- **A full machine per agent.** Run shell commands, read and write files, open ports, snapshot state, and attach a GPU only for the command that needs it.
+- **Any coding harness.** Each sandbox runs one AI backend: OpenCode (default), Claude Code, Codex, Cursor, and a dozen more. You pick it per sandbox.
+- **Durable agent sessions.** Dispatch a prompt and reconnect to the same run after a client crash, a deploy, or a browser reload. Same session ID is idempotent, so a retried request never re-executes.
+- **One key, metered per second.** The same [`sk-tan-` key](/platform/authentication) authenticates every call; you pay for what you use.
 
 ## Why use it
 
-- **Give an agent a real environment, not a chat box.** It runs actual commands in an isolated machine and returns real results — files changed, tests run, output captured.
+- **Give an agent a real environment, not a chat box.** It runs actual commands in an isolated machine and returns real results: files changed, tests run, output captured.
 - **Run untrusted work safely.** Every sandbox is isolated with its own filesystem and egress policy, so an agent's mistakes stay contained.
-- **Keep long runs alive.** Durable sessions survive the things that normally kill a streaming agent — a dropped connection, a redeployed worker, a closed laptop.
+- **Keep long runs alive.** Durable sessions survive the things that normally kill a streaming agent: a dropped connection, a redeployed worker, a closed laptop.
 - **See what happened.** Every run can emit a trace to [Intelligence](/intelligence), so a failed run is inspectable instead of lost.
 
 ## How it works
 
-Your SDK or CLI call hits the Sandbox API, which routes to a driver (container or microVM), provisions the machine, and relays the agent's output back to you as it streams. You never manage the infrastructure — `create` returns a machine, `delete` releases it. For the execution and orchestration internals, see the [runtime docs](/infrastructure/introduction).
+Your SDK or CLI call hits the Sandbox API, which routes to a driver (container or microVM), provisions the machine, and relays the agent's output back to you as it streams. You never manage the infrastructure: `create` returns a machine, `delete` releases it. For the execution and orchestration internals, see the [runtime docs](/infrastructure/introduction).
 
 ## Use cases
 
-- **Coding agents that ship real changes** — point Claude Code, Codex, or OpenCode at a repo in a sandbox and let it edit, run, and verify.
-- **Batch and background work** — dispatch many runs across a fleet of sandboxes, each isolated, each metered.
-- **Evals at scale** — run a task set across sandboxes and send every trace to Intelligence to score what changed.
-- **GPU jobs on demand** — attach a spend-capped GPU lease around the one step that needs it, then release it.
+- **Coding agents that ship real changes.** Point Claude Code, Codex, or OpenCode at a repo in a sandbox and let it edit, run, and verify.
+- **Batch and background work.** Dispatch many runs across a fleet of sandboxes, each isolated, each metered.
+- **Evals at scale.** Run a task set across sandboxes and send every trace to Intelligence to score what changed.
+- **GPU jobs on demand.** Attach a spend-capped GPU lease around the one step that needs it, then release it.
 
 ## Start
 
-- **[Quickstart](/sandbox/quickstart)** — create a sandbox and run your first agent in a few minutes.
-- **[`@tangle-network/sandbox` on npm](https://www.npmjs.com/package/@tangle-network/sandbox)** — the full `@tangle-network/sandbox` surface.
+- **[Quickstart](/sandbox/quickstart).** Create a sandbox and run your first agent in a few minutes.
+- **[`@tangle-network/sandbox` on npm](https://www.npmjs.com/package/@tangle-network/sandbox)**. The full `@tangle-network/sandbox` surface.

--- a/pages/sandbox/index.mdx
+++ b/pages/sandbox/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: Sandbox
-description: A real isolated computer for every agent: shell, files, ports, GPU, and any coding harness, driven by an SDK, CLI, or dashboard.
+description: A real isolated computer for every agent, with a shell, files, ports, GPU, and any coding harness, driven by an SDK, CLI, or dashboard.
 ---
 
 # Sandbox

--- a/pages/sandbox/quickstart.mdx
+++ b/pages/sandbox/quickstart.mdx
@@ -5,7 +5,7 @@ description: Create a sandbox and run your first coding agent in a few minutes.
 
 # Quickstart
 
-Create an isolated machine, run a shell command in it, then hand it to a coding agent — all from a few lines of TypeScript.
+Create an isolated machine, run a shell command in it, then hand it to a coding agent, all from a few lines of TypeScript.
 
 ## 1. Install the SDK
 
@@ -47,7 +47,7 @@ try {
 
 ## 4. Run a coding agent
 
-Each sandbox runs one coding harness. Choose it with `backend.type` — `opencode` (OpenCode) is the default and needs no extra key; `claude-code` (Claude Code) needs an `ANTHROPIC_API_KEY` in the sandbox environment. See [supported harnesses](/infrastructure/harnesses) for the full list.
+Each sandbox runs one coding harness. Choose it with `backend.type`: `opencode` (OpenCode) is the default and needs no extra key; `claude-code` (Claude Code) needs an `ANTHROPIC_API_KEY` in the sandbox environment. See [supported harnesses](/infrastructure/harnesses) for the full list.
 
 ```typescript
 const box = await client.create({
@@ -63,7 +63,7 @@ try {
 }
 ```
 
-For runs that must survive a client crash or a browser reload, use `box.dispatchPrompt(message, { sessionId })` and reconnect with `box.session(sessionId)` — see the [`@tangle-network/sandbox` on npm](https://www.npmjs.com/package/@tangle-network/sandbox).
+For runs that must survive a client crash or a browser reload, use `box.dispatchPrompt(message, { sessionId })` and reconnect with `box.session(sessionId)`. See the [`@tangle-network/sandbox` on npm](https://www.npmjs.com/package/@tangle-network/sandbox).
 
 ## 5. Check before you build (optional)
 
@@ -76,5 +76,5 @@ curl -fsS https://sandbox.tangle.tools/v1/public-templates
 
 ## Next
 
-- **[`@tangle-network/sandbox` on npm](https://www.npmjs.com/package/@tangle-network/sandbox)** — durable sessions, fleets, snapshots, GPU leases, and the full API.
-- **[Connect to Intelligence](/intelligence/connect)** — send each run's trace so you can see why an agent failed and what to fix.
+- **[`@tangle-network/sandbox` on npm](https://www.npmjs.com/package/@tangle-network/sandbox)**: durable sessions, fleets, snapshots, GPU leases, and the full API.
+- **[Connect to Intelligence](/intelligence/connect)**: send each run's trace so you can see why an agent failed and what to fix.

--- a/pages/staking/incentives/how_rewards_work.mdx
+++ b/pages/staking/incentives/how_rewards_work.mdx
@@ -15,7 +15,7 @@ Staking incentives on Tangle come from two sources:
 If you delegate to an operator that runs useful services, you earn:
 
 - **A share of the fees** those services pay (in the same token the customer used).
-- **Optional TNT incentives** when governance has funded a budget — paid from reward vaults on top of your fee share.
+- **Optional TNT incentives** when governance has funded a budget, paid from reward vaults on top of your fee share.
 
 You choose your exposure scope (All vs Fixed), and your share is calculated from your delegated amount and lock multiplier.
 

--- a/pages/vision/introduction.mdx
+++ b/pages/vision/introduction.mdx
@@ -2,11 +2,11 @@
 
 Tangle is infrastructure for AI agents. You **build** them in the [Blueprint Agent](/blueprint-agent/introduction), **run** them in isolated [sandboxes](/infrastructure/introduction) with one API key to [every model](/gateway/getting-started), and **improve** them with [Intelligence](/intelligence), which traces every run and tells you what to fix. One account, one key, one balance across all of it.
 
-We started by building a protocol for complex services — MPC, zero-knowledge, distributed systems. That foundation maps directly to what AI agents need: isolation, coordination, and economic accountability.
+We started by building a protocol for complex services: MPC, zero-knowledge, distributed systems. That foundation maps directly to what AI agents need: isolation, coordination, and economic accountability.
 
 ## Mission
 
-Give developers the infrastructure to run AI agents in production — and a loop that makes each run better than the last.
+Give developers the infrastructure to run AI agents in production, and a loop that makes each run better than the last.
 
 Agents should ship with the rigor of real infrastructure: isolation by default, reviewable outcomes, and cost tied to result.
 
@@ -16,17 +16,17 @@ Running agents in production is brittle. They execute outside any policy, result
 
 ## What exists today
 
-- **Sandbox runtime** — isolated dev containers, one per agent, pre-loaded with any coding harness. The flagship product; everything runs here.
-- **Inference** — one OpenAI-compatible API key to every model and provider.
-- **Intelligence** — ingests traces from sandbox runs and inference calls, and tells you why agents fail and what to change.
-- **Blueprint Agent** — describe a project and an AI agent builds it with you in an in-browser IDE.
-- **Platform** — one account, `sk-tan-` API keys, and a shared USD balance that every product bills against.
+- **Sandbox runtime**: isolated dev containers, one per agent, pre-loaded with any coding harness. The flagship product; everything runs here.
+- **Inference**: one OpenAI-compatible API key to every model and provider.
+- **Intelligence**: ingests traces from sandbox runs and inference calls, and tells you why agents fail and what to change.
+- **Blueprint Agent**: describe a project and an AI agent builds it with you in an in-browser IDE.
+- **Platform**: one account, `sk-tan-` API keys, and a shared USD balance that every product bills against.
 
 ## Where it goes
 
-- **Operator network** — runtime hosting moves to registered operators, paid through on-chain settlement.
-- **Improvement delivery** — today Intelligence reports what to fix; next it delivers those fixes back to the agents directly.
-- **Protocol-native coordination** — payments, reliability, and service discovery move on-chain.
+- **Operator network**: runtime hosting moves to registered operators, paid through on-chain settlement.
+- **Improvement delivery**: today Intelligence reports what to fix; next it delivers those fixes back to the agents directly.
+- **Protocol-native coordination**: payments, reliability, and service discovery move on-chain.
 
 Managed cloud is live today. The decentralized operator network is the trajectory, not a current claim.
 


### PR DESCRIPTION
Em dashes are banned. This removes **all 77 em dashes across 17 pages**, plus one stray en dash, and replaces each with correct punctuation for its context (period between independent clauses, comma for an appositive, colon before a list or explanation).

## Proof
- `git grep` for em dash (U+2014) and en dash (U+2013) across pages + components + release-notes: **zero**.
- Slop linter across 182 prose pages: **emDash: 0, hardSlop: 0**.
- Punctuation-only: no link target, import, code identifier, env var, or URL changed (safety-scanned the diff). Prettier clean.

Example (`sandbox/index.mdx`, the worst offender at 16): bullet labels went from `**Label** — clause` to `**Label.** Clause`; in-prose dashes became colons before lists and periods between clauses. Meaning and voice unchanged.