### PR TITLE
docs: Platform overview + Intelligence how-it-works

### DIFF
--- a/pages/intelligence/_meta.ts
+++ b/pages/intelligence/_meta.ts
@@ -4,6 +4,9 @@ const meta: Meta = {
   index: {
     title: "Overview",
   },
+  "how-it-works": {
+    title: "How it works",
+  },
   quickstart: {
     title: "Quickstart",
   },

--- a/pages/intelligence/how-it-works.mdx
+++ b/pages/intelligence/how-it-works.mdx
@@ -1,0 +1,41 @@
+---
+title: How it works
+description: What Intelligence does with a trace once it lands, from investigation to reports to the improvement loop.
+---
+
+# How it works
+
+[Connecting an agent](/intelligence/connect) gets traces flowing. This is what Intelligence does with them.
+
+## Every run becomes evidence
+
+A trace is not just timing. Intelligence records the session, the spans, the logs, the model and tool inputs and outputs, the tokens, the cost, and the errors, and keeps them as one history you can search. When an agent misbehaves, you pull up the exact run and read what it did, span by span.
+
+## Investigate
+
+Start from a symptom and work back to the cause:
+
+- **Find the run** that shows what happened, by project, time, model, or failure.
+- **Inspect it** down to the span: latency, cost, tokens, and the prompt, completion, and tool I/O for each step.
+- **Ask a question across a set of runs**, for example why a step fails only after a 429, and get an answer with the spans attached.
+
+## Reports
+
+Ask Intelligence to write up a set of runs. A fast report is deterministic and free. A deep report runs the agentic analyst, which reads the evidence and produces findings with the exact spans cited, and is billed for the work it does.
+
+## Turn a finding into a guardrail
+
+Evidence is only useful if it changes the next run. From a finding you can create an eval that catches the same failure next time, an alert or webhook when it recurs, or a dataset for testing. You make the change; Intelligence measures whether behavior actually moved after you shipped it.
+
+## The improvement loop
+
+Recommendations can feed an autonomous improvement worker that drafts the fix. Today Intelligence tells you what to change and proves whether a change worked. Delivering those fixes back to the product agents directly is the direction this is heading, not a current guarantee.
+
+## Works with or without Sandbox
+
+Intelligence runs on its own: send OpenTelemetry, SDK traces, routed model calls, or eval runs. It also pairs with the [Sandbox runtime](/sandbox), where a run's evidence lands in the same history without any exporter setup.
+
+## Next
+
+- **[Quickstart](/intelligence/quickstart)** to get your first content-bearing trace flowing.
+- **[Connect your agent](/intelligence/connect)** for per-agent setup.

--- a/pages/platform/_meta.ts
+++ b/pages/platform/_meta.ts
@@ -1,6 +1,9 @@
 import type { Meta } from "nextra";
 
 const meta: Meta = {
+  index: {
+    title: "Overview",
+  },
   authentication: "Authentication & API keys",
 };
 

--- a/pages/platform/index.mdx
+++ b/pages/platform/index.mdx
@@ -1,0 +1,27 @@
+---
+title: Platform
+description: One Tangle account, one API key, and one balance behind every product, plus the hub your agents reach external services through.
+---
+
+# Platform
+
+One account behind everything. Platform (at [id.tangle.tools](https://id.tangle.tools)) is the identity, keys, and billing that every Tangle product runs on. You sign in once, get one `sk-tan-` API key, and draw from one shared balance, whether you are running a sandbox, calling inference, or reading Intelligence.
+
+## What it gives you
+
+- **One identity.** Sign in with email, GitHub, Google, or a wallet. The same session works across every product.
+- **One API key.** An `sk-tan-` key authenticates Sandbox, Inference, Intelligence, and the rest. See [Authentication](/platform/authentication) for how to create and use it.
+- **One balance.** A single USD credit balance funds every product, so you are not topping up four separate accounts.
+- **The integration hub.** Your agents reach external services through one broker at `/v1/hub/*`: OAuth connections, capability-scoped execution, approvals, and an audit trail, without hand-rolling OAuth per product.
+
+## Why it works this way
+
+An agent that runs code, calls models, and reads traces touches three or four products in one task. Splitting identity, keys, and billing across them would mean four logins and four bills for one workflow. Platform keeps that as one account so the products compose instead of fragmenting.
+
+## How products use it
+
+Every product verifies your key against Platform, checks your balance, and reports usage back to deduct credits. The integration hub is a separate seam: products import a hub client, point it at `id.tangle.tools`, and let Platform handle the OAuth, tokens, and policy for connecting to outside services.
+
+## Start
+
+- **[Authentication and API keys](/platform/authentication)** to create an `sk-tan-` key and make your first authenticated call.


### PR DESCRIPTION
Fills two real gaps in the core-product sections.

- **Platform overview** (`/platform`): the section's only page was Authentication, so the navbar 'Platform' link dropped you into key setup with no context. New overview: one account, one `sk-tan-` key, one balance, plus the integration hub, and how every product uses it. Grounded in the platform README.
- **Intelligence how-it-works** (`/intelligence/how-it-works`): Intelligence had Overview/Quickstart/Connect but nothing on what it *does* with a trace. New page: investigate, reports (fast vs the billable agentic analyst), turning a finding into a guardrail, and the improvement loop, marked roadmap where the product brief says the full loop isn't proven live. Grounded in the product brief.

Verified: em dashes 0, slop 0, copy-check + prettier pass, gray-matter parses, links resolve.