### PR TITLE
docs(nav): put the products in the navbar, fold Runtime under Sandbox

### DIFF
--- a/components/LandingPage.tsx
+++ b/components/LandingPage.tsx
@@ -1,7 +1,7 @@
 import Image from "next/image";
 import { GiPlatform, GiToken } from "react-icons/gi";
 import { GrNodes } from "react-icons/gr";
-import { SiBlueprint } from "react-icons/si";
+import { FiActivity } from "react-icons/fi";
 import CallToActionCard from "./CallToActionCard";
 
 const getStartedCards = [
@@ -13,13 +13,6 @@ const getStartedCards = [
     link: "/sandbox",
   },
   {
-    icon: <GiPlatform />,
-    title: "Blueprint Agent",
-    description:
-      "Describe a project and build it with an AI agent in the browser, then ship it.",
-    link: "/blueprint-agent/introduction",
-  },
-  {
     icon: <GiToken />,
     title: "Inference",
     description:
@@ -27,11 +20,18 @@ const getStartedCards = [
     link: "/gateway",
   },
   {
-    icon: <SiBlueprint />,
-    title: "Blueprints",
+    icon: <FiActivity />,
+    title: "Intelligence",
     description:
-      "Package a service and run it on the Tangle protocol, settled on-chain to operators.",
-    link: "/developers/blueprints/introduction",
+      "Every run leaves a trace. See why an agent failed and what to change.",
+    link: "/intelligence",
+  },
+  {
+    icon: <GiPlatform />,
+    title: "Blueprint Agent",
+    description:
+      "Describe a project and build it with an AI agent in the browser, then ship it.",
+    link: "/blueprint-agent/introduction",
   },
 ];
 

--- a/components/Navigation.tsx
+++ b/components/Navigation.tsx
@@ -4,8 +4,10 @@ import { ComponentProps } from "react";
 const NAV_ITEMS = new Set([
   "vision",
   "sandbox",
+  "gateway",
+  "intelligence",
   "blueprint-agent",
-  "infrastructure",
+  "platform",
   "protocol",
 ]);
 

--- a/pages/_meta.ts
+++ b/pages/_meta.ts
@@ -18,28 +18,20 @@ const meta: Meta = {
     title: "Sandbox",
     type: "page",
   },
-  platform: {
-    title: "Platform",
-    type: "page",
-  },
-  "blueprint-agent": {
-    title: "Blueprint Agent",
-    type: "page",
-  },
   gateway: {
     title: "Inference",
-    type: "page",
-  },
-  infrastructure: {
-    title: "Runtime",
     type: "page",
   },
   intelligence: {
     title: "Intelligence",
     type: "page",
   },
-  blueprints: {
-    title: "Blueprints",
+  "blueprint-agent": {
+    title: "Blueprint Agent",
+    type: "page",
+  },
+  platform: {
+    title: "Platform",
     type: "page",
   },
   protocol: {
@@ -63,6 +55,14 @@ const meta: Meta = {
         href: "/staking/introduction",
       },
     },
+  },
+  infrastructure: {
+    title: "Runtime",
+    type: "page",
+  },
+  blueprints: {
+    title: "Blueprints",
+    type: "page",
   },
   ai: {
     title: "AI",


### PR DESCRIPTION
The navbar was showing the wrong sections. It listed Vision, Sandbox, Blueprint Agent, Runtime, Protocol, and left out **Inference, Intelligence, and Platform** while showing Runtime (Sandbox's internals) as if it were a peer product.

## Fix
- Navbar now reads: **Vision, Sandbox, Inference, Intelligence, Blueprint Agent, Platform, Protocol** (the actual products, flagship first). Updated NAV_ITEMS and reordered `_meta.ts` to match.
- **Runtime folded out of the navbar.** It is Sandbox's execution layer, linked from the Sandbox overview and still in the sidebar, not a second sandbox section.
- Homepage cards now cover the four core products (added Intelligence, dropped the protocol Blueprints card, which stays reachable under Protocol).

No new pages, no dashes. Structure-only.