### PR TITLE
docs: fix dead RPC endpoints and drift-prone provider counts

### DIFF
--- a/components/NetworkResources.tsx
+++ b/components/NetworkResources.tsx
@@ -46,11 +46,7 @@ const NETWORK_DATA = {
     { property: "Host Chain", value: "Base Mainnet" },
     {
       property: "Public RPC URL",
-      value: { type: "wss", url: "https://rpc.tangle.tools" },
-    },
-    {
-      property: "Public WSS URL",
-      value: { type: "wss", url: "wss://rpc.tangle.tools" },
+      value: { type: "wss", url: "https://mainnet.base.org" },
     },
     {
       property: "Protocol Contracts",
@@ -99,11 +95,7 @@ const NETWORK_DATA = {
     { property: "Host Chain", value: "Base Sepolia" },
     {
       property: "Public RPC URL",
-      value: { type: "wss", url: "https://testnet-rpc.tangle.tools" },
-    },
-    {
-      property: "Public WSS URL",
-      value: { type: "wss", url: "wss://testnet-rpc.tangle.tools" },
+      value: { type: "wss", url: "https://sepolia.base.org" },
     },
     {
       property: "Protocol Contracts",

--- a/pages/ai/index.mdx
+++ b/pages/ai/index.mdx
@@ -50,7 +50,7 @@ The [Tangle Gateway](/gateway) is the hosted inference routing layer. Agents and
 
 Key capabilities:
 
-- **One API, any model.** OpenAI, Anthropic, Google, Groq, and 20+ providers.
+- **One API, any model.** OpenAI, Anthropic, Google, Groq, and every other supported provider.
 - **Operator routing.** Route to registered operators when a request pins an operator path or uses SpendAuth.
 - **Compliance.** [Zero Data Retention](/gateway/zdr) and [no-train](/gateway/no-train) routing with verified provider agreements.
 - **On-chain payments.** [SpendAuth](/gateway/spend-auth) lets users pay operators directly without a credit card.

--- a/pages/developers/blueprint-runner/x402.mdx
+++ b/pages/developers/blueprint-runner/x402.mdx
@@ -84,7 +84,7 @@ service_id = 1
 job_index = 1
 invocation_mode = "restricted_paid"
 auth_mode = "payer_is_caller"
-tangle_rpc_url = "https://rpc.tangle.tools"
+tangle_rpc_url = "https://mainnet.base.org"
 tangle_contract = "0xYourTangleContract"
 ```
 

--- a/pages/developers/blueprints/pricing-engine.mdx
+++ b/pages/developers/blueprints/pricing-engine.mdx
@@ -67,8 +67,8 @@ These are the files operators typically tune:
 `pricing-engine-server` reads `operator.toml` and the pricing config, then watches the Tangle Protocol contracts:
 
 ```bash
-OPERATOR_HTTP_RPC=https://rpc.tangle.tools \
-OPERATOR_WS_RPC=wss://rpc.tangle.tools \
+OPERATOR_HTTP_RPC=https://mainnet.base.org \
+OPERATOR_WS_RPC=wss://YOUR_BASE_WS_ENDPOINT \
 OPERATOR_TANGLE_CONTRACT=0x... \
 OPERATOR_RESTAKING_CONTRACT=0x... \
 OPERATOR_STATUS_REGISTRY_CONTRACT=0x... \

--- a/pages/gateway/index.mdx
+++ b/pages/gateway/index.mdx
@@ -9,7 +9,7 @@ Tangle Inference is one OpenAI-compatible endpoint for every model. A single API
 
 ## One key for every provider and operator
 
-- **One key, any model.** Access OpenAI, Anthropic, Google, Groq, Mistral, and 20+ providers through a single API key.
+- **One key, any model.** Reach OpenAI, Anthropic, Google, Groq, Mistral, and every other supported provider through a single API key. The live catalog is at [`/v1/models`](https://router.tangle.tools/v1/models).
 - **Operator network.** Route to operators registered for [Blueprints](/developers/blueprints/introduction); the gateway selects from their advertised endpoint, model support, price, latency, and reputation data.
 - **Compliance routing.** Zero Data Retention and no-train filtering with verified provider agreements.
 - **BYOK.** Bring your own provider keys for zero-markup access.

--- a/pages/gateway/models.mdx
+++ b/pages/gateway/models.mdx
@@ -1,11 +1,11 @@
 ---
 title: Supported Models
-description: Browse models available through Tangle Inference across 16 providers.
+description: Browse the models and providers available through Tangle Inference.
 ---
 
 # Supported Models
 
-Tangle Inference provides access to models from 16 providers through a single API.
+Tangle Inference reaches every supported provider through a single API. The providers below are the most commonly used; the live catalog is always at [`/v1/models`](https://router.tangle.tools/v1/models).
 
 ## Providers
 

--- a/pages/gateway/no-train.mdx
+++ b/pages/gateway/no-train.mdx
@@ -23,10 +23,10 @@ Ensure your prompts and responses are never used by providers to train their mod
 
 Disallow prompt training is a **subset** of [Zero Data Retention](/gateway/zdr). All ZDR-compliant providers also disallow prompt training, but more providers disallow training than offer full ZDR.
 
-| Filter                  | Verified providers |
-| ----------------------- | ------------------ |
-| No-train only           | 25 providers       |
-| ZDR (includes no-train) | 13 providers       |
+| Filter                  | Coverage                                                                      |
+| ----------------------- | ----------------------------------------------------------------------------- |
+| No-train only           | The broader set: every provider that contractually disallows prompt training. |
+| ZDR (includes no-train) | A subset of those: providers that also guarantee zero data retention.         |
 
 Use `disallowPromptTraining` when you care about IP protection but don't need full data deletion guarantees.
 


### PR DESCRIPTION
Accuracy audit against **live hosts** and the **product repos**. Two classes of real defect found.

## 1. Dead RPC endpoints (documented infrastructure that does not work)
`rpc.tangle.tools` returns **521** and `testnet-rpc.tangle.tools` returns **520**, on GET and on a proper JSON-RPC POST. They were referenced in three places: the endpoints component, the x402 config example, and the pricing-engine env block.

The host chain is Base (the page itself lists chain IDs 8453 and 84532, and tnt-core deploys against Base), so these now use the verified public Base RPCs:
- `https://mainnet.base.org` → `eth_chainId` = `0x2105` (8453) ✓
- `https://sepolia.base.org` → `eth_chainId` = `0x14a34` (84532) ✓

The **Public WSS rows are removed** rather than pointed somewhere dead, because Base publishes no public websocket endpoint.

**Why CI never caught this:** these URLs live inside fenced code blocks and a `.tsx` component, which lychee does not scan. `.lycheeignore` does not exclude them. Worth knowing: a dead endpoint in an example is invisible to the link checker.

## 2. Provider counts that contradicted each other and reality
The docs claimed **20+** providers (gateway/index, ai/index), **16** (models.mdx), and **25 / 13** (no-train table). The live router serves **471 models across 61 providers**, so all of them were wrong, and any number hardcoded here drifts again next month.

Copy now names the well-known providers and points at the live [`/v1/models`](https://router.tangle.tools/v1/models) catalog. The no-train table compares coverage (broader set vs subset) instead of asserting counts.

Verified: **all 255 external URLs** in pages and components return 2xx/3xx; em dashes 0; slop 0; copy-check, prettier, gray-matter all pass.