### PR TITLE
docs(inference): correct the video endpoint path

### DIFF
--- a/pages/gateway/models.mdx
+++ b/pages/gateway/models.mdx
@@ -72,7 +72,7 @@ Or use bare names - the gateway resolves the provider by prefix:
 | Images     | `/v1/images/generations`                       | DALL-E, FLUX                 |
 | Audio      | `/v1/audio/transcriptions`, `/v1/audio/speech` | Whisper, TTS                 |
 | Embeddings | `/v1/embeddings`                               | text-embedding-3-small/large |
-| Video      | `/v1/video/*`                                  | Avatar generation, dubbing   |
+| Video      | `/v1/videos/*`                                 | Avatar generation, dubbing   |
 
 ## Model catalog API
 


### PR DESCRIPTION
The modalities table pointed at `/v1/video/*`, which 404s. The router mounts the surface at `/v1/videos/*` (plural).

Verified against the live router:
- `GET /v1/video/providers` → **404**
- `GET /v1/videos/providers` → **200**

Last P1 from the third accuracy audit pass. Closes the loop: the gateway docs went significant-drift → minor-drift → clean.