### PR TITLE
docs: fix 48 factual defects found by auditing claims against the code

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -110,6 +110,25 @@ jobs:
       - name: harness copy
         run: node ./scripts/check-harness-copy.mjs
 
+  endpoints:
+    name: endpoints
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.11.0
+        with:
+          access_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: actions/checkout@v3
+
+      - name: Use Node.js 22.x
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22.x
+
+      - name: live endpoints
+        run: node ./scripts/check-live-endpoints.mjs
+
   links:
     name: links
     runs-on: ubuntu-latest

--- a/components/NetworkResources.tsx
+++ b/components/NetworkResources.tsx
@@ -83,8 +83,8 @@ const NETWORK_DATA = {
       property: "EVM Explorer",
       value: {
         type: "link",
-        url: "https://testnet-explorer.tangle.tools",
-        text: "testnet-explorer.tangle.tools",
+        url: "https://sepolia.basescan.org",
+        text: "sepolia.basescan.org",
       },
     },
     { property: "Asset Details", value: "" },

--- a/pages/blueprint-agent/introduction.mdx
+++ b/pages/blueprint-agent/introduction.mdx
@@ -4,7 +4,7 @@ Describe a project, and an AI agent builds it with you in an in-browser IDE. The
 
 ## What it is
 
-An AI programming workspace in the browser. You describe what you want, the agent writes and edits the code, and you review, run, and iterate on the result in a real dev environment, with no local setup. Each session runs on the [Sandbox runtime](/infrastructure/introduction), so the agent has a full machine: shell, files, ports, and any supported coding harness.
+An AI programming workspace in the browser. You describe what you want, the agent writes and edits the code, and you review, run, and iterate on the result in a real dev environment, with no local setup. Each session runs on the [Sandbox runtime](/infrastructure/introduction), so the agent has a full machine: shell, files, ports, and the coding agent runtime.
 
 It does not improve itself. You drive every change; the agent does the work you direct. (The trace-and-improve loop lives in [Intelligence](/intelligence), a separate product.)
 
@@ -17,7 +17,7 @@ It does not improve itself. You drive every change; the agent does the work you 
 ## How it works
 
 1. **Describe the project**: a plain-language brief of what you want built.
-2. **The agent builds it**: it works in a sandboxed dev environment, writing and running code, with the harness and model you choose.
+2. **The agent builds it**: it works in a sandboxed dev environment, writing and running code, with the model you choose.
 3. **Review and iterate**: read the diffs, run the preview, and steer the next turn.
 4. **Ship**: take the result to your own repo or deployment.
 
@@ -29,4 +29,4 @@ It does not improve itself. You drive every change; the agent does the work you 
 ## Start
 
 - **[Quickstart](/blueprint-agent/workflows)**: start a session and get your first project building.
-- **[Profiles](/blueprint-agent/profiles)**: set the coding harness, model routing, and tool permissions for a session.
+- **[Profiles](/blueprint-agent/profiles)**: set model routing, tool permissions, and MCP servers for a session.

--- a/pages/blueprint-agent/profile-schema.mdx
+++ b/pages/blueprint-agent/profile-schema.mdx
@@ -5,7 +5,7 @@ The profile schema configures sidecar agents. The schema is shared across sandbo
 ## Current Support
 
 - **Sandbox SDK backends**: OpenCode, Claude Code, Kimi Code, Codex, AMP, Factory Droids, Pi, Hermes, Forge, OpenClaw, NanoClaw, ACP, Cursor, and CLI base.
-- **Sandbox UI picker**: the current picker exposes OpenCode, Claude Code, Codex, AMP, Factory Droids, Kimi Code, OpenClaw, NanoClaw, Hermes, and CLI base while deferring Pi, Forge, ACP, and Cursor.
+- **Sandbox UI picker**: the session picker exposes OpenCode, Claude Code, Codex, Kimi Code, OpenClaw, NanoClaw, and Hermes. CLI base is excluded (a no-agent sandbox has nothing to chat with); AMP, Factory Droids, Pi, Forge, and Cursor are SDK-only today.
 - **Blueprint sidecar**: the AI Agent Sandbox blueprint's current all-harness sidecar advertises Claude Code, Codex, OpenCode, Kimi Code, and Gemini CLI through `/api/capabilities`.
 
 Products can expose a subset of these lists. Read runtime capabilities from the sandbox or blueprint service instance instead of assuming every harness is enabled. See [Sandbox Harnesses](/infrastructure/harnesses).

--- a/pages/blueprint-agent/profiles.mdx
+++ b/pages/blueprint-agent/profiles.mdx
@@ -4,7 +4,7 @@ Profiles configure how an agent runs. They package model choice, tool access, pe
 
 ## What A Profile Controls
 
-- **Harness selection**: OpenCode, Claude Code, Kimi Code, Codex, AMP, Factory Droids, Pi, Hermes, Forge, OpenClaw, NanoClaw, ACP, Cursor, or CLI base when the product exposes them. The current Sandbox UI picker defers Pi, Forge, ACP, and Cursor until product policy lands.
+- **Harness selection**: OpenCode, Claude Code, Kimi Code, Codex, AMP, Factory Droids, Pi, Hermes, Forge, OpenClaw, NanoClaw, ACP, Cursor, or CLI base when the product exposes them. The Sandbox session picker currently offers OpenCode, Claude Code, Codex, Kimi Code, OpenClaw, NanoClaw, and Hermes; the remaining backends are SDK-only.
 - **Model selection**: primary and small model routing per profile.
 - **Per-agent tuning**: distinct configs for plan/build/explore (prompt, temperature, max steps).
 - **Tool access**: enable or disable individual tools.
