### PR TITLE
docs: no-ai-slop pass on the core pages

### DIFF
--- a/pages/gateway/index.mdx
+++ b/pages/gateway/index.mdx
@@ -13,7 +13,7 @@ Tangle Inference is one OpenAI-compatible endpoint for every model. A single API
 - **Operator network.** Route to operators registered for [Blueprints](/developers/blueprints/introduction); the gateway selects from their advertised endpoint, model support, price, latency, and reputation data.
 - **Compliance routing.** Zero Data Retention and no-train filtering with verified provider agreements.
 - **BYOK.** Bring your own provider keys for zero-markup access.
-- **On-chain payments.** Pay operators directly via SpendAuth - no credit card required.
+- **On-chain payments.** Pay operators directly via SpendAuth, no credit card required.
 
 ## Quick example
 
@@ -40,7 +40,7 @@ The gateway routes through three tiers, in order:
 | **LiteLLM**   | Proxy with 100+ provider integrations and built-in retries      | Default for standard requests                                  |
 | **Direct**    | Straight to provider API (OpenAI, Anthropic, etc.)              | Fallback when LiteLLM unavailable, or when compliance required |
 
-When [Zero Data Retention](/gateway/zdr) or [no-train](/gateway/no-train) is requested, operators and LiteLLM are skipped - the gateway routes directly to verified providers only.
+When [Zero Data Retention](/gateway/zdr) or [no-train](/gateway/no-train) is requested, operators and LiteLLM are skipped. The gateway routes directly to verified providers only.
 
 ## Where the gateway sits
 

--- a/pages/platform/index.mdx
+++ b/pages/platform/index.mdx
@@ -20,7 +20,7 @@ An agent that runs code, calls models, and reads traces touches three or four pr
 
 ## How products use it
 
-Every product verifies your key against Platform, checks your balance, and reports usage back to deduct credits. The integration hub is a separate seam: products import a hub client, point it at `id.tangle.tools`, and let Platform handle the OAuth, tokens, and policy for connecting to outside services.
+Every product verifies your key against Platform, checks your balance, and reports usage back to deduct credits. The integration hub is a separate path. Products import a hub client, point it at `id.tangle.tools`, and let Platform handle the OAuth, tokens, and policy for connecting to outside services.
 
 ## Start
 


### PR DESCRIPTION
Held the nine core reader-facing pages against the full no-ai-slop checklist (petergyang/no-ai-slop), not just em dashes. **Seven were already clean.** Three fixes on two pages:

- `gateway/index`: two spaced-hyphen dashes → a comma and a period.
- `platform/index`: a colon-reveal rewritten as two plain sentences, and the jargon word 'seam' (banned) replaced with 'path'.

Verified: em dashes 0, copy-check + prettier pass, gray-matter parses.