### PR TITLE
docs(network): add the Tempo testnet deployment

### DIFF
--- a/components/NetworkResources.tsx
+++ b/components/NetworkResources.tsx
@@ -114,6 +114,48 @@ const NETWORK_DATA = {
       },
     },
   ] satisfies NetworkDetail[],
+  tempo: [
+    { property: "Block Explorers", value: "" },
+    {
+      property: "EVM Explorer",
+      value: {
+        type: "link",
+        url: "https://explorer.tempo.xyz",
+        text: "explorer.tempo.xyz",
+      },
+    },
+    { property: "Developer Resources", value: "" },
+    { property: "Chain ID", value: { type: "wss", url: "42431" } },
+    { property: "Host Chain", value: "Tempo Testnet" },
+    {
+      property: "Public RPC URL",
+      value: { type: "wss", url: "https://rpc.testnet.tempo.xyz" },
+    },
+    {
+      property: "Deployment Manifest",
+      value: {
+        type: "link",
+        url: "https://github.com/tangle-network/tnt-core/blob/main/deployments/tempo/latest.json",
+        text: "deployments/tempo/latest.json",
+      },
+    },
+    {
+      property: "Protocol Contracts",
+      value: {
+        type: "link",
+        url: "https://github.com/tangle-network/tnt-core/tree/main",
+        text: "github.com/tangle-network/tnt-core",
+      },
+    },
+    {
+      property: "Blueprint SDK",
+      value: {
+        type: "link",
+        url: "https://github.com/tangle-network/blueprint/tree/main",
+        text: "github.com/tangle-network/blueprint",
+      },
+    },
+  ] satisfies NetworkDetail[],
 } as const;
 
 const NetworkTabs = () => {
@@ -253,6 +295,21 @@ const NetworkTabs = () => {
           {" "}
           <a
             href="#"
+            onClick={() => handleTabClick("tempo")}
+            className={`inline-block p-4 rounded-t-lg ${
+              activeTab === "tempo"
+                ? "text-blue-600 bg-gray-100 active dark:bg-gray-800 dark:text-blue-500"
+                : "hover:text-gray-600 hover:bg-gray-50 dark:hover:bg-gray-800 dark:hover:text-gray-300"
+            }`}
+          >
+            <FlaskConical className="inline w-4 h-4 text-blue-600 me-2 dark:text-blue-500" />
+            Tempo Testnet
+          </a>
+        </li>
+        <li className="inline-flex items-center justify-center px-4 pt-8 text-xl border-b-2 border-transparent rounded-t-lg group">
+          {" "}
+          <a
+            href="#"
             onClick={() => handleTabClick("wallets")}
             className={`inline-block p-4 rounded-t-lg ${
               activeTab === "wallets"
@@ -269,7 +326,9 @@ const NetworkTabs = () => {
       <div className="w-full table-auto">
         {activeTab === "wallets" ? (
           <WalletTable />
-        ) : activeTab === "mainnet" || activeTab === "testnet" ? (
+        ) : activeTab === "mainnet" ||
+          activeTab === "testnet" ||
+          activeTab === "tempo" ? (
           renderTable(NETWORK_DATA[activeTab])
         ) : null}
       </div>

--- a/pages/network/network-parameters.mdx
+++ b/pages/network/network-parameters.mdx
@@ -52,6 +52,25 @@ Testnet source: https://github.com/tangle-network/tnt-core/blob/main/deployments
 | `ServiceFeeDistributor`  | `TBD`   | `0x36b0431187a05f23bc95a7047a66644bc934f621` | `TBD` |
 | `BlueprintAuditors`      | `TBD`   | `0xf4428bbbfa9207b4b91ca5fe8c1d401fd8b1e8e8` | `TBD` |
 
+## Tempo Testnet Addresses
+
+The protocol is also deployed to Tempo testnet (chain ID `42431`, RPC `https://rpc.testnet.tempo.xyz`).
+
+| Contract                 | Tempo Testnet                                |
+| ------------------------ | -------------------------------------------- |
+| `TNT` token              | `0x64fb7ffae82c1682574e9edb4e2f4e377132f671` |
+| `Tangle`                 | `0xff137b9c879c47c28ce389e84501925438ab4cda` |
+| `MultiAssetDelegation`   | `0x9484d07899b98384f1d66bd5b2659f3ed346f89e` |
+| `OperatorStatusRegistry` | `0xaedaffd260e21b41cb9926370e32d14bef812b48` |
+| `TangleMetrics`          | `0x485289432c55ca68a392a204c4bddf1e4a0acf8f` |
+| `RewardVaults`           | `0x9a1615fdcaaf2f659d78eb0d72fd3759480af7c4` |
+| `InflationPool`          | `0x3602b76c625464895205466c645feff0d911836f` |
+| `Credits`                | `0x94e8d532c3205346ee048cf6e37d5e7653c353ae` |
+
+Browse any of these on [explorer.tempo.xyz](https://explorer.tempo.xyz).
+
+Tempo source: https://github.com/tangle-network/tnt-core/blob/main/deployments/tempo/latest.json
+
 ## Base-Mainnet Launch Parameters
 
 These values are defined in `deploy/config/base-mainnet.json`. They can change after launch through governance.


### PR DESCRIPTION
The protocol is deployed to **Tempo testnet (chain ID 42431)** and the docs never mentioned it.

- **Network resources component:** new Tempo tab with explorer, chain ID, public RPC, and the deployment manifest link.
- **Protocol parameters page:** a Tempo address table for TNT, Tangle, MultiAssetDelegation, OperatorStatusRegistry, TangleMetrics, RewardVaults, InflationPool, and Credits.

## Verified two ways
Every address comes from `deployments/tempo/latest.json` on tnt-core main, and:
1. **All 8 match the manifest** (no hand-copying drift).
2. **`eth_getCode` on `https://rpc.testnet.tempo.xyz` confirms bytecode at each one.**

Supporting checks: the RPC returns chain ID `0xa5bf` (42431), the TNT token returns `symbol() = "TNT"`, and `explorer.tempo.xyz` resolves (200) with a working `/address/0x...` pattern.

**Note on how this was missed:** my local `tnt-core` clone was stale and had no `deployments/tempo` directory, which is why an earlier pass reported no Tempo deployment. The canonical GitHub main has it. Checking the remote, not the local clone, is the fix.