@@ -20,13 +20,11 @@ Profiles are validated before execution. Security policies can cap permissions (
 
 ## Base, Variant, and Per-Run Profiles
 
-The workbench will progressively expose profile controls:
+The workbench exposes profile controls today:
 
-- **Base profiles** for org-wide defaults.
-- **Profile variants** for team or project overrides.
-- **Per-run overrides** for experimentation and simulations.
-
-If you want early access to advanced profile configuration, contact the team.
+- **Base profiles** for org-wide defaults, inherited with `extends`.
+- **Custom profiles** for team or project overrides, created and edited from the profile selector in the chat composer.
+- **Per-run selection**: pick the profile a session runs under before each run.
 
 The runtime merges overrides with the base profile, validates the final config, and applies the result to the sidecar session.
 

--- a/pages/blueprints/surplus-market/dapp-and-indexer.mdx
+++ b/pages/blueprints/surplus-market/dapp-and-indexer.mdx
@@ -5,9 +5,9 @@ description: Dapp routing, metadata gaps, protocol state, and live venue checks 
 
 # Surplus Market Dapp Integration
 
-Surplus is live as a hosted app at `https://surplus-market.pages.dev/`.
+Surplus has no live hosted app today. The previously published address (`surplus-market.pages.dev`) no longer resolves, and no `*.blueprint.tangle.tools` host is deployed for it, unlike Sandbox and Trading.
 
-Tangle Cloud should treat it as a first-party link-out until the repo publishes `blueprintUi` metadata and a `*.blueprint.tangle.tools` iframe host. Do not pretend it has the same iframe contract as Sandbox and Trading yet.
+Until a host is published, treat Surplus as protocol-only: route to the raw blueprint and service-instance views. It does not have the iframe contract that Sandbox and Trading have.
 
 The Surplus repo does not ship a dedicated indexer today. The product app can read protocol state from contracts or a shared protocol indexing layer when one exists, but the venue, order book, settlement outbox, and inference redemption state live in the product/operator path.
 
@@ -27,7 +27,7 @@ It does not yet include the full `blueprintUi` object used by Sandbox and Tradin
 
 | Route             | Behavior                                                       |
 | ----------------- | -------------------------------------------------------------- |
-| Product app       | Link to `https://surplus-market.pages.dev/`.                   |
+| Product app       | None deployed. Do not link out until a host is published.      |
 | Protocol fallback | Preserve the raw blueprint and service-instance route.         |
 | Future iframe     | Use only after a trusted host and iframe policy are published. |
 

--- a/pages/developers/auth-surface.mdx
+++ b/pages/developers/auth-surface.mdx
@@ -15,20 +15,20 @@ Roles are defined in [`Base.sol`](https://github.com/tangle-network/tnt-core/blo
 
 Note: each contract defines its own role set. `Tangle` and `MultiAssetDelegation` (MAD) do NOT share role constants; the same name on both contracts is a different keccak slot.
 
-| Role                 | Where                                                                                                                         | Suggested holder            |
-| -------------------- | ----------------------------------------------------------------------------------------------------------------------------- | --------------------------- |
-| `DEFAULT_ADMIN_ROLE` | All AccessControl contracts                                                                                                   | `TangleTimelock`            |
-| `ADMIN_ROLE`         | Tangle, MAD, and most peripherals                                                                                             | `TangleTimelock`            |
-| `PAUSER_ROLE`        | Tangle only                                                                                                                   | Operations multisig         |
-| `UPGRADER_ROLE`      | Tangle, MBSMRegistry, TangleToken, RewardVaults, InflationPool, TangleMetrics, ServiceFeeDistributor, StreamingPaymentManager | `TangleTimelock`            |
-| `SLASH_ADMIN_ROLE`   | Tangle only                                                                                                                   | Slashing oversight multisig |
-| `MANAGER_ROLE`       | MBSMRegistry only                                                                                                             | `TangleTimelock`            |
-| `ASSET_MANAGER_ROLE` | MAD only                                                                                                                      | Operations multisig         |
-| `SLASHER_ROLE`       | MAD only                                                                                                                      | Tangle (via `addSlasher`)   |
-| `TANGLE_ROLE`        | MAD only                                                                                                                      | Tangle (via `setTangle`)    |
-| `MINTER_ROLE`        | TangleToken only                                                                                                              | `TangleTimelock`            |
+| Role                 | Where                                                                                                                              | Suggested holder            |
+| -------------------- | ---------------------------------------------------------------------------------------------------------------------------------- | --------------------------- |
+| `DEFAULT_ADMIN_ROLE` | All AccessControl contracts                                                                                                        | `TangleTimelock`            |
+| `ADMIN_ROLE`         | Tangle, MAD, and most peripherals                                                                                                  | `TangleTimelock`            |
+| `PAUSER_ROLE`        | Tangle only                                                                                                                        | Operations multisig         |
+| `UPGRADER_ROLE`      | Tangle, MAD, MBSMRegistry, TangleToken, RewardVaults, InflationPool, TangleMetrics, ServiceFeeDistributor, StreamingPaymentManager | `TangleTimelock`            |
+| `SLASH_ADMIN_ROLE`   | Tangle only                                                                                                                        | Slashing oversight multisig |
+| `MANAGER_ROLE`       | MBSMRegistry only                                                                                                                  | `TangleTimelock`            |
+| `ASSET_MANAGER_ROLE` | MAD only                                                                                                                           | Operations multisig         |
+| `SLASHER_ROLE`       | MAD only                                                                                                                           | Tangle (via `addSlasher`)   |
+| `TANGLE_ROLE`        | MAD only                                                                                                                           | Tangle (via `setTangle`)    |
+| `MINTER_ROLE`        | TangleToken only                                                                                                                   | `TangleTimelock`            |
 
-`MultiAssetDelegation` does NOT define a `UPGRADER_ROLE`. Its `_authorizeUpgrade` is gated on `ADMIN_ROLE`. Its pause/unpause are gated on `ADMIN_ROLE` (no separate `PAUSER_ROLE` on MAD).
+`MultiAssetDelegation` defines its own `UPGRADER_ROLE` and gates `_authorizeUpgrade` on it. Its pause/unpause are gated on `ADMIN_ROLE` (no separate `PAUSER_ROLE` on MAD).
 
 ## Tangle (`src/Tangle.sol`)
 
@@ -42,27 +42,27 @@ Tangle is the protocol entrypoint, composed of mixins under `src/core/`. Every s
 
 | Function                               | Caller                             | Source                                                                                                   |
 | -------------------------------------- | ---------------------------------- | -------------------------------------------------------------------------------------------------------- |
-| `pause()`                              | `PAUSER_ROLE`                      | [Base.sol](https://github.com/tangle-network/tnt-core/blob/main/src/core/Base.sol)                       |
-| `unpause()`                            | `PAUSER_ROLE`                      | [Base.sol](https://github.com/tangle-network/tnt-core/blob/main/src/core/Base.sol)                       |
+| `pause()`                              | `PAUSER_ROLE`                      | [TangleCoreApi.sol](https://github.com/tangle-network/tnt-core/blob/main/src/core/TangleCoreApi.sol)     |
+| `unpause()`                            | `PAUSER_ROLE`                      | [TangleCoreApi.sol](https://github.com/tangle-network/tnt-core/blob/main/src/core/TangleCoreApi.sol)     |
 | `_authorizeUpgrade(newImpl)`           | `UPGRADER_ROLE`                    | [Base.sol](https://github.com/tangle-network/tnt-core/blob/main/src/core/Base.sol)                       |
-| `setMBSMRegistry(addr)`                | `ADMIN_ROLE` (when not paused)     | [Base.sol](https://github.com/tangle-network/tnt-core/blob/main/src/core/Base.sol)                       |
-| `setMetricsRecorder(addr)`             | `ADMIN_ROLE`                       | [Base.sol](https://github.com/tangle-network/tnt-core/blob/main/src/core/Base.sol)                       |
-| `setOperatorStatusRegistry(addr)`      | `ADMIN_ROLE`                       | [Base.sol](https://github.com/tangle-network/tnt-core/blob/main/src/core/Base.sol)                       |
-| `setServiceFeeDistributor(addr)`       | `ADMIN_ROLE`                       | [Base.sol](https://github.com/tangle-network/tnt-core/blob/main/src/core/Base.sol)                       |
-| `setPriceOracle(addr)`                 | `ADMIN_ROLE`                       | [Base.sol](https://github.com/tangle-network/tnt-core/blob/main/src/core/Base.sol)                       |
+| `setMBSMRegistry(addr)`                | `ADMIN_ROLE` (when not paused)     | [TangleCoreApi.sol](https://github.com/tangle-network/tnt-core/blob/main/src/core/TangleCoreApi.sol)     |
+| `setMetricsRecorder(addr)`             | `ADMIN_ROLE`                       | [TangleCoreApi.sol](https://github.com/tangle-network/tnt-core/blob/main/src/core/TangleCoreApi.sol)     |
+| `setOperatorStatusRegistry(addr)`      | `ADMIN_ROLE`                       | [TangleCoreApi.sol](https://github.com/tangle-network/tnt-core/blob/main/src/core/TangleCoreApi.sol)     |
+| `setServiceFeeDistributor(addr)`       | `ADMIN_ROLE`                       | [TangleCoreApi.sol](https://github.com/tangle-network/tnt-core/blob/main/src/core/TangleCoreApi.sol)     |
+| `setPriceOracle(addr)`                 | `ADMIN_ROLE`                       | [TangleCoreApi.sol](https://github.com/tangle-network/tnt-core/blob/main/src/core/TangleCoreApi.sol)     |
 | `setTreasury(addr)`                    | `ADMIN_ROLE` (NOT `whenNotPaused`) | [PaymentsRewards.sol](https://github.com/tangle-network/tnt-core/blob/main/src/core/PaymentsRewards.sol) |
 | `setPaymentSplit(split)`               | `ADMIN_ROLE` (NOT `whenNotPaused`) | [PaymentsRewards.sol](https://github.com/tangle-network/tnt-core/blob/main/src/core/PaymentsRewards.sol) |
-| `setTntToken(addr)`                    | `ADMIN_ROLE`                       | [Base.sol](https://github.com/tangle-network/tnt-core/blob/main/src/core/Base.sol)                       |
-| `setRewardVaults(addr)`                | `ADMIN_ROLE`                       | [Base.sol](https://github.com/tangle-network/tnt-core/blob/main/src/core/Base.sol)                       |
-| `setMaxBlueprintsPerOperator(n)`       | `ADMIN_ROLE`                       | [Base.sol](https://github.com/tangle-network/tnt-core/blob/main/src/core/Base.sol)                       |
-| `setDefaultTntMinExposureBps(bps)`     | `ADMIN_ROLE`                       | [Base.sol](https://github.com/tangle-network/tnt-core/blob/main/src/core/Base.sol)                       |
-| `setTntPaymentDiscountBps(bps)`        | `ADMIN_ROLE`                       | [Base.sol](https://github.com/tangle-network/tnt-core/blob/main/src/core/Base.sol)                       |
-| `setMinServiceTtl(seconds)`            | `ADMIN_ROLE`                       | [Base.sol](https://github.com/tangle-network/tnt-core/blob/main/src/core/Base.sol)                       |
-| `setMaxServiceTtl(seconds)`            | `ADMIN_ROLE`                       | [Base.sol](https://github.com/tangle-network/tnt-core/blob/main/src/core/Base.sol)                       |
-| `setRequestExpiryGracePeriod(seconds)` | `ADMIN_ROLE`                       | [Base.sol](https://github.com/tangle-network/tnt-core/blob/main/src/core/Base.sol)                       |
-| `setMaxQuoteAge(seconds)`              | `ADMIN_ROLE`                       | [Base.sol](https://github.com/tangle-network/tnt-core/blob/main/src/core/Base.sol)                       |
+| `setTntToken(addr)`                    | `ADMIN_ROLE`                       | [TangleCoreApi.sol](https://github.com/tangle-network/tnt-core/blob/main/src/core/TangleCoreApi.sol)     |
+| `setRewardVaults(addr)`                | `ADMIN_ROLE`                       | [TangleCoreApi.sol](https://github.com/tangle-network/tnt-core/blob/main/src/core/TangleCoreApi.sol)     |
+| `setMaxBlueprintsPerOperator(n)`       | `ADMIN_ROLE`                       | [TangleCoreApi.sol](https://github.com/tangle-network/tnt-core/blob/main/src/core/TangleCoreApi.sol)     |
+| `setDefaultTntMinExposureBps(bps)`     | `ADMIN_ROLE`                       | [TangleCoreApi.sol](https://github.com/tangle-network/tnt-core/blob/main/src/core/TangleCoreApi.sol)     |
+| `setTntPaymentDiscountBps(bps)`        | `ADMIN_ROLE`                       | [TangleCoreApi.sol](https://github.com/tangle-network/tnt-core/blob/main/src/core/TangleCoreApi.sol)     |
+| `setMinServiceTtl(seconds)`            | `ADMIN_ROLE`                       | [TangleCoreApi.sol](https://github.com/tangle-network/tnt-core/blob/main/src/core/TangleCoreApi.sol)     |
+| `setMaxServiceTtl(seconds)`            | `ADMIN_ROLE`                       | [TangleCoreApi.sol](https://github.com/tangle-network/tnt-core/blob/main/src/core/TangleCoreApi.sol)     |
+| `setRequestExpiryGracePeriod(seconds)` | `ADMIN_ROLE`                       | [TangleCoreApi.sol](https://github.com/tangle-network/tnt-core/blob/main/src/core/TangleCoreApi.sol)     |
+| `setMaxQuoteAge(seconds)`              | `ADMIN_ROLE`                       | [TangleCoreApi.sol](https://github.com/tangle-network/tnt-core/blob/main/src/core/TangleCoreApi.sol)     |
 
-Most admin setters in `Base.sol` are `whenNotPaused`. The two exceptions, both in `Payments.sol`, are `setTreasury` and `setPaymentSplit`. Paused governance can still rewire payment routing; this is intentional so a halted protocol can fix a known-bad treasury before resuming.
+Most admin setters in `TangleCoreApi.sol` are `whenNotPaused`. The two exceptions, both in `PaymentsRewards.sol`, are `setTreasury` and `setPaymentSplit`. Paused governance can still rewire payment routing; this is intentional so a halted protocol can fix a known-bad treasury before resuming.
 
 ### Slashing
 
@@ -117,8 +117,10 @@ See [Slashing](/developers/slashing) for the full lifecycle and runbooks.
 | `withdrawRemainingEscrow(serviceId)`       | Service owner, after termination          |
 | `billSubscription(serviceId)`              | Anyone, gated by interval                 |
 | `billSubscriptionBatch(ids)`               | Anyone                                    |
-| `claimReward(token)`                       | The reward beneficiary                    |
-| `claimRewards(tokens)`                     | The reward beneficiary                    |
+| `claimRewards()`                           | The reward beneficiary                    |
+| `claimRewards(token)`                      | The reward beneficiary                    |
+| `claimRewardsBatch(tokens)`                | The reward beneficiary                    |
+| `claimRewardsAll()`                        | The reward beneficiary                    |
 
 ## MultiAssetDelegation (`src/staking/MultiAssetDelegation.sol`)
 
@@ -126,20 +128,20 @@ Staking and delegation are a separate proxy with its own role registry. Function
 
 ### Upgrade and Global Config (StakingAdminFacet)
 
-| Function                                                     | Caller                                                                            |
-| ------------------------------------------------------------ | --------------------------------------------------------------------------------- |
-| `_authorizeUpgrade(newImpl)`                                 | `ADMIN_ROLE` (NOT a separate `UPGRADER_ROLE`; SHOULD be held by `TangleTimelock`) |
-| `pause()` / `unpause()`                                      | `ADMIN_ROLE` (no separate `PAUSER_ROLE` on MAD)                                   |
-| `setTangle(addr)`                                            | `ADMIN_ROLE` -- grants `TANGLE_ROLE`                                              |
-| `setOperatorBondToken(token)`                                | `ADMIN_ROLE` -- locked once any operator exists                                   |
-| `addSlasher(addr)` / `removeSlasher(addr)`                   | `ADMIN_ROLE` -- grants/revokes `SLASHER_ROLE`                                     |
-| `setOperatorCommission(bps)`                                 | `ADMIN_ROLE` (queues a 7-day timelocked commission change)                        |
-| `executeCommissionChange()` / `cancelCommissionChange()`     | `ADMIN_ROLE`                                                                      |
-| `setDelays(...)`                                             | `ADMIN_ROLE`                                                                      |
-| `setRewardsManager(addr)` / `setServiceFeeDistributor(addr)` | `ADMIN_ROLE`                                                                      |
-| `rescueTokens(token, to, amount)`                            | `DEFAULT_ADMIN_ROLE`                                                              |
-| `sweepDust(token, to)`                                       | `ADMIN_ROLE`                                                                      |
-| `resetPendingSlashCount(op, count)`                          | `ADMIN_ROLE` (recovery only; default reverts unless overridden)                   |
+| Function                                                     | Caller                                                          |
+| ------------------------------------------------------------ | --------------------------------------------------------------- |
+| `_authorizeUpgrade(newImpl)`                                 | `UPGRADER_ROLE` (SHOULD be held by `TangleTimelock`)            |
+| `pause()` / `unpause()`                                      | `ADMIN_ROLE` (no separate `PAUSER_ROLE` on MAD)                 |
+| `setTangle(addr)`                                            | `ADMIN_ROLE` -- grants `TANGLE_ROLE`                            |
+| `setOperatorBondToken(token)`                                | `ADMIN_ROLE` -- locked once any operator exists                 |
+| `addSlasher(addr)` / `removeSlasher(addr)`                   | `ADMIN_ROLE` -- grants/revokes `SLASHER_ROLE`                   |
+| `setOperatorCommission(bps)`                                 | `ADMIN_ROLE` (queues a 7-day timelocked commission change)      |
+| `executeCommissionChange()` / `cancelCommissionChange()`     | `ADMIN_ROLE`                                                    |
+| `setDelays(...)`                                             | `ADMIN_ROLE`                                                    |
+| `setRewardsManager(addr)` / `setServiceFeeDistributor(addr)` | `ADMIN_ROLE`                                                    |
+| `rescueTokens(token, to, amount)`                            | `DEFAULT_ADMIN_ROLE`                                            |
+| `sweepDust(token, to)`                                       | `ADMIN_ROLE`                                                    |
+| `resetPendingSlashCount(op, count)`                          | `ADMIN_ROLE` (recovery only; default reverts unless overridden) |
 
 ### Asset Configuration (StakingAssetsFacet)
 
@@ -191,10 +193,11 @@ Staking and delegation are a separate proxy with its own role registry. Function
 
 ### `ValidatorPodManager`
 
-| Function                                                   | Caller                       |
-| ---------------------------------------------------------- | ---------------------------- |
-| `createPod()`                                              | Anyone (one pod per address) |
-| `recordBeaconChainEthBalanceUpdate(podOwner, sharesDelta)` | Pod (the contract itself)    |
+| Function                                         | Caller                       |
+| ------------------------------------------------ | ---------------------------- |
+| `createPod()`                                    | Anyone (one pod per address) |
+| `recordBeaconChainDeposit(podOwner, assets)`     | Pod (the contract itself)    |
+| `recordBeaconChainRebase(podOwner, assetsDelta)` | Pod (the contract itself)    |
 
 ### `L2SlashingReceiver`
 

--- a/pages/developers/blueprints/pricing-and-payments.mdx
+++ b/pages/developers/blueprints/pricing-and-payments.mdx
@@ -77,7 +77,7 @@ High-level flow:
 
 1. User requests a per-job quote from one or more operators (off-chain).
 2. Operators respond with an EIP-712 signed
-   `JobQuoteDetails { requester, serviceId, jobIndex, price, timestamp, expiry, confidentiality }`.
+   `JobQuoteDetails { requester, serviceId, jobIndex, price, timestamp, expiry, confidentiality, inputsHash }`.
 3. User submits the job on-chain with the signed quote(s) via `submitJobFromQuote`.
 
 Key properties:
@@ -87,7 +87,7 @@ Key properties:
   wildcard `requester == address(0)`. Operators MUST sign per-caller quotes and populate
   `requester` with the address they expect to consume the quote; an attacker who lifts a
   signed digest off the wire cannot redirect it to themselves. The new typehash string is:
-  `JobQuoteDetails(address requester,uint64 serviceId,uint8 jobIndex,uint256 price,uint64 timestamp,uint64 expiry,uint8 confidentiality)`.
+  `JobQuoteDetails(address requester,uint64 serviceId,uint8 jobIndex,uint256 price,uint64 timestamp,uint64 expiry,uint8 confidentiality,bytes32 inputsHash)`.
 - `msg.value` must equal `sum(quote.price)` across quotes.
 - Quotes are replay-protected and expire (protocol also enforces `maxQuoteAge`).
 - Only quoted operators can submit results for RFQ jobs.
@@ -102,7 +102,8 @@ Types.JobQuoteDetails({
     price: 1_000_000 gwei,
     timestamp: uint64(block.timestamp),
     expiry: uint64(block.timestamp + 5 minutes),
-    confidentiality: 0           // 0=Any, 1=Required, 2=Preferred
+    confidentiality: 0,          // 0=Any, 1=Required, 2=Preferred
+    inputsHash: keccak256(inputs) // the job inputs the price is quoted against
 });
 ```
 
@@ -116,7 +117,8 @@ The equivalent EIP-712 typed-data payload (`message`):
   "price": "1000000000000000",
   "timestamp": "1746700000",
   "expiry": "1746700300",
-  "confidentiality": 0
+  "confidentiality": 0,
+  "inputsHash": "0xCAFE000000000000000000000000000000000000000000000000000000000000"
 }
 ```
 
@@ -140,7 +142,8 @@ Service RFQ lets a user create a service instantly using operator quotes:
 
 1. User requests service quotes from operators for `(blueprintId, ttlBlocks, confidentiality, security requirements)`.
 2. Operators sign EIP-712
-   `QuoteDetails { requester, blueprintId, ttlBlocks, totalCost, timestamp, expiry, confidentiality, securityCommitments[], resourceCommitments[] }`.
+   `QuoteDetails { requester, blueprintId, ttlBlocks, totalCost, timestamp, expiry, confidentiality, operation, serviceId, securityCommitments[], resourceCommitments[] }`.
+   `serviceId` MUST be 0 on Create and equal the target service on Extend.
 3. User calls `createServiceFromQuotes(...)` (or `extendServiceFromQuotes(...)`) with quotes and payment.
 
 All quotes for a single RFQ service creation or extension must agree on confidentiality. Changing confidentiality mode is
@@ -153,7 +156,7 @@ EIP-712 typehash. The contract enforces `requester == msg.sender` on
 expect to redeem the quote; previously the field existed on the struct but was excluded from
 the typehash, so a mempool observer could rewrite `details.requester` and the operator's
 signature still recovered. The new typehash string is:
-`QuoteDetails(address requester,uint64 blueprintId,uint64 ttlBlocks,uint256 totalCost,uint64 timestamp,uint64 expiry,uint8 confidentiality,AssetSecurityCommitment[] securityCommitments,ResourceCommitment[] resourceCommitments)`.
+`QuoteDetails(address requester,uint64 blueprintId,uint64 ttlBlocks,uint256 totalCost,uint64 timestamp,uint64 expiry,uint8 confidentiality,uint8 operation,uint64 serviceId,AssetSecurityCommitment[] securityCommitments,ResourceCommitment[] resourceCommitments)Asset(uint8 kind,address token)AssetSecurityCommitment(Asset asset,uint16 exposureBps)ResourceCommitment(uint8 kind,uint64 count)`.
 
 Pre-fix signatures (without `requester` in the typehash) are invalid against the new
 typehash and will fail signature recovery.

--- a/pages/developers/slashing.mdx
+++ b/pages/developers/slashing.mdx
@@ -45,7 +45,7 @@ Anyone the protocol accepts as a slasher creates a `SlashProposal`. The proposal
 4. Sets `executeAfter = block.timestamp + disputeWindow`.
 5. Calls the blueprint manager's `onUnappliedSlash` hook (best effort, capped gas).
 
-If the operator already has `maxPendingSlashesPerOperator` pending, the call reverts. Default cap is 32.
+If the operator already has `maxPendingSlashesPerOperator` pending, the call reverts. Default cap is 8.
 
 `evidence` MUST be non-zero. The contract rejects `bytes32(0)` evidence so off-chain monitors keying off
 non-zero evidence never observe silently-zero entries.
@@ -101,16 +101,16 @@ See [Auth Surface](/developers/auth-surface) for the full role-by-role table acr
 
 Set with `setSlashConfig(disputeWindow, instantSlashEnabled, maxSlashBps, disputeResolutionDeadline, disputeBond, maxPendingSlashesPerOperator)`. All parameters are admin-tunable and SHOULD be timelocked in production.
 
-| Parameter                      | Default | Bounds            | Purpose                                                                                                                                                                                               |
-| ------------------------------ | ------- | ----------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `disputeWindow`                | 7 days  | [1 hour, 30 days] | How long after `proposeSlash` the operator has to dispute                                                                                                                                             |
-| `instantSlashEnabled`          | `false` | bool              | Reserved for emergencies. The current public `proposeSlash` hardcodes `instant=false`, so this flag has no effect through the standard API. A future internal entrypoint (or upgrade) would honor it. |
-| `maxSlashBps`                  | 10000   | (0, 10000]        | Hard cap on any single slash proposal                                                                                                                                                                 |
-| `disputeResolutionDeadline`    | 14 days | [1 day, 60 days]  | Time `SLASH_ADMIN` has to resolve a dispute before it auto-fails                                                                                                                                      |
-| `disputeBond`                  | 0       | uint256           | Native-asset bond required from the operator to dispute. Forfeit to treasury on auto-fail or execute, refunded on cancel                                                                              |
-| `maxPendingSlashesPerOperator` | 32      | (0, uint16.max]   | Cap on concurrent pending slashes per operator (anti-spam)                                                                                                                                            |
+| Parameter                      | Default    | Bounds            | Purpose                                                                                                                                                                                               |
+| ------------------------------ | ---------- | ----------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `disputeWindow`                | 7 days     | [1 hour, 30 days] | How long after `proposeSlash` the operator has to dispute                                                                                                                                             |
+| `instantSlashEnabled`          | `false`    | bool              | Reserved for emergencies. The current public `proposeSlash` hardcodes `instant=false`, so this flag has no effect through the standard API. A future internal entrypoint (or upgrade) would honor it. |
+| `maxSlashBps`                  | 10000      | (0, 10000]        | Hard cap on any single slash proposal                                                                                                                                                                 |
+| `disputeResolutionDeadline`    | 14 days    | [1 day, 60 days]  | Time `SLASH_ADMIN` has to resolve a dispute before it auto-fails                                                                                                                                      |
+| `disputeBond`                  | 0.02 ether | uint256           | Native-asset bond required from the operator to dispute. Forfeit to treasury on auto-fail or execute, refunded on cancel                                                                              |
+| `maxPendingSlashesPerOperator` | 8          | (0, uint16.max]   | Cap on concurrent pending slashes per operator (anti-spam)                                                                                                                                            |
 
-`disputeBond` defaults to 0 (disabled). On a live network you SHOULD set a bond high enough to deter free self-disputes but low enough that legitimate disputes are not gated by capital. A reasonable starting point is 1% of `minOperatorStake`.
+`disputeBond` ships with a non-zero default (0.02 ether) so an unconfigured deployment is never free to self-dispute. On a live network you SHOULD tune it high enough to deter free self-disputes but low enough that legitimate disputes are not gated by capital.
 
 ## Operator Runbook
 

--- a/pages/developers/upgrade-discipline.mdx
+++ b/pages/developers/upgrade-discipline.mdx
@@ -5,14 +5,14 @@ description: UUPS upgrade rules, storage gap discipline, and parameter migration
 
 # Upgrade Discipline
 
-Every upgradeable Tangle contract is UUPS. The role that gates `_authorizeUpgrade` differs by contract: `UPGRADER_ROLE` on most peripherals, `ADMIN_ROLE` on `MultiAssetDelegation`, `onlyGovernance` on `TangleGovernor`, and `onlySelf` on `TangleTimelock`. In production the relevant role SHOULD be held by [`TangleTimelock`](https://github.com/tangle-network/tnt-core/blob/main/src/governance/TangleTimelock.sol) so all upgrades flow through governance with a delay window. This page lists the rules for upgrading the protocol so changes stay safe and reviewable.
+Every upgradeable Tangle contract is UUPS. The role that gates `_authorizeUpgrade` differs by contract: `UPGRADER_ROLE` on `Tangle`, `MultiAssetDelegation`, and most peripherals, `onlyGovernance` on `TangleGovernor`, and `onlySelf` on `TangleTimelock`. In production the relevant role SHOULD be held by [`TangleTimelock`](https://github.com/tangle-network/tnt-core/blob/main/src/governance/TangleTimelock.sol) so all upgrades flow through governance with a delay window. This page lists the rules for upgrading the protocol so changes stay safe and reviewable.
 
 ## Upgradeable Contracts
 
 | Contract                  | Upgrade gate                                                | Source                                                                                                                                    |
 | ------------------------- | ----------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
 | `Tangle`                  | `UPGRADER_ROLE`                                             | [`src/Tangle.sol`](https://github.com/tangle-network/tnt-core/blob/main/src/Tangle.sol)                                                   |
-| `MultiAssetDelegation`    | `ADMIN_ROLE` (no `UPGRADER_ROLE` on this contract)          | [`src/staking/MultiAssetDelegation.sol`](https://github.com/tangle-network/tnt-core/blob/main/src/staking/MultiAssetDelegation.sol)       |
+| `MultiAssetDelegation`    | `UPGRADER_ROLE`                                             | [`src/staking/MultiAssetDelegation.sol`](https://github.com/tangle-network/tnt-core/blob/main/src/staking/MultiAssetDelegation.sol)       |
 | `MBSMRegistry`            | `UPGRADER_ROLE`                                             | [`src/MBSMRegistry.sol`](https://github.com/tangle-network/tnt-core/blob/main/src/MBSMRegistry.sol)                                       |
 | `TangleGovernor`          | `onlyGovernance` (proposal-driven)                          | [`src/governance/TangleGovernor.sol`](https://github.com/tangle-network/tnt-core/blob/main/src/governance/TangleGovernor.sol)             |
 | `TangleTimelock`          | `onlySelf` (the timelock executing its own queued proposal) | [`src/governance/TangleTimelock.sol`](https://github.com/tangle-network/tnt-core/blob/main/src/governance/TangleTimelock.sol)             |
@@ -117,10 +117,10 @@ assert(!tangle.hasRole(UPGRADER_ROLE, deployer));
 assert(!tangle.hasRole(PAUSER_ROLE, deployer));
 assert(!tangle.hasRole(SLASH_ADMIN_ROLE, deployer));
 
-// On MultiAssetDelegation (note: NO UPGRADER_ROLE on this contract;
-// upgrades are gated by ADMIN_ROLE).
+// On MultiAssetDelegation (upgrades are gated by UPGRADER_ROLE).
 assert(!staking.hasRole(DEFAULT_ADMIN_ROLE, deployer));
 assert(!staking.hasRole(ADMIN_ROLE, deployer));
+assert(!staking.hasRole(UPGRADER_ROLE, deployer));
 assert(!staking.hasRole(ASSET_MANAGER_ROLE, deployer));
 
 // On MBSMRegistry

--- a/pages/gateway/api-chat.mdx
+++ b/pages/gateway/api-chat.mdx
@@ -60,13 +60,13 @@ All standard OpenAI parameters (`tools`, `tool_choice`, `response_format`, `top_
 
 ### Validation
 
-| Field         | Constraint                                         |
-| ------------- | -------------------------------------------------- |
-| `model`       | Required. Alphanumeric + `/-.:\\_`, max 128 chars. |
-| `messages`    | Required. Non-empty array. Each must have `role`.  |
-| `max_tokens`  | Optional. 1-128,000. Default: 4,096.               |
-| `temperature` | Optional. 0-2. Default: 1.                         |
-| Body size     | Max 1MB.                                           |
+| Field         | Constraint                                                                                        |
+| ------------- | ------------------------------------------------------------------------------------------------- |
+| `model`       | Required. Alphanumeric + `/-.:\\_`, max 128 chars.                                                |
+| `messages`    | Required. Non-empty array. Each must have `role`.                                                 |
+| `max_tokens`  | Optional. Accepted range 1-128,000; the effective ceiling sent upstream is 8,192. Default: 4,096. |
+| `temperature` | Optional. 0-2. Default: 1.                                                                        |
+| Body size     | Max 1MB.                                                                                          |
 
 ## Response (non-streaming)
 

--- a/pages/gateway/api-compliance.mdx
+++ b/pages/gateway/api-compliance.mdx
@@ -9,10 +9,11 @@ These endpoints report each provider's Zero Data Retention (ZDR) and no-train gu
 
 ## GET /api/gateway/compliance
 
-List compliance data for all providers. Public endpoint (rate-limited).
+List compliance data for all providers. Requires authentication (API key or session).
 
 ```bash
-curl https://router.tangle.tools/api/gateway/compliance
+curl https://router.tangle.tools/api/gateway/compliance \
+  -H "Authorization: Bearer sk-tan-YOUR_KEY"
 ```
 
 ```json

--- a/pages/gateway/api-credits.mdx
+++ b/pages/gateway/api-credits.mdx
@@ -18,12 +18,16 @@ Authorization: Bearer sk-tan-YOUR_KEY
 
 ```json
 {
-  "balance": "95.50",
-  "total_used": "4.50"
+  "data": {
+    "total_credits": 100.0,
+    "total_usage": 4.5
+  }
 }
 ```
 
-| Field        | Description                    |
-| ------------ | ------------------------------ |
-| `balance`    | Remaining credit balance (USD) |
-| `total_used` | Total credits consumed (USD)   |
+| Field           | Description                                                   |
+| --------------- | ------------------------------------------------------------- |
+| `total_credits` | Total credits ever granted: balance plus lifetime spend (USD) |
+| `total_usage`   | Lifetime credits consumed (USD)                               |
+
+Remaining balance = `total_credits` - `total_usage`.

--- a/pages/gateway/authentication.mdx
+++ b/pages/gateway/authentication.mdx
@@ -5,7 +5,7 @@ description: Authentication methods for Tangle Inference.
 
 # Authentication
 
-Four ways to authenticate to the gateway, plus anonymous access to free-tier models, each with its own rate limit.
+Three ways to authenticate to the gateway, plus anonymous access to free-tier models, each with its own rate limit.
 
 ## API Key
 
@@ -26,15 +26,6 @@ Browser-based authentication via Better Auth. Supports email/password and OAuth 
 
 - **Rate limit:** 30 req/min
 - **Credit check:** Yes
-
-## SIWE (Sign-In with Ethereum)
-
-Wallet-based authentication: sign an EIP-191 message with your Ethereum wallet.
-
-```
-POST /api/siwe/verify
-{ "address": "0x...", "signature": "0x...", "message": "..." }
-```
 
 ## SpendAuth (On-Chain Payment)
 

--- a/pages/gateway/byok.mdx
+++ b/pages/gateway/byok.mdx
@@ -27,22 +27,7 @@ Pass credentials in `providerOptions.gateway.byok`:
 
 ### Multiple credentials
 
-Specify multiple credentials per provider. The gateway tries them in order:
-
-```json
-{
-  "providerOptions": {
-    "gateway": {
-      "byok": {
-        "anthropic": [
-          {"apiKey": "sk-ant-primary"},
-          {"apiKey": "sk-ant-backup"}
-        ]
-      }
-    }
-  }
-}
-```
+The array shape is accepted for Vercel AI Gateway compatibility, but only the first credential is used. If it fails, the gateway falls back to platform credentials (compliance filters preserved), not to a second BYOK key.
 
 ### Multiple providers
 

--- a/pages/gateway/caching.mdx
+++ b/pages/gateway/caching.mdx
@@ -26,13 +26,13 @@ Some providers require explicit cache markers to enable prompt caching, while ot
 
 ## Per-provider behavior
 
-| Provider                       | Caching Type | What `auto` does                                                        |
-| ------------------------------ | ------------ | ----------------------------------------------------------------------- |
-| OpenAI                         | Implicit     | No change needed. Caching happens automatically.                        |
-| Google                         | Implicit     | No change needed.                                                       |
-| DeepSeek                       | Implicit     | No change needed.                                                       |
-| Anthropic                      | Explicit     | Adds `cache_control: { type: 'ephemeral' }` to the last system message. |
-| Anthropic (via Bedrock/Vertex) | Explicit     | Same as Anthropic direct.                                               |
+| Provider                       | Caching Type | What `auto` does                                                                                                               |
+| ------------------------------ | ------------ | ------------------------------------------------------------------------------------------------------------------------------ |
+| OpenAI                         | Implicit     | No change needed. Caching happens automatically.                                                                               |
+| Google                         | Implicit     | No change needed.                                                                                                              |
+| DeepSeek                       | Implicit     | No change needed.                                                                                                              |
+| Anthropic                      | Explicit     | Adds `cache_control: { type: 'ephemeral' }` to the last system message.                                                        |
+| Anthropic (via Bedrock/Vertex) | Not applied  | The gateway only injects `cache_control` for providers flagged `caching_type: explicit`, which is Anthropic direct only today. |
 
 For Anthropic, the gateway converts:
 

--- a/pages/gateway/enterprise-zdr.mdx
+++ b/pages/gateway/enterprise-zdr.mdx
@@ -13,7 +13,6 @@ Read the [ZDR trust model](/gateway/zdr#trust-model) first. Key points:
 
 - ZDR is enforced at the **direct provider** level only.
 - **Operators are skipped** when ZDR is enabled (their backing provider is unverifiable).
-- **LiteLLM is skipped** (its internal routing is uncontrollable).
 - BYOK fallback to platform credentials preserves ZDR filtering.
 
 ## Step 2: Choose your approach
@@ -22,14 +21,7 @@ Read the [ZDR trust model](/gateway/zdr#trust-model) first. Key points:
 
 Enable ZDR for all requests from your team. No code changes needed - every request is automatically filtered.
 
-Contact your admin to set `zdrEnabled: true` on your team record via the admin API:
-
-```bash
-# Admin sets team-wide ZDR
-curl -X PUT https://router.tangle.tools/api/admin/compliance \
-  -H "Cookie: session_token=ADMIN_SESSION" \
-  -d '{"providerId": "...", "zdr": true}'
-```
+Team-wide ZDR lives on the `Team.zdrEnabled` column. There is no self-serve API for it today: contact Tangle and we set it on your team record.
 
 ### Option B: Per-request ZDR
 
@@ -52,7 +44,9 @@ response = client.chat.completions.create(
 Check which providers are ZDR-verified for the models you need:
 
 ```bash
-curl https://router.tangle.tools/api/gateway/compliance | jq '.providers[] | select(.zdr == true)'
+curl https://router.tangle.tools/api/gateway/compliance \
+  -H "Authorization: Bearer sk-tan-YOUR_KEY" \
+  | jq '.providers[] | select(.zdr == true)'
 ```
 
 If your required model is only available from a non-ZDR provider, the request will return 400 with a clear error listing which providers were considered.

--- a/pages/gateway/fallbacks.mdx
+++ b/pages/gateway/fallbacks.mdx
@@ -17,7 +17,7 @@ Pass a `models` array in `providerOptions.gateway`:
   "messages": [{"role": "user", "content": "Hello"}],
   "providerOptions": {
     "gateway": {
-      "models": ["anthropic/claude-sonnet-4-6", "groq/llama-3.1-70b-versatile"]
+      "models": ["anthropic/claude-sonnet-4-6", "groq/llama-3.1-8b-instant"]
     }
   }
 }
@@ -27,7 +27,7 @@ The gateway tries:
 
 1. `openai/gpt-4o` (primary model)
 2. `anthropic/claude-sonnet-4-6` (first fallback)
-3. `groq/llama-3.1-70b-versatile` (second fallback)
+3. `groq/llama-3.1-8b-instant` (second fallback)
 
 The response comes from the first model that succeeds.
 
@@ -36,10 +36,9 @@ The response comes from the first model that succeeds.
 For each model in the list, the gateway runs the full routing chain:
 
 1. **Operators** - try operators serving this model (if available)
-2. **LiteLLM** - try the proxy with built-in retries
-3. **Direct provider** - call the provider API directly
+2. **Direct provider** - call the provider API directly
 
-If all tiers fail for a model, the gateway moves to the next model in the list.
+If both tiers fail for a model, the gateway moves to the next model in the list.
 
 ## Combining with provider ordering
 

--- a/pages/gateway/feature-flags.mdx
+++ b/pages/gateway/feature-flags.mdx
@@ -28,7 +28,7 @@ ENABLE_RESPONSE_CACHE=false # Disable response cache reads/writes
 
 ## Behavior when disabled
 
-- `ENABLE_COMPLIANCE_FILTER` only disables the early validation check that returns a 400 before routing. The actual ZDR/no-train enforcement in the routing tiers (skip operators, skip LiteLLM) stays active regardless. This flag is for suppressing the early error, not for bypassing compliance.
+- `ENABLE_COMPLIANCE_FILTER` only disables the early validation check that returns a 400 before routing. The actual ZDR/no-train enforcement in the routing tiers (skip operators) stays active regardless. This flag is for suppressing the early error, not for bypassing compliance.
 
 - When `ENABLE_GUARDRAILS=false`, no PII or injection scanning occurs. The `X-Tangle-Guardrails` header is never set. GuardrailEvent records are not created.
 

--- a/pages/gateway/free-tier.mdx
+++ b/pages/gateway/free-tier.mdx
@@ -19,16 +19,18 @@ Try the gateway without credits. Free tier restricts to cheap, fast models with 
 
 Free tier requests can use:
 
-| Model                       | Provider  |
-| --------------------------- | --------- |
-| `gpt-4o-mini`               | OpenAI    |
-| `claude-3-5-haiku-20241022` | Anthropic |
-| `llama-3.1-8b-instant`      | Groq      |
-| `llama-3.2-1b-preview`      | Groq      |
-| `llama-3.2-3b-preview`      | Groq      |
-| `gemini-2.0-flash-lite`     | Google    |
-| `cerebras/llama-3.1-8b`     | Cerebras  |
-| `deepseek-chat`             | DeepSeek  |
+| Model                                 | Provider  |
+| ------------------------------------- | --------- |
+| `openai/gpt-4o-mini`                  | OpenAI    |
+| `anthropic/claude-haiku-4-5-20251001` | Anthropic |
+| `groq/llama-3.1-8b-instant`           | Groq      |
+| `google/gemini-2.5-flash-lite`        | Google    |
+| `deepseek/deepseek-chat`              | DeepSeek  |
+| `deepseek/deepseek-v4-flash`          | DeepSeek  |
+| `groq/llama-3.2-1b-preview`           | Groq      |
+| `groq/llama-3.2-3b-preview`           | Groq      |
+
+Write the two `groq/llama-3.2-*-preview` ids in full. Their bare forms are not in the free-tier set and return 402.
 
 ## Blocked models
 
@@ -45,7 +47,7 @@ Requesting a blocked model without credits returns 402:
 ```json
 {
   "error": {
-    "message": "Model \"gpt-4o\" requires credits. Free tier models: gpt-4o-mini, llama-3.1-8b-instant, gemini-2.0-flash-lite, deepseek-chat. Add credits or use a free tier model.",
+    "message": "Model \"gpt-4o\" requires credits. Free-tier models: openai/gpt-4o-mini, groq/llama-3.1-8b-instant, google/gemini-2.5-flash-lite, anthropic/claude-haiku-4-5-20251001, deepseek/deepseek-chat, deepseek/deepseek-v4-flash. Add credits or pick a free-tier model.",
     "type": "insufficient_funds",
     "code": "free_tier_limit"
   }
@@ -54,7 +56,7 @@ Requesting a blocked model without credits returns 402:
 
 ## Response headers
 
-Free tier responses include remaining quota:
+When a request is rejected for free-tier reasons (402), the response reports your quota:
 
 ```
 X-Free-Tier-Remaining: 3

--- a/pages/gateway/getting-started.mdx
+++ b/pages/gateway/getting-started.mdx
@@ -82,7 +82,6 @@ anthropic/claude-sonnet-4-6
 google/gemini-2.0-flash-lite
 groq/llama-3.1-8b-instant
 deepseek/deepseek-chat
-mistral/mistral-large-latest
 ```
 
 You can also use bare model names (`gpt-4o-mini`, `claude-sonnet-4-6`) - the gateway resolves the provider automatically.

--- a/pages/gateway/how-routing-works.mdx
+++ b/pages/gateway/how-routing-works.mdx
@@ -1,16 +1,16 @@
 ---
 title: How Routing Works
-description: The three-tier routing architecture behind Tangle Inference.
+description: The two-tier routing architecture behind Tangle Inference.
 ---
 
 # How Routing Works
 
-Every request passes through up to three routing tiers. The gateway tries each tier in order and returns the first successful response.
+Every request passes through up to two routing tiers. The gateway tries each tier in order and returns the first successful response.
 
-## The three tiers
+## The two tiers
 
 ```
-Request → Tier 1: Operators → Tier 2: LiteLLM → Tier 3: Direct Provider → Response
+Request → Tier 1: Operators → Tier 2: Direct Provider → Response
 ```
 
 ### Tier 1: Operator routing
@@ -26,19 +26,11 @@ Operators run [Blueprints](/developers/blueprints/introduction): service templat
 
 **When it's skipped:** When [ZDR](/gateway/zdr) or [no-train](/gateway/no-train) is requested (operators can't verify compliance). When `routing: "provider"` is set explicitly.
 
-### Tier 2: LiteLLM proxy
-
-An internal proxy that handles 100+ provider integrations with built-in retries and provider-level fallbacks.
-
-**When it's used:** Default for standard requests when no operator is available.
-
-**When it's skipped:** When ZDR or no-train is requested (LiteLLM's downstream routing is not compliance-controllable). When LiteLLM is not configured (`LITELLM_URL` unset).
-
-### Tier 3: Direct provider
+### Tier 2: Direct provider
 
 The gateway calls the provider API directly using platform credentials (or [BYOK](/gateway/byok) credentials).
 
-**When it's used:** Fallback when tiers 1 and 2 fail. Only tier used when compliance routing is active.
+**When it's used:** Default for standard requests, and the fallback when tier 1 fails. Only tier used when compliance routing is active.
 
 **Always used for:** ZDR requests, no-train requests, BYOK with compliance flags.
 
@@ -47,18 +39,18 @@ The gateway calls the provider API directly using platform credentials (or [BYOK
 When `zeroDataRetention` or `disallowPromptTraining` is set:
 
 ```
-Request → Tier 3: Direct Provider (verified only) → Response
+Request → Tier 2: Direct Provider (verified only) → Response
 ```
 
-Tiers 1 and 2 are bypassed. The gateway routes only to providers with verified compliance agreements. See [Zero Data Retention](/gateway/zdr) for the trust model.
+Tier 1 is bypassed. The gateway routes only to providers with verified compliance agreements. See [Zero Data Retention](/gateway/zdr) for the trust model.
 
 ## Routing control
 
 | Method                          | Effect                                               |
 | ------------------------------- | ---------------------------------------------------- |
-| `routing: "auto"`               | Try all three tiers (default)                        |
+| `routing: "auto"`               | Try both tiers (default)                             |
 | `routing: "operator"`           | Operators only. Fails if no operator available.      |
-| `routing: "provider"`           | Skip operators, use LiteLLM + direct only.           |
+| `routing: "provider"`           | Skip operators, use the direct provider tier only.   |
 | `X-Tangle-Blueprint: <id>`      | Pin to operators under this Blueprint.               |
 | `X-Tangle-Operator: <slug>`     | Pin to a specific operator.                          |
 | `providerOptions.gateway.order` | Control which providers are tried and in what order. |

--- a/pages/gateway/index.mdx
+++ b/pages/gateway/index.mdx
@@ -32,15 +32,14 @@ Works with any OpenAI-compatible SDK. Change the base URL and you're done.
 
 ## Architecture
 
-The gateway routes through three tiers, in order:
+The gateway routes through two tiers, in order:
 
 | Tier          | What                                                            | When                                                           |
 | ------------- | --------------------------------------------------------------- | -------------------------------------------------------------- |
 | **Operators** | Tangle-registered inference operators with advertised endpoints | Default for operator-pinned requests and SpendAuth             |
-| **LiteLLM**   | Proxy with 100+ provider integrations and built-in retries      | Default for standard requests                                  |
-| **Direct**    | Straight to provider API (OpenAI, Anthropic, etc.)              | Fallback when LiteLLM unavailable, or when compliance required |
+| **Direct**    | Straight to provider API (OpenAI, Anthropic, etc.)              | Default for standard requests, and when compliance is required |
 
-When [Zero Data Retention](/gateway/zdr) or [no-train](/gateway/no-train) is requested, operators and LiteLLM are skipped. The gateway routes directly to verified providers only.
+When [Zero Data Retention](/gateway/zdr) or [no-train](/gateway/no-train) is requested, operators are skipped. The gateway routes directly to verified providers only.
 
 ## Where the gateway sits
 
@@ -54,5 +53,5 @@ The gateway sits between the [Workbench](/blueprint-agent/introduction) where ag
 
 - [Getting Started](/gateway/getting-started) - make your first request in 2 minutes
 - [Supported Models](/gateway/models) - browse the model catalog
-- [How Routing Works](/gateway/how-routing-works) - understand the 3-tier architecture
+- [How Routing Works](/gateway/how-routing-works) - understand the 2-tier architecture
 - [Zero Data Retention](/gateway/zdr) - compliance for regulated industries

--- a/pages/gateway/migrate-openai.mdx
+++ b/pages/gateway/migrate-openai.mdx
@@ -50,7 +50,7 @@ Tangle Inference is OpenAI-compatible. Change two lines and you're done.
 
 ## What Tangle adds over the OpenAI API
 
-- **Access to every provider** through the same client. Try `anthropic/claude-sonnet-4-6` or `groq/llama-3.1-70b` without changing SDKs.
+- **Access to every provider** through the same client. Try `anthropic/claude-sonnet-4-6` or `groq/llama-3.1-8b-instant` without changing SDKs.
 - **Automatic fallbacks.** If OpenAI is down, configure backup models.
 - **Cost visibility.** Every response tells you exactly what it cost via `X-Tangle-Price-*` headers.
 - **Compliance routing.** One flag for ZDR, one flag for no-train.

--- a/pages/gateway/migrate-vercel.mdx
+++ b/pages/gateway/migrate-vercel.mdx
@@ -9,30 +9,30 @@ Tangle Inference supports the same `providerOptions.gateway` schema as Vercel AI
 
 ## What maps directly
 
-| Vercel Feature                                   | Tangle Equivalent | Notes                             |
-| ------------------------------------------------ | ----------------- | --------------------------------- |
-| `providerOptions.gateway.byok`                   | Same              | Identical schema                  |
-| `providerOptions.gateway.zeroDataRetention`      | Same              | 13 verified providers             |
-| `providerOptions.gateway.disallowPromptTraining` | Same              | 25 verified providers             |
-| `providerOptions.gateway.caching: 'auto'`        | Same              | Anthropic cache_control injection |
-| `providerOptions.gateway.order`                  | Same              | Provider priority                 |
-| `providerOptions.gateway.only`                   | Same              | Provider allowlist                |
-| `models` fallback array                          | Same              | Model-level failover              |
-| `GET /v1/credits`                                | Same              | Balance check                     |
-| `GET /v1/generation`                             | Same              | Request detail lookup             |
+| Vercel Feature                                   | Tangle Equivalent | Notes                                                                                                           |
+| ------------------------------------------------ | ----------------- | --------------------------------------------------------------------------------------------------------------- |
+| `providerOptions.gateway.byok`                   | Same              | Identical schema                                                                                                |
+| `providerOptions.gateway.zeroDataRetention`      | Same              | 13 verified providers                                                                                           |
+| `providerOptions.gateway.disallowPromptTraining` | Same              | 18 verified providers                                                                                           |
+| `providerOptions.gateway.caching: 'auto'`        | Same              | Anthropic cache_control injection                                                                               |
+| `providerOptions.gateway.order`                  | Same              | Provider priority                                                                                               |
+| `providerOptions.gateway.only`                   | Same              | Provider allowlist                                                                                              |
+| `providerOptions.gateway.webSearch`              | Same              | Perplexity, Parallel, Exa, Tavily, Brave, You.com, SerpAPI, Serper, Google CSE, SearXNG; plus `POST /v1/search` |
+| `models` fallback array                          | Same              | Model-level failover                                                                                            |
+| `GET /v1/credits`                                | Same              | Balance check                                                                                                   |
+| `GET /v1/generation`                             | Same              | Request detail lookup                                                                                           |
 
 ## What's different
 
-| Feature               | Vercel                                | Tangle                                                             |
-| --------------------- | ------------------------------------- | ------------------------------------------------------------------ |
-| **Base URL**          | `ai-gateway.vercel.sh/v1`             | `router.tangle.tools/v1`                                           |
-| **Auth**              | API key or OIDC token                 | API key, session, SIWE (wallet), or SpendAuth (on-chain)           |
-| **Pricing**           | Zero markup                           | 20% markup (0% with BYOK)                                          |
-| **Operator network**  | None                                  | Managed provider endpoints, selected by health, price, and latency |
-| **On-chain payments** | None                                  | SpendAuth (EIP-712) - pay without a credit card                    |
-| **Guardrails**        | None                                  | PII + injection detection built-in                                 |
-| **Web search tools**  | Perplexity, Parallel, provider-native | Not available through Tangle Inference today                       |
-| **OIDC auth**         | Vercel-only                           | Not applicable                                                     |
+| Feature               | Vercel                    | Tangle                                                             |
+| --------------------- | ------------------------- | ------------------------------------------------------------------ |
+| **Base URL**          | `ai-gateway.vercel.sh/v1` | `router.tangle.tools/v1`                                           |
+| **Auth**              | API key or OIDC token     | API key, session, or SpendAuth (on-chain)                          |
+| **Pricing**           | Zero markup               | 20% markup (0% with BYOK)                                          |
+| **Operator network**  | None                      | Managed provider endpoints, selected by health, price, and latency |
+| **On-chain payments** | None                      | SpendAuth (EIP-712) - pay without a credit card                    |
+| **Guardrails**        | None                      | PII + injection detection built-in                                 |
+| **OIDC auth**         | Vercel-only               | Not applicable                                                     |
 
 ## Code change
 
@@ -75,6 +75,5 @@ Tangle Inference supports the same `providerOptions.gateway` schema as Vercel AI
 
 - **Operator network.** Routes across managed provider endpoints selected by health, model support, price, and latency.
 - **On-chain payments.** Pay with crypto via SpendAuth - no Stripe/credit card required.
-- **Wallet auth.** Sign in with Ethereum (SIWE) for web3-native access.
 - **Guardrails.** Built-in PII and prompt injection detection on every request.
 - **Self-hostable (roadmap).** Running your own open-source gateway instance is planned.

--- a/pages/gateway/models.mdx
+++ b/pages/gateway/models.mdx
@@ -9,32 +9,34 @@ Tangle Inference reaches every supported provider through a single API. The prov
 
 ## Providers
 
-| Provider    | Slug        | Models                                                |
-| ----------- | ----------- | ----------------------------------------------------- |
-| OpenAI      | `openai`    | GPT-4o, GPT-4o-mini, o1, o3, o4, DALL-E, Whisper, TTS |
-| Anthropic   | `anthropic` | Claude Opus, Sonnet, Haiku                            |
-| Google      | `google`    | Gemini 2.5 Pro, Flash, Flash-Lite                     |
-| Groq        | `groq`      | Llama 3.1/3.2 (fast inference)                        |
-| Together AI | `together`  | Open-source models (Llama, Qwen, Mixtral)             |
-| DeepSeek    | `deepseek`  | DeepSeek Chat, DeepSeek Coder                         |
-| Mistral     | `mistral`   | Mistral Large, Codestral, Pixtral                     |
-| Fireworks   | `fireworks` | Phi, StarCoder, open models                           |
-| Cohere      | `cohere`    | Command R/R+                                          |
-| xAI         | `xai`       | Grok 2, Grok 3                                        |
-| Cerebras    | `cerebras`  | Llama (fast inference)                                |
-| SambaNova   | `sambanova` | Fast open-model inference                             |
-| AI21        | `ai21`      | Jamba                                                 |
-| Nvidia      | `nvidia`    | Nemotron                                              |
-| Z.ai        | `zai`       | GLM-4.7, GLM-5                                        |
-| Moonshot    | `moonshot`  | Kimi                                                  |
+| Provider    | Slug        | Models                                                  |
+| ----------- | ----------- | ------------------------------------------------------- |
+| OpenAI      | `openai`    | GPT-4o, GPT-4o-mini, o1, o3, o4, DALL-E, Whisper, TTS   |
+| Anthropic   | `anthropic` | Claude Opus, Sonnet, Haiku                              |
+| Google      | `google`    | Gemini 2.5 Pro, Flash, Flash-Lite                       |
+| Groq        | `groq`      | Llama 3.1/3.2 (fast inference)                          |
+| Together AI | `together`  | Open-source models (Llama, Qwen, Mixtral)               |
+| DeepSeek    | `deepseek`  | DeepSeek Chat, DeepSeek Coder                           |
+| Mistral     | `mistral`   | Mistral Large, Codestral, Pixtral                       |
+| Fireworks   | `fireworks` | Phi, StarCoder, open models                             |
+| Cohere      | `cohere`    | Command R/R+                                            |
+| xAI         | `xai`       | Grok 4.3, Grok 4.5 (not yet wired for chat completions) |
+| Cerebras    | `cerebras`  | Llama (fast inference)                                  |
+| SambaNova   | `sambanova` | Fast open-model inference                               |
+| AI21        | `ai21`      | Jamba                                                   |
+| Nvidia      | `nvidia`    | Nemotron                                                |
+| Z.ai        | `zai`       | GLM-5, GLM-4.5                                          |
+| Moonshot    | `moonshot`  | Kimi                                                    |
+
+Together AI, Fireworks, SambaNova, and AI21 have no routeable models on the gateway today. Filter [`/v1/models`](https://router.tangle.tools/v1/models) on `routeability.routeable === true` to see what a provider can actually serve right now.
 
 Plus operators registered on Tangle and running [Blueprints](/developers/blueprints/introduction):
 
-| Blueprint                                                                  | Models                                          | How to route                          |
-| -------------------------------------------------------------------------- | ----------------------------------------------- | ------------------------------------- |
-| [LLM Inference](https://github.com/tangle-network/llm-inference-blueprint) | Llama, Qwen, Mistral, any vLLM-compatible model | `X-Tangle-Routing: operator` or auto  |
-| Vector Store                                                               | Embedding models for RAG                        | `/v1/collections` and `/v1/rag/query` |
-| Custom Blueprints                                                          | Any model the operator deploys                  | Pin by Blueprint ID or operator slug  |
+| Blueprint                                                                  | Models                                          | How to route                         |
+| -------------------------------------------------------------------------- | ----------------------------------------------- | ------------------------------------ |
+| [LLM Inference](https://github.com/tangle-network/llm-inference-blueprint) | Llama, Qwen, Mistral, any vLLM-compatible model | `X-Tangle-Routing: operator` or auto |
+| Vector Store                                                               | Embedding models for RAG                        | Pin by Blueprint ID or operator slug |
+| Custom Blueprints                                                          | Any model the operator deploys                  | Pin by Blueprint ID or operator slug |
 
 Operators set their own pricing and the gateway [scores them](/gateway/smart-routing) on reputation, latency, and price. See [Operator Routing](/gateway/operator-routing) for details.
 
@@ -45,7 +47,7 @@ Use `provider/model-name`:
 ```
 anthropic/claude-sonnet-4-6
 openai/gpt-4o-mini
-groq/llama-3.1-70b-versatile
+groq/llama-3.1-8b-instant
 ```
 
 Or use bare names - the gateway resolves the provider by prefix:

--- a/pages/gateway/no-train.mdx
+++ b/pages/gateway/no-train.mdx
@@ -32,12 +32,12 @@ Use `disallowPromptTraining` when you care about IP protection but don't need fu
 
 ## No-train verified providers
 
-All ZDR providers plus: OpenAI, Google AI Studio, Cohere, Perplexity, xAI, Morph AI, Novita AI, Voyage AI.
+All ZDR providers plus: OpenAI, Google, Cohere, Perplexity, xAI.
 
 See the full list at [`GET /api/gateway/compliance`](/gateway/api-compliance).
 
 ## Routing behavior
 
-Same as ZDR: operators and LiteLLM are skipped. Only direct provider calls to verified no-train providers.
+Same as ZDR: operators are skipped. Only direct provider calls to verified no-train providers.
 
-Can be enabled team-wide via `noTrainEnabled: true` on the team record.
+Team-wide no-train lives on the `Team.noTrainEnabled` column. There is no self-serve API for it today: contact Tangle and we set it on your team record.

--- a/pages/gateway/operator-routing.mdx
+++ b/pages/gateway/operator-routing.mdx
@@ -74,7 +74,7 @@ curl -X POST "https://router.tangle.tools/v1/chat/completions" \
 | ------------------------- | ---------------------------------- |
 | Operator Ethereum address | Yes (signed transaction)           |
 | Active/inactive status    | Yes (BSM contract state)           |
-| Staked amount             | Yes (on-chain balance)             |
+| Staked amount             | No (not synced from chain today)   |
 | Pricing (per-token)       | Yes (BSM contract)                 |
 | Endpoint URL              | No (self-reported at registration) |
 | Backing provider          | No (not tracked)                   |

--- a/pages/gateway/pricing.mdx
+++ b/pages/gateway/pricing.mdx
@@ -28,10 +28,14 @@ curl -H "Authorization: Bearer sk-tan-YOUR_KEY" \
 
 ```json
 {
-  "balance": "95.50",
-  "total_used": "4.50"
+  "data": {
+    "total_credits": 100.0,
+    "total_usage": 4.5
+  }
 }
 ```
+
+`total_credits` is every credit ever granted (balance plus lifetime spend) and `total_usage` is lifetime consumption, so your remaining balance is `total_credits` - `total_usage`.
 
 ## Cost per request
 

--- a/pages/gateway/provider-options.mdx
+++ b/pages/gateway/provider-options.mdx
@@ -36,17 +36,17 @@ interface GatewayOptions {
 
 ## Options reference
 
-| Option                   | Type                               | Default | Description                                                    |
-| ------------------------ | ---------------------------------- | ------- | -------------------------------------------------------------- |
-| `byok`                   | `Record<string, Array<{apiKey}>>`  | -       | Per-request provider credentials. [Details](/gateway/byok)     |
-| `zeroDataRetention`      | `boolean`                          | `false` | Route only to ZDR-verified providers. [Details](/gateway/zdr)  |
-| `disallowPromptTraining` | `boolean`                          | `false` | Route only to no-train providers. [Details](/gateway/no-train) |
-| `caching`                | `'auto'`                           | -       | Auto-inject prompt cache markers. [Details](/gateway/caching)  |
-| `cache`                  | `false`                            | -       | Set `false` to skip response cache for this request.           |
-| `order`                  | `string[]`                         | -       | Provider priority order. [Details](/gateway/smart-routing)     |
-| `only`                   | `string[]`                         | -       | Restrict to these providers only.                              |
-| `models`                 | `string[]`                         | -       | Fallback model list. [Details](/gateway/fallbacks)             |
-| `timeout`                | `number \| Record<string, number>` | `30000` | Timeout in ms. [Details](/gateway/timeouts)                    |
+| Option                   | Type                               | Default  | Description                                                    |
+| ------------------------ | ---------------------------------- | -------- | -------------------------------------------------------------- |
+| `byok`                   | `Record<string, Array<{apiKey}>>`  | -        | Per-request provider credentials. [Details](/gateway/byok)     |
+| `zeroDataRetention`      | `boolean`                          | `false`  | Route only to ZDR-verified providers. [Details](/gateway/zdr)  |
+| `disallowPromptTraining` | `boolean`                          | `false`  | Route only to no-train providers. [Details](/gateway/no-train) |
+| `caching`                | `'auto'`                           | -        | Auto-inject prompt cache markers. [Details](/gateway/caching)  |
+| `cache`                  | `false`                            | -        | Set `false` to skip response cache for this request.           |
+| `order`                  | `string[]`                         | -        | Provider priority order. [Details](/gateway/smart-routing)     |
+| `only`                   | `string[]`                         | -        | Restrict to these providers only.                              |
+| `models`                 | `string[]`                         | -        | Fallback model list. [Details](/gateway/fallbacks)             |
+| `timeout`                | `number \| Record<string, number>` | `180000` | Timeout in ms. [Details](/gateway/timeouts)                    |
 
 ## Example: all options combined
 

--- a/pages/gateway/response-headers.mdx
+++ b/pages/gateway/response-headers.mdx
@@ -21,16 +21,16 @@ Every response from the gateway includes metadata headers.
 
 ## Conditional headers
 
-| Header                   | When present                      | Description                     |
-| ------------------------ | --------------------------------- | ------------------------------- |
-| `X-Tangle-Routing-Trace` | When `ENABLE_ROUTING_TRACE` is on | Compact routing path            |
-| `X-Tangle-Operator`      | When served by an operator        | Operator slug                   |
-| `X-Tangle-BYOK`          | When BYOK credentials used        | `true`                          |
-| `X-Tangle-Caching`       | When prompt caching applied       | `auto`                          |
-| `X-Tangle-Guardrails`    | When guardrails flagged content   | `pii:low,prompt_injection:high` |
-| `X-Payment-Settled`      | When SpendAuth payment succeeded  | `true`                          |
-| `X-Free-Tier-Remaining`  | Free tier requests                | `3`                             |
-| `X-Free-Tier-Limit`      | Free tier daily cap               | `5`                             |
+| Header                   | When present                               | Description                     |
+| ------------------------ | ------------------------------------------ | ------------------------------- |
+| `X-Tangle-Routing-Trace` | When `ENABLE_ROUTING_TRACE` is on          | Compact routing path            |
+| `X-Tangle-Operator`      | When served by an operator                 | Operator slug                   |
+| `X-Tangle-BYOK`          | When BYOK credentials used                 | `true`                          |
+| `X-Tangle-Caching`       | When prompt caching applied                | `auto`                          |
+| `X-Tangle-Guardrails`    | When guardrails flagged content            | `pii:low,prompt_injection:high` |
+| `X-Payment-Settled`      | When SpendAuth payment succeeded           | `true`                          |
+| `X-Free-Tier-Remaining`  | 402 free-tier / payment-required responses | `3`                             |
+| `X-Free-Tier-Limit`      | 402 free-tier / payment-required responses | `5`                             |
 
 ## Error response headers
 

--- a/pages/gateway/routing-trace.mdx
+++ b/pages/gateway/routing-trace.mdx
@@ -10,7 +10,7 @@ Every response includes an `X-Tangle-Routing-Trace` header showing the routing p
 ## Header format
 
 ```
-X-Tangle-Routing-Trace: openai/gpt-4o[operator(err:5001ms)→litellm(200:340ms)]
+X-Tangle-Routing-Trace: openai/gpt-4o[operator(err:5001ms)→openai(200:340ms)]
 ```
 
 Format: `model[provider(status:latency)→provider(status:latency)]`

--- a/pages/gateway/smart-routing.mdx
+++ b/pages/gateway/smart-routing.mdx
@@ -13,11 +13,11 @@ The gateway scores every operator serving a model and routes the request to the 
 score = reputation(40%) + latency(30%) + price(30%)
 ```
 
-| Factor         | Weight | What it measures                                          |
-| -------------- | ------ | --------------------------------------------------------- |
-| **Reputation** | 40%    | Normalized reputation score (0-100) from on-chain history |
-| **Latency**    | 30%    | Inverse of average response time (lower = better)         |
-| **Price**      | 30%    | Inverse of per-token price (cheaper = better)             |
+| Factor         | Weight | What it measures                                                                                                                                   |
+| -------------- | ------ | -------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Reputation** | 40%    | Score (0-100) computed by the gateway from the last 30 days of served traffic: uptime (30%), latency (25%), error rate (25%), request volume (20%) |
+| **Latency**    | 30%    | Inverse of average response time (lower = better)                                                                                                  |
+| **Price**      | 30%    | Inverse of per-token price (cheaper = better)                                                                                                      |
 
 ## Operator selection
 

--- a/pages/gateway/timeouts.mdx
+++ b/pages/gateway/timeouts.mdx
@@ -41,7 +41,7 @@ Different providers have different latency profiles. Set timeouts individually:
 
 ## Default timeouts
 
-Without explicit timeouts, the gateway uses a 30-second default for all providers and a 30-second idle timeout for streaming responses.
+Without explicit timeouts, the gateway uses a 180-second default for all providers and a 30-second idle timeout for streaming responses.
 
 ## Bounds
 

--- a/pages/gateway/zdr.mdx
+++ b/pages/gateway/zdr.mdx
@@ -31,29 +31,27 @@ When ZDR is enabled:
 
 1. **Operators are skipped.** Operators self-report their backing provider. The gateway cannot verify what provider an operator actually routes through, so operators are excluded from ZDR-compliant routing.
 
-2. **LiteLLM is skipped.** LiteLLM has its own internal fallback chain that may route to non-ZDR providers. Since we can't control LiteLLM's routing decisions, it's excluded.
+2. **Direct provider only.** The gateway calls the provider API directly, selecting only from verified ZDR providers.
 
-3. **Direct provider only.** The gateway calls the provider API directly, selecting only from verified ZDR providers.
-
-4. **BYOK fallback preserves ZDR.** If your [BYOK](/gateway/byok) credentials fail, the fallback to platform credentials still enforces ZDR filtering.
+3. **BYOK fallback preserves ZDR.** If your [BYOK](/gateway/byok) credentials fail, the fallback to platform credentials still enforces ZDR filtering.
 
 ## ZDR-verified providers
 
-| Provider       | ZDR | No-Train | Policy                                                                                                 |
-| -------------- | --- | -------- | ------------------------------------------------------------------------------------------------------ |
-| Anthropic      | Yes | Yes      | [ZDR policy](https://platform.claude.com/docs/en/build-with-claude/zero-data-retention)                |
-| Amazon Bedrock | Yes | Yes      | [Data protection](https://docs.aws.amazon.com/bedrock/latest/userguide/data-protection.html)           |
-| Azure OpenAI   | Yes | Yes      | [Data privacy](https://learn.microsoft.com/en-us/azure/foundry/responsible-ai/openai/data-privacy)     |
-| Groq           | Yes | Yes      | [ZDR policy](https://console.groq.com/docs/your-data#zero-data-retention)                              |
-| Mistral        | Yes | Yes      | [Terms](https://legal.mistral.ai/terms)                                                                |
-| Fireworks      | Yes | Yes      | [Data handling](https://docs.fireworks.ai/guides/security_compliance/data_handling)                    |
-| Together       | Yes | Yes      | [Terms](https://www.together.ai/terms-of-service)                                                      |
-| Cerebras       | Yes | Yes      | [Privacy](https://www.cerebras.ai/privacy-policy)                                                      |
-| Google Vertex  | Yes | Yes      | [ZDR policy](https://docs.cloud.google.com/vertex-ai/generative-ai/docs/vertex-ai-zero-data-retention) |
-| Nebius         | Yes | Yes      | [Legal guide](https://docs.tokenfactory.nebius.com/legal/legal-quick-guide)                            |
-| Parasail       | Yes | Yes      | [Terms](https://parasail.io/legal/terms-of-service)                                                    |
-| Baseten        | Yes | Yes      | [Security](https://docs.baseten.co/observability/security)                                             |
-| DeepInfra      | Yes | Yes      | [Data handling](https://deepinfra.com/docs/data)                                                       |
+| Provider       | ZDR | No-Train | Policy                                                                                             |
+| -------------- | --- | -------- | -------------------------------------------------------------------------------------------------- |
+| Anthropic      | Yes | Yes      | [ZDR policy](https://platform.claude.com/docs/en/build-with-claude/zero-data-retention)            |
+| Amazon Bedrock | Yes | Yes      | [Data protection](https://docs.aws.amazon.com/bedrock/latest/userguide/data-protection.html)       |
+| Azure OpenAI   | Yes | Yes      | [Data privacy](https://learn.microsoft.com/en-us/azure/foundry/responsible-ai/openai/data-privacy) |
+| Groq           | Yes | Yes      | [ZDR policy](https://console.groq.com/docs/your-data#zero-data-retention)                          |
+| Mistral        | Yes | Yes      | [Terms](https://legal.mistral.ai/terms)                                                            |
+| Fireworks      | Yes | Yes      | [Data handling](https://docs.fireworks.ai/guides/security_compliance/data_handling)                |
+| Together       | Yes | Yes      | [Terms](https://www.together.ai/terms-of-service)                                                  |
+| Cerebras       | Yes | Yes      | [Privacy](https://www.cerebras.ai/privacy-policy)                                                  |
+| Moonmath       | Yes | Yes      | Verified agreement, no public policy URL                                                           |
+| Nebius         | Yes | Yes      | [Legal guide](https://docs.tokenfactory.nebius.com/legal/legal-quick-guide)                        |
+| Parasail       | Yes | Yes      | [Terms](https://parasail.io/legal/terms-of-service)                                                |
+| Baseten        | Yes | Yes      | [Security](https://docs.baseten.co/observability/security)                                         |
+| DeepInfra      | Yes | Yes      | [Data handling](https://deepinfra.com/docs/data)                                                   |
 
 Compliance data is managed via the admin API (`PUT /api/admin/compliance`) and can be updated without code deploys.
 
@@ -62,7 +60,6 @@ Compliance data is managed via the admin API (`PUT /api/admin/compliance`) and c
 | Routing tier            | ZDR behavior                                               |
 | ----------------------- | ---------------------------------------------------------- |
 | **Operators**           | Skipped. Self-reported backing provider is unverifiable.   |
-| **LiteLLM**             | Skipped. Internal fallback chain is uncontrollable.        |
 | **Direct provider**     | Routed only to verified ZDR providers.                     |
 | **BYOK fallback**       | ZDR filters preserved on fallback to platform credentials. |
 | **Operator-only + ZDR** | 400 error. Conflicting requirements.                       |

--- a/pages/infrastructure/sandboxing.mdx
+++ b/pages/infrastructure/sandboxing.mdx
@@ -10,11 +10,9 @@ Operators choose isolation based on security requirements and workload type:
 
 **Docker containers** provide process, filesystem, and network separation. Containers are lightweight, well-understood, and suitable for most workloads where standard isolation suffices.
 
-**gVisor** adds an additional isolation layer by intercepting system calls through a user-space kernel. This limits attack surface and is suitable for higher-security workloads where container escapes are a concern.
-
 **Firecracker micro-VMs** provide hardware-level isolation with millisecond boot times. Suitable for workloads requiring the strongest guarantees, where even kernel-level exploits should not compromise the host.
 
-Operators declare supported isolation technologies. Customers specify requirements when requesting services.
+Docker containers and Firecracker micro-VMs are the supported drivers today. Operators declare which ones they run, and customers select one per sandbox with `driver: { type: "docker" | "firecracker" }`.
 
 ## Isolation Guarantees
 

--- a/pages/intelligence/connect.mdx
+++ b/pages/intelligence/connect.mdx
@@ -75,7 +75,7 @@ Codex emits content on the logs signal (`codex.*` events). Set `TANGLE_API_KEY` 
 OpenCode has no native OTel exporter today, so a standalone install emits nothing without a shim.
 
 - **Inside a Tangle sandbox:** already instrumented. The adapter subscribes to OpenCode's event stream and exports content. Nothing to do.
-- **Standalone:** use `tangle-opencode-exporter`, a thin process that subscribes to OpenCode's SSE event bus and exports content-bearing OTLP. This is the one agent where the simple path is ours to provide rather than a config flag.
+- **Standalone:** install the CLI with `npm i -g @tangle-network/sandbox-cli`, start OpenCode in server mode with `opencode serve`, then in another terminal run `tangle connect opencode --run`. That process subscribes to OpenCode's event stream and exports content-bearing OTLP. This is the one agent where the simple path is ours to provide rather than a config flag.
 
 ## OpenClaw, Hermes, NanoClaw
 
@@ -89,21 +89,30 @@ If Intelligence shows your runs (models, tokens, tool names, durations) but the 
 
 - **Claude Code / Symphony** → add the four `OTEL_LOG_*` gates above. For Symphony, set them on the Claude Code child process it spawns.
 - **Codex** → set `log_user_prompt = true`.
-- **OpenCode** → run the `tangle connect opencode` exporter.
+- **OpenCode** → run `tangle connect opencode --run` alongside a running `opencode serve`.
 
 Project grouping is unaffected, so this only turns content on.
 
 ## Verify content is flowing
 
-Setup is not done until this shows a content key. Run the agent once on a real task, then within about 30 seconds:
+Setup is not done until this reports content. Run the agent once on a real task, then within about 30 seconds:
 
 ```sh
 AUTH="Authorization: Bearer ${TANGLE_API_KEY}"
-TID=$(curl -sS "https://intelligence.tangle.tools/v1/traces?limit=1" -H "$AUTH" | jq -r '.items[0].trace_id')
-curl -sS "https://intelligence.tangle.tools/v1/traces/$TID/spans" -H "$AUTH" \
-  | jq '[.items[].attributes // .spans[].attributes | keys] | add | unique'
+curl -sS "https://intelligence.tangle.tools/v1/onboarding/status" -H "$AUTH" \
+  | jq '{tracesSeen, contentSeen, byAgent}'
 ```
 
-The keys must include at least one content key. If you see only metadata (`tool_name`, `duration_ms`, `success`, ids), content is not flowing. You missed a gate. Common misses: Claude Code without `OTEL_LOGS_EXPORTER=otlp` or the `OTEL_LOG_*` gates; Codex without `log_user_prompt=true`; OpenCode standalone without the exporter.
+`contentSeen: true` means content is landing; `byAgent` breaks it down so you can see which agent is still metadata-only. `tangle connect <agent> --verify` polls this same endpoint as a one-command equivalent.
 
-Recognized content keys (any one is enough): `gen_ai.prompt`, `gen_ai.completion`, `input.value`, `llm.input_messages`, `user.message`, `tangle.task`, `tangle.tool.args` / `tangle.tool.result`, or the agent-native `claude_code.user_prompt` / `api_request_body`, `codex.user_prompt`, `opencode message.part.text`.
+If `tracesSeen` is true but `contentSeen` is false, you missed a gate. Common misses: Claude Code without `OTEL_LOGS_EXPORTER=otlp` or the `OTEL_LOG_*` gates; Codex without `log_user_prompt=true`; OpenCode standalone without the exporter.
+
+To see which keys a single run carried, list that trace's log records. Content rides the logs signal, so span attributes on their own will look metadata-only even when everything is wired correctly:
+
+```sh
+TID=$(curl -sS "https://intelligence.tangle.tools/v1/traces?limit=1" -H "$AUTH" | jq -r '.items[0].traceId')
+curl -sS "https://intelligence.tangle.tools/v1/traces/$TID/logs" -H "$AUTH" \
+  | jq '[.items[].attributes | keys] | add | unique'
+```
+
+Recognized content keys (any one is enough): `gen_ai.prompt`, `gen_ai.completion`, `input.value`, `llm.input_messages`, `user.message`, `tangle.task`, `tangle.tool.args` / `tangle.tool.result`. Agents that emit their own keys are also recognized: Claude Code writes `claude_code.user_prompt` and `api_request_body`, Codex writes `codex.user_prompt`, and OpenCode writes `message.part.text`. See [supported harnesses](/infrastructure/harnesses) for the full set.

--- a/pages/intelligence/quickstart.mdx
+++ b/pages/intelligence/quickstart.mdx
@@ -26,6 +26,10 @@ export OTEL_EXPORTER_OTLP_ENDPOINT=https://intelligence.tangle.tools/v1/otlp
 export OTEL_EXPORTER_OTLP_HEADERS="Authorization=Bearer ${TANGLE_API_KEY}"
 
 export OTEL_LOGS_EXPORTER=otlp          # required: content rides log events
+export OTEL_METRICS_EXPORTER=otlp       # tokens / cost
+export OTEL_TRACES_EXPORTER=otlp        # spans
+export CLAUDE_CODE_ENHANCED_TELEMETRY_BETA=1   # required for spans
+
 export OTEL_LOG_USER_PROMPTS=1          # task/prompt text
 export OTEL_LOG_TOOL_DETAILS=1          # tool arguments
 
@@ -45,16 +49,15 @@ claude -p "fix the failing test in src/auth"
 
 ## 4. Verify content is flowing
 
-Within about 30 seconds, check that a trace landed with a content key, not just metadata:
+Within about 30 seconds, ask Intelligence whether content landed. This endpoint checks both spans and log records, so it sees content wherever it rides:
 
 ```sh
 AUTH="Authorization: Bearer ${TANGLE_API_KEY}"
-TID=$(curl -sS "https://intelligence.tangle.tools/v1/traces?limit=1" -H "$AUTH" | jq -r '.items[0].trace_id')
-curl -sS "https://intelligence.tangle.tools/v1/traces/$TID/spans" -H "$AUTH" \
-  | jq '[.items[].attributes // .spans[].attributes | keys] | add | unique'
+curl -sS "https://intelligence.tangle.tools/v1/onboarding/status" -H "$AUTH" \
+  | jq '{tracesSeen, contentSeen, byAgent}'
 ```
 
-If the keys include a content key such as `claude_code.user_prompt` or `gen_ai.prompt`, content is flowing. If you see only `tool_name`, `duration_ms`, and ids, you missed a gate. See [Connect your agent](/intelligence/connect#verify-content-is-flowing).
+`contentSeen: true` means content is flowing. If `tracesSeen` is true but `contentSeen` is false, you missed a gate. `tangle connect claude-code --verify` runs the same check as one command. See [Connect your agent](/intelligence/connect#verify-content-is-flowing).
 
 ## Next
 

--- a/pages/network/network-parameters.mdx
+++ b/pages/network/network-parameters.mdx
@@ -30,11 +30,11 @@ Source: https://github.com/tangle-network/tnt-core/blob/main/deploy/distribution
 
 ## TNT Contract Addresses
 
-| Environment | Token Contract                               | Explorer                                                                                 |
-| ----------- | -------------------------------------------- | ---------------------------------------------------------------------------------------- |
-| Mainnet     | `TBD`                                        | `TBD`                                                                                    |
-| Testnet     | `0xa9ffe787eea7f385dac8481cd8bdc3d9194aeb5a` | https://testnet-explorer.tangle.tools/address/0xa9ffe787eea7f385dac8481cd8bdc3d9194aeb5a |
-| Local       | `TBD`                                        | `TBD`                                                                                    |
+| Environment | Token Contract                               | Explorer                                                                        |
+| ----------- | -------------------------------------------- | ------------------------------------------------------------------------------- |
+| Mainnet     | `TBD`                                        | `TBD`                                                                           |
+| Testnet     | `0x62b3407a22e50183b1055e54d70ee21f59bf865b` | https://sepolia.basescan.org/address/0x62b3407a22e50183b1055e54d70ee21f59bf865b |
+| Local       | `TBD`                                        | `TBD`                                                                           |
 
 Testnet source: https://github.com/tangle-network/tnt-core/blob/main/deployments/base-sepolia/latest.json
 
@@ -42,13 +42,15 @@ Testnet source: https://github.com/tangle-network/tnt-core/blob/main/deployments
 
 | Contract                 | Mainnet | Testnet                                      | Local |
 | ------------------------ | ------- | -------------------------------------------- | ----- |
-| `Tangle`                 | `TBD`   | `0x1be58d12620ecc8ba9d780feec2596510d75a933` | `TBD` |
-| `MultiAssetDelegation`   | `TBD`   | `0x787dd1de4099ff8c68bfac11b82e4aed52c7f1e1` | `TBD` |
-| `OperatorStatusRegistry` | `TBD`   | `0x20258c5e4cba66d4819a06045ff00d15775e64fb` | `TBD` |
-| `TangleMetrics`          | `TBD`   | `0x2057f94d04e4d667c4d5e60d23d2963358c00970` | `TBD` |
-| `RewardVaults`           | `TBD`   | `0x2963a51fec3e2cf51b19b848942d91296448a353` | `TBD` |
-| `InflationPool`          | `TBD`   | `0xe620f87540724a0cebdee9796dd8580e02dd4911` | `TBD` |
-| `Credits`                | `TBD`   | `0x758226e04478541fcdac605e1f235e2956259a10` | `TBD` |
+| `Tangle`                 | `TBD`   | `0x8299d60f373f3a4a8c4878e335cb9d840e6e3730` | `TBD` |
+| `MultiAssetDelegation`   | `TBD`   | `0x91b1186f4f31d6e02e481c0af29c7244a3fe417d` | `TBD` |
+| `OperatorStatusRegistry` | `TBD`   | `0x2a7ceb96a9b18721b5bbb0022b4d358b3c50bcb2` | `TBD` |
+| `TangleMetrics`          | `TBD`   | `0x48725b945a76540d7e5262855566cdb74366bb75` | `TBD` |
+| `RewardVaults`           | `TBD`   | `0xbaad23dac876467ea1b1f70f4d6e02e5891d2e04` | `TBD` |
+| `InflationPool`          | `TBD`   | `0xedf2a17c4a02f543178a76d0e22d2ef096e66970` | `TBD` |
+| `Credits`                | `TBD`   | `0xb587a927ee90ba5587ca9d90fd1a813eb81fc24b` | `TBD` |
+| `ServiceFeeDistributor`  | `TBD`   | `0x36b0431187a05f23bc95a7047a66644bc934f621` | `TBD` |
+| `BlueprintAuditors`      | `TBD`   | `0xf4428bbbfa9207b4b91ca5fe8c1d401fd8b1e8e8` | `TBD` |
 
 ## Base-Mainnet Launch Parameters
 

--- a/pages/network/points-mechanics.mdx
+++ b/pages/network/points-mechanics.mdx
@@ -30,11 +30,11 @@ Contract source (GitHub): https://github.com/tangle-network/tnt-core/blob/main/p
 
 We will publish the contract addresses as each environment is deployed.
 
-| Environment | Credits Contract                             | Explorer                                                                                 |
-| ----------- | -------------------------------------------- | ---------------------------------------------------------------------------------------- |
-| Mainnet     | `TBD`                                        | `TBD`                                                                                    |
-| Testnet     | `0x758226e04478541fcdac605e1f235e2956259a10` | https://testnet-explorer.tangle.tools/address/0x758226e04478541fcdac605e1f235e2956259a10 |
-| Local       | `TBD`                                        | `TBD`                                                                                    |
+| Environment | Credits Contract                             | Explorer                                                                        |
+| ----------- | -------------------------------------------- | ------------------------------------------------------------------------------- |
+| Mainnet     | `TBD`                                        | `TBD`                                                                           |
+| Testnet     | `0xb587a927ee90ba5587ca9d90fd1a813eb81fc24b` | https://sepolia.basescan.org/address/0xb587a927ee90ba5587ca9d90fd1a813eb81fc24b |
+| Local       | `TBD`                                        | `TBD`                                                                           |
 
 Testnet source: https://github.com/tangle-network/tnt-core/blob/main/deployments/base-sepolia/latest.json
 

--- a/pages/sandbox/quickstart.mdx
+++ b/pages/sandbox/quickstart.mdx
@@ -47,7 +47,7 @@ try {
 
 ## 4. Run a coding agent
 
-Each sandbox runs one coding harness. Choose it with `backend.type`: `opencode` (OpenCode) is the default and needs no extra key; `claude-code` (Claude Code) needs an `ANTHROPIC_API_KEY` in the sandbox environment. See [supported harnesses](/infrastructure/harnesses) for the full list.
+Each sandbox runs one coding harness. Choose it with `backend.type`. `opencode` (OpenCode) is the default and needs no extra key. `claude-code` (Claude Code) runs on Tangle Router by default with no extra key. To bring your own Anthropic credential, pass `backend: { type: 'claude-code', model: { apiKey: process.env.ANTHROPIC_API_KEY } }`. See [supported harnesses](/infrastructure/harnesses) for the full list.
 
 ```typescript
 const box = await client.create({

--- a/pages/sandbox/sdk-reference.mdx
+++ b/pages/sandbox/sdk-reference.mdx
@@ -109,8 +109,8 @@ const { sessionId, alreadyExisted } = await box.dispatchPrompt(prompt, {
   sessionId, // derive this server-side; never accept a caller-chosen id
 });
 
-// From any process, replay what happened or wait for the result:
-for await (const event of box.session(sessionId).events({ since: 0 })) {
+// From any process, follow the run or wait for the result:
+for await (const event of box.session(sessionId).events()) {
   console.log(event);
 }
 const final = await box.session(sessionId).result();
@@ -124,7 +124,11 @@ The same `sessionId` is idempotent. A duplicate dispatch returns the in-flight o
 Keep the base sandbox cheap and attach a GPU only around the step that needs it. Every lease takes a hard spend cap and lifetime.
 
 ```typescript
-const lease = await box.gpu.attach({ maxSpendUsd: 5, maxLifetimeSeconds: 600 });
+const lease = await box.gpu.attach({
+  accelerator: { kind: "nvidia-h100", count: 1 },
+  maxSpendUsd: 5,
+  maxLifetimeSeconds: 600,
+});
 try {
   await box.gpu.exec(lease.id, { command: "python train.py" });
 } finally {

--- a/pages/staking/incentives/configs.mdx
+++ b/pages/staking/incentives/configs.mdx
@@ -34,7 +34,7 @@ The staking portion of each epoch is transferred to `RewardVaults`.
 
 Service payments are split between developer / protocol / operators / stakers:
 
-- `Tangle.setPaymentSplit({ developerBps, protocolBps, operatorBps, stakerBps })`
+- `Tangle.setPaymentSplit({ developerBps, protocolBps, operatorBps, stakerBps, keeperBps })`
 
 If staker fee distribution is enabled, the protocol routes staker shares to `ServiceFeeDistributor`.
 

--- a/scripts/check-live-endpoints.mjs
+++ b/scripts/check-live-endpoints.mjs
@@ -1,0 +1,109 @@
+// Fails when a URL the docs tell people to call is dead at the origin.
+//
+// The link checker only reads markdown link syntax in scanned pages, so a URL
+// sitting inside a fenced code block or a .tsx component is invisible to it.
+// That is exactly how rpc.tangle.tools stayed documented while returning 521.
+// This checks those too.
+//
+// Deliberately narrow: only hard origin failures fail the build (5xx and
+// connection failures). Auth walls, method restrictions, and rate limits mean
+// the host is alive, which is all this check claims to prove.
+
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join } from "node:path";
+
+const ROOTS = ["pages", "components"];
+const EXTENSIONS = new Set([".md", ".mdx", ".ts", ".tsx", ".js", ".jsx"]);
+const URL_RE = /https?:\/\/[a-zA-Z0-9._~:/?#@!$&*+,;=%-]+/g;
+
+// Not real destinations: local dev, illustrative hosts, and template slots.
+const SKIP_RE =
+  /localhost|127\.0\.0\.1|0\.0\.0\.0|example\.(com|org|net)|YOUR_|your-|<|\{|\}|\.\.\.|placeholder|xxx/i;
+
+// Only public hosts are checkable from CI. A private/internal name in an example
+// config is correct documentation, not a dead endpoint.
+function isPublicHost(url) {
+  let host;
+  try {
+    host = new URL(url).hostname;
+  } catch {
+    return false; // not a parseable URL (e.g. a bare "https://" in prose)
+  }
+  if (!host.includes(".")) return false; // intranet-style single-label host
+  return !/\.(internal|local|localdomain|test|invalid|example)$/i.test(host);
+}
+
+// The host answered, so it exists. Only the origin being down is a docs defect.
+const ALIVE = new Set([
+  200, 201, 202, 204, 301, 302, 303, 304, 307, 308, 400, 401, 403, 404, 405,
+  406, 409, 410, 415, 422, 429,
+]);
+
+function walk(path, files = []) {
+  const stat = statSync(path);
+  if (stat.isDirectory()) {
+    for (const entry of readdirSync(path)) walk(join(path, entry), files);
+    return files;
+  }
+  const dot = path.lastIndexOf(".");
+  if (stat.isFile() && EXTENSIONS.has(dot === -1 ? "" : path.slice(dot)))
+    files.push(path);
+  return files;
+}
+
+const seen = new Map(); // url -> first file that used it
+for (const root of ROOTS) {
+  for (const file of walk(root)) {
+    for (const raw of readFileSync(file, "utf8").match(URL_RE) ?? []) {
+      const url = raw.replace(/[.,);:'"`\]]+$/, "");
+      if (SKIP_RE.test(url) || !isPublicHost(url) || seen.has(url)) continue;
+      seen.set(url, file);
+    }
+  }
+}
+
+async function probe(url) {
+  // Two attempts: a transient blip should not fail the build.
+  for (let attempt = 0; attempt < 2; attempt++) {
+    try {
+      const controller = new AbortController();
+      const timer = setTimeout(() => controller.abort(), 15000);
+      const res = await fetch(url, {
+        redirect: "follow",
+        signal: controller.signal,
+      });
+      clearTimeout(timer);
+      if (ALIVE.has(res.status)) return null;
+      if (attempt === 1) return `HTTP ${res.status}`;
+    } catch (error) {
+      if (attempt === 1)
+        return error.name === "AbortError" ? "timeout" : "unreachable";
+    }
+    await new Promise((r) => setTimeout(r, 2000));
+  }
+  return null;
+}
+
+const urls = [...seen.keys()];
+const dead = [];
+const CONCURRENCY = 12;
+for (let i = 0; i < urls.length; i += CONCURRENCY) {
+  const batch = urls.slice(i, i + CONCURRENCY);
+  const outcomes = await Promise.all(batch.map((url) => probe(url)));
+  outcomes.forEach((reason, index) => {
+    if (reason)
+      dead.push({ url: batch[index], file: seen.get(batch[index]), reason });
+  });
+}
+
+if (dead.length > 0) {
+  console.error(
+    `${dead.length} documented endpoint(s) are dead at the origin.\n` +
+      "The docs tell people to call these. Fix or remove them.\n",
+  );
+  for (const { url, file, reason } of dead)
+    console.error(`${file}: ${url} (${reason})`);
+  process.exit(1);
+}
+
+console.log(`Live endpoint check passed. ${urls.length} URLs reachable.`);


### PR DESCRIPTION
## The gap
The link checker only reads markdown link syntax, so a URL inside a fenced code block or a `.tsx` component is invisible to it. That is exactly how `rpc.tangle.tools` stayed documented while returning **521**.

`scripts/check-live-endpoints.mjs` extracts URLs from `pages/` and `components/` **including code blocks**, probes each, and fails only on hard origin failures (5xx and connection errors). Auth walls, method restrictions, and rate limits count as alive, because they prove the host exists. Private and single-label hosts in example configs are skipped, so an internal `prometheus.internal:9090` in a sample config does not fail the build. Wired in as the `endpoints` CI job.

**Proven, not assumed:** I reintroduced the dead RPC into a code block and confirmed the checker fails on it (`HTTP 521`), then confirmed it passes clean.

## What it found immediately
`pages/blueprints/surplus-market/dapp-and-indexer.mdx` claimed *"Surplus is live as a hosted app at surplus-market.pages.dev"*. That host no longer resolves (000), and no `*.blueprint.tangle.tools` host is deployed for Surplus, while Sandbox and Trading both return 200. The page now states there is no hosted app and routes to the protocol views instead of linking somewhere dead.

Checker passes on everything else: **235 URLs reachable**.

---

## Accuracy audit: 358 claims checked, 48 defects fixed (27 P1)

Five agents verified every concrete claim (endpoints, fields, method names, model IDs, contract addresses, file paths, defaults) against the real repos **and live APIs**. Highlights, each backed by code `file:line` or a live response:

**Inference (12 P1)**
- Docs described a **3-tier router with a LiteLLM tier that was deliberately deleted** from the code. Live trace proves one hop. Now documented as two tiers.
- `GET /v1/credits` documented with **fields that do not exist** (`balance`/`total_used` vs real `data.total_credits`/`total_usage`).
- **SIWE auth pointed at `POST /api/siwe/verify` → 404.** Real route is a 501 stub; SIWE moved to id.tangle.tools.
- **5 of 8 advertised free-tier models return 402** when actually called.
- BYOK claimed credential fallback the code never implements (reads only `[0]`).
- Two documented Vector Store paths are **not mounted** on the deployed router.

**Protocol (10 P1)**
- The testnet address table **did not match the manifest it cites**, and several addresses had **no bytecode** on Base Sepolia. Addresses now come from the canonical manifest and are **verified on chain** (11/11 match).
- 18 auth rows cited `Base.sol` for functions that live in `TangleCoreApi.sol`.
- `disputeBond` documented as `0`; shipped default is **0.02 ether**, so an operator following the docs reverts.
- Explorer links moved to `sepolia.basescan.org` because `testnet-explorer.tangle.tools` now serves an unrelated site.

**Intelligence (4 P1)** — including defects in pages I wrote last session, because I grounded them in a repo `CONNECT.md` that does not match the running system:
- Verify step read `trace_id` where the API returns `traceId`, and asserted content on span attributes when content lands in the **logs** table. Both now use the onboarding status endpoint.
- The standalone OpenCode path named `tangle-opencode-exporter`, which **does not exist on npm**. Now uses the real sandbox CLI.

**Sandbox (1 P1)** — the GPU example omitted the required `accelerator` field, so it did not compile.

Verified: 11/11 addresses match the canonical manifest, em dashes 0, copy-check + prettier pass, frontmatter parses.